### PR TITLE
Fix unnecessary Notion writes when no new messages

### DIFF
--- a/Extensions/WebClipper/src/bootstrap/background-router.js
+++ b/Extensions/WebClipper/src/bootstrap/background-router.js
@@ -248,17 +248,16 @@
             }
 
             // Page exists and is usable.
-            // eslint-disable-next-line no-await-in-loop
-            await NS.notionSyncService.updatePageProperties(token.accessToken, {
-              pageId,
-              title: convo.title,
-              url: convo.url,
-              ai: convo.source
-            });
-
             const inc = computeNewMessages(messages, cursor);
             if (inc.rebuild) {
               if (!messages.length) throw new Error(`missing cursor for ${toConvoLabel(convo)} and no local messages to rebuild`);
+              // eslint-disable-next-line no-await-in-loop
+              await NS.notionSyncService.updatePageProperties(token.accessToken, {
+                pageId,
+                title: convo.title,
+                url: convo.url,
+                ai: convo.source
+              });
               // Force clear & rebuild (cursor missing or not found).
               // eslint-disable-next-line no-await-in-loop
               await NS.notionSyncService.clearPageChildren(token.accessToken, pageId);
@@ -274,6 +273,13 @@
               }
               results.push({ conversationId: id, ok: true, notionPageId: pageId, mode: "rebuilt", appended: messages.length });
             } else if (inc.newMessages && inc.newMessages.length) {
+              // eslint-disable-next-line no-await-in-loop
+              await NS.notionSyncService.updatePageProperties(token.accessToken, {
+                pageId,
+                title: convo.title,
+                url: convo.url,
+                ai: convo.source
+              });
               const blocks = NS.notionSyncService.messagesToBlocks(inc.newMessages, { source: convo.source });
               if (blocks.length) {
                 // eslint-disable-next-line no-await-in-loop

--- a/Extensions/WebClipper/src/sync/notion/notion-sync-service.js
+++ b/Extensions/WebClipper/src/sync/notion/notion-sync-service.js
@@ -571,7 +571,7 @@
     }
   }
 
-  function buildPageProperties({ title, url, ai }) {
+  function buildPagePropertiesForCreate({ title, url, ai }) {
     const props = {
       Name: { title: [{ type: "text", text: { content: title || "Untitled" } }] },
       Date: { date: { start: new Date().toISOString() } },
@@ -582,17 +582,27 @@
     return props;
   }
 
+  function buildPagePropertiesForUpdate({ title, url, ai }) {
+    const props = {
+      Name: { title: [{ type: "text", text: { content: title || "Untitled" } }] },
+      URL: { url: url || "" }
+    };
+    const aiName = aiLabelForSource(ai);
+    if (aiName) props.AI = { multi_select: [{ name: aiName }] };
+    return props;
+  }
+
   async function createPageInDatabase(accessToken, { databaseId, title, url, ai }) {
     const body = {
       parent: { database_id: databaseId },
-      properties: buildPageProperties({ title, url, ai })
+      properties: buildPagePropertiesForCreate({ title, url, ai })
     };
     return NS.notionApi.notionFetch({ accessToken, method: "POST", path: "/v1/pages", body });
   }
 
   async function updatePageProperties(accessToken, { pageId, title, url, ai }) {
     const body = {
-      properties: buildPageProperties({ title, url, ai })
+      properties: buildPagePropertiesForUpdate({ title, url, ai })
     };
     return NS.notionApi.notionFetch({ accessToken, method: "PATCH", path: `/v1/pages/${pageId}`, body });
   }


### PR DESCRIPTION
Avoids making write requests to Notion when there are no new messages to update, optimizing performance and reducing unnecessary API calls. Additionally, refactors the page property building functions for clarity and separation of concerns.