### PR TITLE
Use `t` as stable identifier for NotionAI Chat

### DIFF
--- a/Extensions/WebClipper/src/bootstrap/background.js
+++ b/Extensions/WebClipper/src/bootstrap/background.js
@@ -79,19 +79,96 @@
     return { ...payload };
   }
 
+  function extractNotionAiThreadIdFromUrl(url) {
+    try {
+      const u = new URL(String(url || ""));
+      const t = String(u.searchParams.get("t") || "").trim();
+      if (/^[0-9a-fA-F]{32}$/.test(t)) return t.toLowerCase();
+      const hash = String(u.hash || "").replace(/^#/, "");
+      const m = hash.match(/(?:^|[?&])t=([0-9a-fA-F]{32})(?:[&#]|$)/);
+      return m ? String(m[1]).toLowerCase() : "";
+    } catch (_e) {
+      return "";
+    }
+  }
+
+  function notionAiStableConversationKey(threadId) {
+    return threadId ? `notionai_t_${threadId}` : "";
+  }
+
+  function notionAiCanonicalChatUrl(threadId) {
+    return threadId ? `https://www.notion.so/chat?t=${threadId}&wfv=chat` : "";
+  }
+
+  async function findExistingNotionAiConversationByThreadId(conversationsStore, threadId) {
+    if (!conversationsStore || !threadId) return null;
+    return await new Promise((resolve, reject) => {
+      const req = conversationsStore.openCursor();
+      req.onsuccess = () => {
+        const cursor = req.result;
+        if (!cursor) return resolve(null);
+        const v = cursor.value;
+        try {
+          if (v && v.source === "notionai") {
+            const tid = extractNotionAiThreadIdFromUrl(v.url || "");
+            if (tid && tid === threadId) return resolve(v);
+          }
+        } catch (_e) {
+          // ignore and continue
+        }
+        cursor.continue();
+      };
+      req.onerror = () => reject(req.error || new Error("indexedDB cursor failed"));
+    });
+  }
+
   async function upsertConversation(payload) {
     const db = await openDb();
-    const { t, stores } = tx(db, ["conversations"], "readwrite");
+    const source = payload && payload.source ? String(payload.source) : "";
+    const conversationKeyRaw = payload && payload.conversationKey ? String(payload.conversationKey) : "";
+    const urlRaw = payload && payload.url ? String(payload.url) : "";
+
+    const notionThreadId = source === "notionai" ? extractNotionAiThreadIdFromUrl(urlRaw) : "";
+    const stableKey = notionThreadId ? notionAiStableConversationKey(notionThreadId) : "";
+    const conversationKey = stableKey || conversationKeyRaw;
+    const normalizedUrl = notionThreadId ? notionAiCanonicalChatUrl(notionThreadId) : urlRaw;
+
+    const storeNames = (source === "notionai" && notionThreadId) ? ["conversations", "sync_mappings"] : ["conversations"];
+    const { t, stores } = tx(db, storeNames, "readwrite");
     const idx = stores.conversations.index("by_source_conversationKey");
-    const existing = await reqToPromise(idx.get([payload.source, payload.conversationKey]));
+    let existing = await reqToPromise(idx.get([source, conversationKey]));
+
+    // NotionAI: migrate legacy keys (page-dependent) to stable `t=` keys when we can prove they refer to the same thread.
+    if (!existing && source === "notionai" && notionThreadId && stores.conversations) {
+      const legacy = await findExistingNotionAiConversationByThreadId(stores.conversations, notionThreadId);
+      const legacyKey = legacy && legacy.conversationKey ? String(legacy.conversationKey) : "";
+      if (legacy && legacyKey && legacyKey !== conversationKey) {
+        // If a sync mapping exists for the legacy key, migrate it too.
+        if (stores.sync_mappings) {
+          try {
+            const mappingIdx = stores.sync_mappings.index("by_source_conversationKey");
+            const existingMapping = await reqToPromise(mappingIdx.get([source, legacyKey]));
+            const targetMapping = await reqToPromise(mappingIdx.get([source, conversationKey]));
+            if (existingMapping && !targetMapping) {
+              await reqToPromise(stores.sync_mappings.put({ ...existingMapping, source, conversationKey, updatedAt: Date.now() }));
+            } else if (existingMapping && targetMapping) {
+              await reqToPromise(stores.sync_mappings.delete(existingMapping.id));
+            }
+          } catch (_e) {
+            // ignore mapping migration failures; conversation upsert still succeeds
+          }
+        }
+        existing = legacy;
+      }
+    }
 
     const now = Date.now();
     const nextTitle = (payload.title && String(payload.title).trim()) ? String(payload.title).trim() : "";
-    const nextUrl = (payload.url && String(payload.url).trim()) ? String(payload.url).trim() : "";
+    const nextUrl = (normalizedUrl && String(normalizedUrl).trim()) ? String(normalizedUrl).trim() : "";
     const baseRecord = {
       sourceType: payload.sourceType || "chat",
-      source: payload.source,
-      conversationKey: payload.conversationKey,
+      source,
+      conversationKey,
       title: nextTitle || (existing ? existing.title || "" : ""),
       url: nextUrl || (existing ? existing.url || "" : ""),
       // Optional metadata (mainly for `sourceType=article`, but safe for all sources).

--- a/Extensions/WebClipper/src/collectors/notionai-collector.js
+++ b/Extensions/WebClipper/src/collectors/notionai-collector.js
@@ -1,6 +1,24 @@
 (function () {
   const NS = (globalThis.WebClipper = globalThis.WebClipper || {});
 
+  function findChatThreadIdFromHref(href) {
+    try {
+      const u = new URL(String(href || location.href || ""));
+      const t = String(u.searchParams.get("t") || "").trim();
+      if (/^[0-9a-fA-F]{32}$/.test(t)) return t.toLowerCase();
+      const hash = String(u.hash || "").replace(/^#/, "");
+      const m = hash.match(/(?:^|[?&])t=([0-9a-fA-F]{32})(?:[&#]|$)/);
+      return m ? String(m[1]).toLowerCase() : "";
+    } catch (_e) {
+      return "";
+    }
+  }
+
+  function notionAiCanonicalChatUrl(threadId) {
+    if (!threadId) return "";
+    return `https://www.notion.so/chat?t=${threadId}&wfv=chat`;
+  }
+
   function hasChatSignals(scope) {
     const s = scope || document;
     // NotionAI chat turns include this marker on user messages (observed across page/side-panel/floating dialog).
@@ -541,11 +559,15 @@
 
     if (!messages.length) return null;
 
+    const threadId = findChatThreadIdFromHref(location.href);
     const pageId = findPageIdFromUrl();
     const firstUser = messages.find((m) => m.role === "user");
     const firstUserSig = firstUser ? NS.normalize.fnv1a32(firstUser.contentText) : NS.normalize.fnv1a32(String(Date.now()));
-    const conversationKey = `notionai_${pageId || location.pathname}_${firstUserSig}`;
+    const conversationKey = threadId
+      ? `notionai_t_${threadId}`
+      : `notionai_${pageId || location.pathname}_${firstUserSig}`;
     const title = getChatTitleFromRoot(root || document);
+    const canonicalUrl = threadId ? notionAiCanonicalChatUrl(threadId) : "";
 
     return {
       conversation: {
@@ -553,7 +575,7 @@
         source: "notionai",
         conversationKey,
         title: title || document.title || "NotionAI",
-        url: location.href,
+        url: canonicalUrl || location.href,
         warningFlags,
         lastCapturedAt: Date.now()
       },

--- a/Extensions/WebClipper/tests/collectors/notionai-collector.test.ts
+++ b/Extensions/WebClipper/tests/collectors/notionai-collector.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vitest";
 
+function loadNormalize() {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const modulePath = require.resolve("../../src/shared/normalize.js");
+  // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+  delete require.cache[modulePath];
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  return require("../../src/shared/normalize.js");
+}
+
 function loadRegistry() {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const modulePath = require.resolve("../../src/collectors/registry.js");
@@ -88,5 +97,91 @@ describe("notionai-collector", () => {
     });
     expect(active && active.id).toBe("notionai");
   });
-});
 
+  it("uses thread id `t` as stable conversationKey and canonical /chat URL", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { JSDOM } = require("jsdom");
+
+    const threadId = "30cbe9d6386a807c83e900a970ea41b2";
+    const html = `
+      <div data-agent-chat-user-step-id="u1">
+        <div data-content-editable-leaf="true">你好</div>
+      </div>
+      <div class="autolayout-col autolayout-fill-width">
+        <div data-block-id="b1">
+          <div data-content-editable-leaf="true">Hello</div>
+        </div>
+      </div>
+    `;
+
+    const dom = new JSDOM(`<body>${html}</body>`, {
+      url: `https://www.notion.so/chiimagnus/Some-Page-0123456789abcdef0123456789abcdef?t=${threadId}`
+    });
+    // @ts-expect-error test global
+    globalThis.window = dom.window;
+    // @ts-expect-error test global
+    globalThis.document = dom.window.document;
+    // @ts-expect-error test global
+    globalThis.Node = dom.window.Node;
+    // @ts-expect-error test global
+    globalThis.location = dom.window.location;
+
+    // @ts-expect-error test global
+    globalThis.WebClipper = {};
+    loadNormalize();
+    loadContract();
+    loadRegistry();
+    const collector = loadNotionAiCollector();
+
+    const snap = collector.capture();
+    expect(snap).toBeTruthy();
+    expect(snap.conversation.conversationKey).toBe(`notionai_t_${threadId}`);
+    expect(snap.conversation.url).toBe(`https://www.notion.so/chat?t=${threadId}&wfv=chat`);
+  });
+
+  it("keeps notionai conversationKey stable across different page paths when `t` matches", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { JSDOM } = require("jsdom");
+
+    const threadId = "30cbe9d6386a807c83e900a970ea41b2";
+    const html = `
+      <div data-agent-chat-user-step-id="u1">
+        <div data-content-editable-leaf="true">hi</div>
+      </div>
+      <div class="autolayout-col autolayout-fill-width">
+        <div data-block-id="b1"><div>ok</div></div>
+      </div>
+    `;
+
+    const urls = [
+      `https://www.notion.so/chiimagnus/Page-A-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa?t=${threadId}`,
+      `https://www.notion.so/chiimagnus/Page-B-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb?t=${threadId}`
+    ];
+
+    const keys: string[] = [];
+    for (const url of urls) {
+      const dom = new JSDOM(`<body>${html}</body>`, { url });
+      // @ts-expect-error test global
+      globalThis.window = dom.window;
+      // @ts-expect-error test global
+      globalThis.document = dom.window.document;
+      // @ts-expect-error test global
+      globalThis.Node = dom.window.Node;
+      // @ts-expect-error test global
+      globalThis.location = dom.window.location;
+
+      // @ts-expect-error test global
+      globalThis.WebClipper = {};
+      loadNormalize();
+      loadContract();
+      loadRegistry();
+      const collector = loadNotionAiCollector();
+
+      const snap = collector.capture();
+      keys.push(snap.conversation.conversationKey);
+    }
+
+    expect(keys[0]).toBe(`notionai_t_${threadId}`);
+    expect(keys[1]).toBe(`notionai_t_${threadId}`);
+  });
+});


### PR DESCRIPTION
Implement a stable conversation key and canonical URL for NotionAI Chat using the `t` parameter. This change ensures consistent handling of conversation identifiers across different pages.