### PR TITLE
Fix status bar menu unclickable and functionality

### DIFF
--- a/SyncNosHelper/HelperStatusBarController.swift
+++ b/SyncNosHelper/HelperStatusBarController.swift
@@ -1,7 +1,7 @@
 import AppKit
 import Combine
 
-final class HelperStatusBarController {
+final class HelperStatusBarController: NSObject {
     private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     private var cancellables = Set<AnyCancellable>()
     
@@ -14,7 +14,8 @@ final class HelperStatusBarController {
     private let toggleAppleItem = NSMenuItem(title: "Auto Sync Apple Books", action: #selector(toggleAppleAutoSync), keyEquivalent: "")
     private let toggleGoodLinksItem = NSMenuItem(title: "Auto Sync GoodLinks", action: #selector(toggleGoodLinksAutoSync), keyEquivalent: "")
     
-    init() {
+    override init() {
+        super.init()
         if let button = statusItem.button {
             // 仅使用 Helper target 中的 AppIcon 资源（不提供回退方案）
             if let img = NSImage(named: "AppIcon") {


### PR DESCRIPTION
Make `HelperStatusBarController` inherit `NSObject` to enable menu item actions.

The menu items were grey and unclickable because `NSMenuItem`'s `target/action` mechanism relies on the Objective-C runtime's `responds(to:)` method. Without inheriting `NSObject`, `HelperStatusBarController` could not properly respond, causing AppKit to disable the menu items.

---
<a href="https://cursor.com/background-agent?bcId=bc-119f8e73-5670-428c-8eee-818bfc620e7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-119f8e73-5670-428c-8eee-818bfc620e7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

