### PR TITLE
Enhance concurrency and retry logic for Notion block deletion

### DIFF
--- a/Extensions/WebClipper/src/export/notion/notion-api.js
+++ b/Extensions/WebClipper/src/export/notion/notion-api.js
@@ -3,6 +3,23 @@
 
   const NOTION_VERSION = "2022-06-28";
 
+  function parseRetryAfterMs(res) {
+    try {
+      const raw = res && res.headers && typeof res.headers.get === "function"
+        ? String(res.headers.get("Retry-After") || "").trim()
+        : "";
+      if (!raw) return 0;
+      const sec = Number(raw);
+      if (Number.isFinite(sec) && sec > 0) return Math.round(sec * 1000);
+      const dateMs = Date.parse(raw);
+      if (!Number.isFinite(dateMs)) return 0;
+      const delta = dateMs - Date.now();
+      return delta > 0 ? delta : 0;
+    } catch (_e) {
+      return 0;
+    }
+  }
+
   async function notionFetch({ accessToken, method, path, body, notionVersion }) {
     if (!accessToken) throw new Error("missing notion access token");
     const url = `https://api.notion.com${path}`;
@@ -17,7 +34,19 @@
       body: body ? JSON.stringify(body) : undefined
     });
     const text = await res.text();
-    if (!res.ok) throw new Error(`notion api failed: ${method} ${path} HTTP ${res.status} ${text}`);
+    if (!res.ok) {
+      const err = new Error(`notion api failed: ${method} ${path} HTTP ${res.status} ${text}`);
+      err.status = res.status;
+      const retryAfterMs = parseRetryAfterMs(res);
+      if (retryAfterMs > 0) err.retryAfterMs = retryAfterMs;
+      try {
+        const parsed = text ? JSON.parse(text) : null;
+        if (parsed && parsed.code) err.code = String(parsed.code);
+      } catch (_e) {
+        // ignore
+      }
+      throw err;
+    }
     return text ? JSON.parse(text) : {};
   }
 

--- a/Extensions/WebClipper/src/export/notion/notion-sync-service.js
+++ b/Extensions/WebClipper/src/export/notion/notion-sync-service.js
@@ -3,7 +3,9 @@
 
   const MAX_TEXT = 1900;
   const APPEND_BATCH = 90;
-  const RATE_DELAY_MS = 250;
+  const APPEND_RATE_DELAY_MS = 250;
+  const CLEAR_DELETE_CONCURRENCY = 3;
+  const CLEAR_DELETE_MAX_ATTEMPTS = 5;
 
   function aiLabelForSource(source) {
     const api = NS.notionAi;
@@ -14,6 +16,25 @@
 
   function sleep(ms) {
     return new Promise((r) => setTimeout(r, ms));
+  }
+
+  function parseHttpStatus(error) {
+    const raw = error && error.status != null ? Number(error.status) : NaN;
+    if (Number.isFinite(raw) && raw > 0) return raw;
+    const message = error && error.message ? String(error.message) : String(error || "");
+    const m = message.match(/\bHTTP\s+(\d{3})\b/i);
+    return m ? Number(m[1]) : 0;
+  }
+
+  function retryDelayMs(error, attempt) {
+    const retryAfterMs = error && error.retryAfterMs != null ? Number(error.retryAfterMs) : 0;
+    if (Number.isFinite(retryAfterMs) && retryAfterMs > 0) {
+      return Math.min(5000, Math.max(150, Math.round(retryAfterMs)));
+    }
+    const a = Number.isFinite(Number(attempt)) ? Math.max(1, Number(attempt)) : 1;
+    const base = 180 * (2 ** (a - 1));
+    const jitter = Math.floor(Math.random() * 120);
+    return Math.min(5000, base + jitter);
   }
 
   function splitText(text) {
@@ -134,9 +155,8 @@
     }];
   }
 
-  function messagesToBlocks(messages, options) {
+  function messagesToBlocks(messages, _options) {
     const out = [];
-    const source = options && options.source ? String(options.source) : "";
     for (const m of messages || []) {
       const role = m.role || "assistant";
       const label = role === "user" ? "User" : role === "assistant" ? "Assistant" : role;
@@ -182,13 +202,50 @@
     return NS.notionApi.notionFetch({ accessToken, method: "DELETE", path: `/v1/blocks/${blockId}` });
   }
 
+  async function archiveBlockWithRetry(accessToken, blockId) {
+    let attempt = 0;
+    for (;;) {
+      attempt += 1;
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        return await archiveBlock(accessToken, blockId);
+      } catch (error) {
+        const status = parseHttpStatus(error);
+        const retryable = status === 429 || status === 503;
+        if (!retryable || attempt >= CLEAR_DELETE_MAX_ATTEMPTS) throw error;
+        // eslint-disable-next-line no-await-in-loop
+        await sleep(retryDelayMs(error, attempt));
+      }
+    }
+  }
+
+  async function parallelEach(items, worker, concurrency) {
+    const queue = Array.isArray(items) ? items.slice() : [];
+    if (!queue.length) return true;
+    const size = Number.isFinite(Number(concurrency)) ? Math.max(1, Number(concurrency)) : 1;
+    const workers = [];
+    for (let i = 0; i < size; i += 1) {
+      workers.push((async () => {
+        for (;;) {
+          const item = queue.shift();
+          if (item == null) return;
+          // eslint-disable-next-line no-await-in-loop
+          await worker(item);
+        }
+      })());
+    }
+    await Promise.all(workers);
+    return true;
+  }
+
   async function clearPageChildren(accessToken, pageId) {
     const children = await listChildren(accessToken, pageId);
-    for (const c of children) {
-      if (!c || !c.id) continue;
-      await archiveBlock(accessToken, c.id);
-      await sleep(RATE_DELAY_MS);
-    }
+    const ids = children
+      .map((c) => c && c.id ? String(c.id).trim() : "")
+      .filter(Boolean);
+    await parallelEach(ids, async (blockId) => {
+      await archiveBlockWithRetry(accessToken, blockId);
+    }, CLEAR_DELETE_CONCURRENCY);
   }
 
   async function appendChildren(accessToken, pageId, blocks) {
@@ -202,7 +259,7 @@
         path: `/v1/blocks/${pageId}/children`,
         body: { children: batch }
       });
-      if (remaining.length) await sleep(RATE_DELAY_MS);
+      if (remaining.length) await sleep(APPEND_RATE_DELAY_MS);
     }
   }
 

--- a/Extensions/WebClipper/tests/smoke/notion-sync-service.test.ts
+++ b/Extensions/WebClipper/tests/smoke/notion-sync-service.test.ts
@@ -187,6 +187,85 @@ describe("notion-sync-service", () => {
     const getCalls = calls.filter((c) => c.method === "GET");
     const delCalls = calls.filter((c) => c.method === "DELETE");
     expect(getCalls.length).toBe(2);
-    expect(delCalls.map((c) => c.path)).toEqual(["/v1/blocks/b1", "/v1/blocks/b2"]);
+    expect(delCalls.map((c) => c.path).sort()).toEqual(["/v1/blocks/b1", "/v1/blocks/b2"]);
+  });
+
+  it("retries transient errors when clearing page children", async () => {
+    const calls: any[] = [];
+    let b1DeleteAttempts = 0;
+    // @ts-expect-error test global
+    globalThis.WebClipper = {};
+    // @ts-expect-error test global
+    globalThis.WebClipper.notionApi = {
+      notionFetch: async (req: any) => {
+        calls.push(req);
+        if (req.method === "GET" && req.path.startsWith("/v1/blocks/p2/children")) {
+          return { results: [{ id: "b1" }, { id: "b2" }], has_more: false, next_cursor: null };
+        }
+        if (req.method === "DELETE" && req.path === "/v1/blocks/b1") {
+          b1DeleteAttempts += 1;
+          if (b1DeleteAttempts === 1) {
+            const err: any = new Error("notion api failed: DELETE /v1/blocks/b1 HTTP 429");
+            err.status = 429;
+            err.retryAfterMs = 1;
+            throw err;
+          }
+          return { ok: true };
+        }
+        if (req.method === "DELETE" && req.path === "/v1/blocks/b2") return { ok: true };
+        throw new Error(`unexpected notionFetch: ${req.method} ${req.path}`);
+      }
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const modulePath = require.resolve("../../src/export/notion/notion-sync-service.js");
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete require.cache[modulePath];
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const notionSyncService = require("../../src/export/notion/notion-sync-service.js");
+
+    await notionSyncService.clearPageChildren("t", "p2");
+    const deleteCalls = calls.filter((c) => c.method === "DELETE").map((c) => c.path);
+    const b1Calls = deleteCalls.filter((path) => path === "/v1/blocks/b1");
+    expect(b1Calls.length).toBe(2);
+    expect(deleteCalls.includes("/v1/blocks/b2")).toBe(true);
+  });
+
+  it("archives children concurrently when clearing a page", async () => {
+    const startedDeletes: string[] = [];
+    const deleteResolvers = new Map<string, () => void>();
+    // @ts-expect-error test global
+    globalThis.WebClipper = {};
+    // @ts-expect-error test global
+    globalThis.WebClipper.notionApi = {
+      notionFetch: async (req: any) => {
+        if (req.method === "GET" && req.path.startsWith("/v1/blocks/p3/children")) {
+          return { results: [{ id: "b1" }, { id: "b2" }], has_more: false, next_cursor: null };
+        }
+        if (req.method === "DELETE" && (req.path === "/v1/blocks/b1" || req.path === "/v1/blocks/b2")) {
+          startedDeletes.push(req.path);
+          return new Promise((resolve) => {
+            deleteResolvers.set(req.path, () => resolve({ ok: true }));
+          });
+        }
+        throw new Error(`unexpected notionFetch: ${req.method} ${req.path}`);
+      }
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const modulePath = require.resolve("../../src/export/notion/notion-sync-service.js");
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete require.cache[modulePath];
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const notionSyncService = require("../../src/export/notion/notion-sync-service.js");
+
+    const clearing = notionSyncService.clearPageChildren("t", "p3");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(startedDeletes.slice().sort()).toEqual(["/v1/blocks/b1", "/v1/blocks/b2"]);
+
+    deleteResolvers.get("/v1/blocks/b1")?.();
+    deleteResolvers.get("/v1/blocks/b2")?.();
+    await clearing;
   });
 });


### PR DESCRIPTION
Improve the handling of transient errors during block deletion by implementing a retry mechanism and allowing concurrent deletions of blocks. This update optimizes the process of clearing page children in Notion.