### PR TITLE
Register OAuth webNavigation listener safely for Notion integration

### DIFF
--- a/Extensions/WebClipper/src/integrations/notion/oauth.ts
+++ b/Extensions/WebClipper/src/integrations/notion/oauth.ts
@@ -189,16 +189,26 @@ export async function handleNotionOAuthCallbackNavigation(
 
 export function setupNotionOAuthNavigationListener(): void {
   const { chrome, browser } = getApis();
-  const addListener =
-    chrome?.webNavigation?.onCommitted?.addListener ??
-    browser?.webNavigation?.onCommitted?.addListener;
-  if (typeof addListener !== 'function') return;
+  try {
+    if (chrome?.webNavigation?.onCommitted?.addListener) {
+      chrome.webNavigation.onCommitted.addListener((details: any) => {
+        handleNotionOAuthCallbackNavigation({
+          url: String(details?.url || ''),
+          tabId: Number(details?.tabId),
+        }).catch(() => {});
+      });
+      return;
+    }
 
-  addListener((details: any) => {
-    handleNotionOAuthCallbackNavigation({
-      url: String(details?.url || ''),
-      tabId: Number(details?.tabId),
-    }).catch(() => {});
-  });
+    if (browser?.webNavigation?.onCommitted?.addListener) {
+      browser.webNavigation.onCommitted.addListener((details: any) => {
+        handleNotionOAuthCallbackNavigation({
+          url: String(details?.url || ''),
+          tabId: Number(details?.tabId),
+        }).catch(() => {});
+      });
+    }
+  } catch (_e) {
+    // ignore: best-effort (some browsers/polyfills may throw on listener registration)
+  }
 }
-

--- a/Extensions/WebClipper/tests/integrations/notion-oauth.test.ts
+++ b/Extensions/WebClipper/tests/integrations/notion-oauth.test.ts
@@ -4,6 +4,7 @@ import {
   ensureDefaultNotionOAuthClientId,
   getNotionOAuthDefaults,
   handleNotionOAuthCallbackNavigation,
+  setupNotionOAuthNavigationListener,
 } from '../../src/integrations/notion/oauth';
 
 function mockChromeStorage(initial: Record<string, unknown> = {}) {
@@ -57,6 +58,25 @@ function mockFetchJsonOk(json: unknown) {
 }
 
 describe('notion oauth (ts)', () => {
+  it('setupNotionOAuthNavigationListener registers webNavigation listener (chrome)', async () => {
+    // @ts-expect-error test global
+    globalThis.browser = undefined;
+
+    const chromeMock: any = mockChromeStorage();
+    chromeMock.webNavigation = {
+      onCommitted: {
+        addListener(cb: any) {
+          chromeMock.__webNavCb = cb;
+        },
+      },
+    };
+    // @ts-expect-error test global
+    globalThis.chrome = chromeMock;
+
+    setupNotionOAuthNavigationListener();
+    expect(typeof chromeMock.__webNavCb).toBe('function');
+  });
+
   it('ensureDefaultNotionOAuthClientId sets default id and removes secret', async () => {
     // @ts-expect-error test global
     globalThis.browser = undefined;
@@ -153,4 +173,3 @@ describe('notion oauth (ts)', () => {
     expect(token.createdAt).toBe(456);
   });
 });
-


### PR DESCRIPTION
Ensure safe registration of the OAuth webNavigation listener for Notion by handling potential errors during listener setup. This improves reliability across different browsers.