### PR TITLE
chore: use English download label

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,10 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           name: ${{ github.ref_name }}
+          body: |
+            **Download:** https://apps.apple.com/app/syncnos/id6755133888
           generate_release_notes: true
+          append_body: true
           draft: false
           prerelease: false
         env:


### PR DESCRIPTION
### Motivation
- Make the App Store download link in generated GitHub release notes readable in English.

### Description
- Replace the Chinese label with an English label by changing the `body` in `.github/workflows/release.yml` to `**Download:** https://apps.apple.com/app/syncnos/id6755133888` for the `softprops/action-gh-release@v2` step.

### Testing
- No automated tests were run because this is a CI workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696f8318ab60832ea3d248987ecd4c26)