### PR TITLE
Show success message after saving snapshot and fix no-conversation tip

### DIFF
--- a/Extensions/WebClipper/src/bootstrap/content-controller.js
+++ b/Extensions/WebClipper/src/bootstrap/content-controller.js
@@ -148,12 +148,10 @@
                 showInpageTip("Saving...", "loading");
               }
               const snapshot = await Promise.resolve(collector.capture({ manual: true }));
-              if (!snapshot) {
-                showInpageTip("No visible conversation found", "error");
-                return null;
-              }
-              await saveSnapshot(snapshot);
-              return { ok: true };
+              if (!snapshot) throw new Error("No visible conversation found");
+              const saved = await saveSnapshot(snapshot);
+              if (!saved) throw new Error("No visible conversation found");
+              return saved;
             }
           });
         } catch (_e) {
@@ -207,8 +205,8 @@
             if (!snapshot) return;
             const inc = NS.incrementalUpdater && NS.incrementalUpdater.computeIncremental(snapshot);
             if (!inc || !inc.changed) return;
-            await saveSnapshot(inc.snapshot);
-            showInpageTip("Saved", "ok");
+            const saved = await saveSnapshot(inc.snapshot);
+            if (saved) showInpageTip("Saved", "ok");
           } catch (_e) {
             if (runtime && typeof runtime.isInvalidContextError === "function" && runtime.isInvalidContextError(_e)) {
               stop();

--- a/Extensions/WebClipper/tests/smoke/content-controller-inpage-combo.test.ts
+++ b/Extensions/WebClipper/tests/smoke/content-controller-inpage-combo.test.ts
@@ -173,6 +173,24 @@ describe("content-controller inpage combo", () => {
     expect(harness.tipCalls.some((c) => c.opts?.kind === "ok")).toBe(true);
   });
 
+  it("shows error tip when manual capture finds no visible conversation", async () => {
+    const harness = createHarness({
+      captureImpl: (args) => {
+        if (!args || !args.manual) return null;
+        return null;
+      }
+    });
+
+    await harness.runTick();
+    const cfg = harness.getButtonConfig();
+    expect(typeof cfg?.onClick).toBe("function");
+
+    await cfg.onClick();
+
+    expect(harness.tipCalls.some((c) => String(c.text).includes("No visible conversation"))).toBe(true);
+    expect(harness.tipCalls.some((c) => c.opts?.kind === "ok")).toBe(false);
+  });
+
   it("shows tip when auto incremental save succeeds", async () => {
     const snapshot = {
       conversation: { source: "gemini", conversationKey: "auto-1" },


### PR DESCRIPTION
Enhance user feedback by displaying a success message after a snapshot is saved. Fix the error handling to show a tip when no visible conversation is found during manual save.