### PR TITLE
Add confirmation modal for conversation deletion and improve Notion page handling

### DIFF
--- a/Extensions/WebClipper/entrypoints/popup/tabs/ChatsTab.tsx
+++ b/Extensions/WebClipper/entrypoints/popup/tabs/ChatsTab.tsx
@@ -83,7 +83,8 @@ type PreviewState = { conversationId: number; left: number; top: number } | null
 function normalizeRole(role: unknown) {
   const r = String(role || 'assistant').toLowerCase();
   if (r === 'user') return 'user';
-  if (r === 'assistant') return 'assistant';
+  if (r === 'assistant')
+     return 'assistant';
   return 'other';
 }
 
@@ -95,6 +96,8 @@ export default function ChatsTab() {
 
   const [filterKey, setFilterKey] = useState<string>('all');
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+  const [confirmDeleteIds, setConfirmDeleteIds] = useState<number[]>([]);
 
   const [exportOpen, setExportOpen] = useState(false);
   const exportWrapRef = useRef<HTMLDivElement | null>(null);
@@ -249,11 +252,37 @@ export default function ChatsTab() {
     }
   };
 
-  const onDeleteSelected = async () => {
+  const openDeleteConfirm = () => {
     const ids = selectedIds.slice();
-    if (!ids.length) return;
-    const ok = confirm(`Delete ${ids.length} conversation(s)? This cannot be undone.`);
-    if (!ok) return;
+    if (!ids.length || loadingList) return;
+    setConfirmDeleteIds(ids);
+    setConfirmDeleteOpen(true);
+  };
+
+  const closeDeleteConfirm = () => {
+    if (loadingList) return;
+    setConfirmDeleteOpen(false);
+    setConfirmDeleteIds([]);
+  };
+
+  useEffect(() => {
+    if (!confirmDeleteOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      e.preventDefault();
+      closeDeleteConfirm();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [confirmDeleteOpen]);
+
+  const onConfirmDelete = async () => {
+    const ids = confirmDeleteIds.slice();
+    if (!ids.length) {
+      closeDeleteConfirm();
+      return;
+    }
     setLoadingList(true);
     setError(null);
     try {
@@ -262,6 +291,8 @@ export default function ChatsTab() {
       setPreview(null);
       setPreviewDetail(null);
       await refresh();
+      setConfirmDeleteOpen(false);
+      setConfirmDeleteIds([]);
     } catch (e) {
       setError((e as any)?.message ?? String(e ?? 'failed'));
     } finally {
@@ -578,7 +609,7 @@ export default function ChatsTab() {
           </select>
 
           <div id="chatActionButtons" className="chatActionButtons">
-            <button id="btnDelete" className="btn danger" type="button" title="Delete selected" onClick={() => onDeleteSelected().catch(() => {})} disabled={!selectedCount}>
+            <button id="btnDelete" className="btn danger" type="button" title="Delete selected" onClick={openDeleteConfirm} disabled={!selectedCount || loadingList}>
               Delete
             </button>
 
@@ -643,6 +674,36 @@ export default function ChatsTab() {
           </div>
         </section>
       </footer>
+
+      {confirmDeleteOpen ? (
+        <div
+          className="modalOverlay"
+          role="presentation"
+          onMouseDown={(e) => {
+            e.preventDefault();
+            closeDeleteConfirm();
+          }}
+        >
+          <div
+            className="modalCard"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Confirm delete"
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            <div className="modalTitle">Delete conversations?</div>
+            <div className="modalBody">Delete {confirmDeleteIds.length} conversation(s)? This cannot be undone.</div>
+            <div className="modalActions">
+              <button className="btn" type="button" onClick={closeDeleteConfirm} disabled={loadingList}>
+                Cancel
+              </button>
+              <button className="btn danger" type="button" onClick={() => onConfirmDelete().catch(() => {})} disabled={loadingList}>
+                {loadingList ? 'Deleting…' : 'Delete'}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </>
   );
 }

--- a/Extensions/WebClipper/entrypoints/popup/tabs/SettingsTab.tsx
+++ b/Extensions/WebClipper/entrypoints/popup/tabs/SettingsTab.tsx
@@ -114,6 +114,27 @@ async function searchNotionParentPages(accessToken: string): Promise<NotionPageO
     .filter((p: NotionPageOption) => !!p.id);
 }
 
+async function retrieveNotionParentPage(accessToken: string, pageId: string): Promise<NotionPageOption | null> {
+  const safeId = String(pageId || '').trim();
+  if (!safeId) return null;
+  const res = await fetch(`https://api.notion.com/v1/pages/${encodeURIComponent(safeId)}`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Notion-Version': '2022-06-28',
+      Accept: 'application/json',
+    },
+  });
+  const text = await res.text();
+  if (!res.ok) return null;
+  const json = text ? JSON.parse(text) : {};
+  if (!json || json.object !== 'page') return null;
+  if (json.archived === true || json.in_trash === true) return null;
+  const id = String(json.id || safeId).trim();
+  if (!id) return null;
+  return { id, title: getPageTitle(json) };
+}
+
 function openHttpUrl(url: string) {
   const u = String(url || '').trim();
   if (!/^https?:\/\//i.test(u)) return false;
@@ -179,10 +200,12 @@ export default function SettingsTab() {
   const [notionPendingState, setNotionPendingState] = useState<string>('');
   const [notionLastError, setNotionLastError] = useState<string>('');
   const [notionParentPageId, setNotionParentPageId] = useState<string>('');
+  const [notionParentPageTitle, setNotionParentPageTitle] = useState<string>('');
   const [notionPages, setNotionPages] = useState<Array<{ id: string; title: string }>>([]);
   const [loadingNotionPages, setLoadingNotionPages] = useState(false);
   const [pollingNotion, setPollingNotion] = useState(false);
   const [notionJob, setNotionJob] = useState<any>(null);
+  const notionPagesAutoLoadRef = useRef(false);
 
   // Obsidian
   const [obsidianApiBaseUrl, setObsidianApiBaseUrl] = useState<string>('');
@@ -223,6 +246,7 @@ export default function SettingsTab() {
           'notion_oauth_pending_state',
           'notion_oauth_last_error',
           'notion_parent_page_id',
+          'notion_parent_page_title',
           'notion_ai_preferred_model_index',
           'inpage_supported_only',
         ]),
@@ -239,6 +263,7 @@ export default function SettingsTab() {
       setNotionPendingState(String(local?.notion_oauth_pending_state || '').trim());
       setNotionLastError(String(local?.notion_oauth_last_error || '').trim());
       setNotionParentPageId(String(local?.notion_parent_page_id || '').trim());
+      setNotionParentPageTitle(String(local?.notion_parent_page_title || '').trim());
       setNotionAiModelIndex(String(local?.notion_ai_preferred_model_index || '').trim());
       setInpageSupportedOnly(local?.inpage_supported_only == null ? null : !!local.inpage_supported_only);
 
@@ -276,6 +301,23 @@ export default function SettingsTab() {
     return () => clearInterval(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pollingNotion]);
+
+  const notionPageOptions = useMemo(() => {
+    const list = Array.isArray(notionPages) ? notionPages.slice() : [];
+    const selectedId = String(notionParentPageId || '').trim();
+    if (selectedId && !list.some((p) => String(p?.id || '').trim() === selectedId)) {
+      const title = String(notionParentPageTitle || '').trim();
+      list.unshift({ id: selectedId, title: title || selectedId });
+    }
+    const seen = new Set<string>();
+    return list.filter((p) => {
+      const id = p && p.id ? String(p.id).trim() : '';
+      if (!id) return false;
+      if (seen.has(id)) return false;
+      seen.add(id);
+      return true;
+    });
+  }, [notionPages, notionParentPageId, notionParentPageTitle]);
 
   const notionStatusText = useMemo(() => {
     if (notionConnected == null) return 'unknown';
@@ -329,22 +371,51 @@ export default function SettingsTab() {
       const status = unwrap(await send<ApiResponse<any>>(NOTION_MESSAGE_TYPES.GET_AUTH_STATUS, {}));
       const accessToken = String(status?.token?.accessToken || '');
       if (!accessToken) throw new Error('Notion not connected');
-      const pages = await searchNotionParentPages(accessToken);
+      const savedId = String(notionParentPageId || '').trim();
+      const savedTitle = String(notionParentPageTitle || '').trim();
+
+      let pages = await searchNotionParentPages(accessToken);
+      let resolvedSaved = savedId ? pages.find((p) => p.id === savedId) ?? null : null;
+      if (savedId && !resolvedSaved) {
+        const retrieved = await retrieveNotionParentPage(accessToken, savedId);
+        if (retrieved) {
+          pages = [retrieved, ...pages.filter((p) => p.id !== retrieved.id)];
+          resolvedSaved = retrieved;
+        }
+      }
+
       setNotionPages(pages);
 
-      const saved = String(notionParentPageId || '').trim();
-      const hasSaved = saved && pages.some((p) => p.id === saved);
-      const next = hasSaved ? saved : (pages[0]?.id || '');
-      if (next && next !== saved) {
-        setNotionParentPageId(next);
-        await storageSet({ notion_parent_page_id: next });
-      }
+      const nextId = savedId || (pages[0]?.id || '');
+      const nextTitle = (resolvedSaved?.title || (savedId ? savedTitle : pages[0]?.title) || '').trim();
+      if (nextId) setNotionParentPageId(nextId);
+      if (nextTitle) setNotionParentPageTitle(nextTitle);
+
+      const payload: Record<string, unknown> = {};
+      if (nextId && nextId !== savedId) payload.notion_parent_page_id = nextId;
+      if (nextTitle && nextTitle !== savedTitle) payload.notion_parent_page_title = nextTitle;
+      if (Object.keys(payload).length) await storageSet(payload);
     } catch (e) {
       setError((e as any)?.message ?? String(e ?? 'failed to load pages'));
     } finally {
       setLoadingNotionPages(false);
     }
   };
+
+  useEffect(() => {
+    if (!notionConnected) {
+      notionPagesAutoLoadRef.current = false;
+      return;
+    }
+    if (notionPagesAutoLoadRef.current) return;
+    if (notionPages.length) {
+      notionPagesAutoLoadRef.current = true;
+      return;
+    }
+    notionPagesAutoLoadRef.current = true;
+    onLoadNotionPages().catch(() => {});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [notionConnected]);
 
   const onSaveNotionParentPage = async (id: string) => {
     const next = String(id || '').trim();
@@ -353,7 +424,11 @@ export default function SettingsTab() {
     setError(null);
     try {
       setNotionParentPageId(next);
-      await storageSet({ notion_parent_page_id: next });
+      const match = notionPages.find((p) => p && String(p.id || '').trim() === next) ?? null;
+      if (match && match.title) setNotionParentPageTitle(String(match.title || '').trim());
+      const payload: Record<string, unknown> = { notion_parent_page_id: next };
+      if (match && match.title) payload.notion_parent_page_title = String(match.title || '').trim();
+      await storageSet(payload);
     } catch (e) {
       setError((e as any)?.message ?? String(e ?? 'failed'));
     } finally {
@@ -602,8 +677,8 @@ export default function SettingsTab() {
               disabled={busy || !notionConnected}
               onChange={(e) => onSaveNotionParentPage(e.target.value).catch(() => {})}
             >
-              {notionPages.length ? null : <option value="">{notionConnected ? 'Click refresh →' : 'Connect Notion first'}</option>}
-              {notionPages.map((p) => (
+              {notionPageOptions.length ? null : <option value="">{notionConnected ? 'Click refresh →' : 'Connect Notion first'}</option>}
+              {notionPageOptions.map((p) => (
                 <option key={p.id} value={p.id}>
                   {p.title}
                 </option>

--- a/Extensions/WebClipper/src/domains/settings/background-handlers.ts
+++ b/Extensions/WebClipper/src/domains/settings/background-handlers.ts
@@ -24,6 +24,7 @@ function getInstanceId(): string {
 function getNotionDisconnectStorageKeys(): string[] {
   const base = [
     'notion_parent_page_id',
+    'notion_parent_page_title',
     'notion_oauth_pending_state',
     'notion_oauth_last_error',
   ];

--- a/Extensions/WebClipper/src/ui/app/routes/Settings.tsx
+++ b/Extensions/WebClipper/src/ui/app/routes/Settings.tsx
@@ -114,6 +114,27 @@ async function searchNotionParentPages(accessToken: string): Promise<NotionPageO
     .filter((p: NotionPageOption) => !!p.id);
 }
 
+async function retrieveNotionParentPage(accessToken: string, pageId: string): Promise<NotionPageOption | null> {
+  const safeId = String(pageId || '').trim();
+  if (!safeId) return null;
+  const res = await fetch(`https://api.notion.com/v1/pages/${encodeURIComponent(safeId)}`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Notion-Version': '2022-06-28',
+      Accept: 'application/json',
+    },
+  });
+  const text = await res.text();
+  if (!res.ok) return null;
+  const json = text ? JSON.parse(text) : {};
+  if (!json || json.object !== 'page') return null;
+  if (json.archived === true || json.in_trash === true) return null;
+  const id = String(json.id || safeId).trim();
+  if (!id) return null;
+  return { id, title: getPageTitle(json) };
+}
+
 function openHttpUrl(url: string) {
   const u = String(url || '').trim();
   if (!/^https?:\/\//i.test(u)) return false;
@@ -164,10 +185,12 @@ export default function Settings() {
   const [notionLastError, setNotionLastError] = useState<string>('');
   const [notionClientId, setNotionClientId] = useState<string>('');
   const [notionParentPageId, setNotionParentPageId] = useState<string>('');
+  const [notionParentPageTitle, setNotionParentPageTitle] = useState<string>('');
   const [notionPages, setNotionPages] = useState<Array<{ id: string; title: string }>>([]);
   const [loadingNotionPages, setLoadingNotionPages] = useState(false);
   const [pollingNotion, setPollingNotion] = useState(false);
   const [notionJob, setNotionJob] = useState<any>(null);
+  const notionPagesAutoLoadRef = useRef(false);
 
   // Obsidian
   const [obsidianApiBaseUrl, setObsidianApiBaseUrl] = useState<string>('');
@@ -226,6 +249,7 @@ export default function Settings() {
           'notion_oauth_pending_state',
           'notion_oauth_last_error',
           'notion_parent_page_id',
+          'notion_parent_page_title',
           'notion_ai_preferred_model_index',
           'inpage_supported_only',
         ]),
@@ -242,6 +266,7 @@ export default function Settings() {
       setNotionPendingState(String(local?.notion_oauth_pending_state || '').trim());
       setNotionLastError(String(local?.notion_oauth_last_error || '').trim());
       setNotionParentPageId(String(local?.notion_parent_page_id || '').trim());
+      setNotionParentPageTitle(String(local?.notion_parent_page_title || '').trim());
       setNotionAiModelIndex(String(local?.notion_ai_preferred_model_index || '').trim());
       setInpageSupportedOnly(local?.inpage_supported_only == null ? null : !!local.inpage_supported_only);
 
@@ -278,6 +303,23 @@ export default function Settings() {
     return () => clearInterval(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pollingNotion]);
+
+  const notionPageOptions = useMemo(() => {
+    const list = Array.isArray(notionPages) ? notionPages.slice() : [];
+    const selectedId = String(notionParentPageId || '').trim();
+    if (selectedId && !list.some((p) => String(p?.id || '').trim() === selectedId)) {
+      const title = String(notionParentPageTitle || '').trim();
+      list.unshift({ id: selectedId, title: title || selectedId });
+    }
+    const seen = new Set<string>();
+    return list.filter((p) => {
+      const id = p && p.id ? String(p.id).trim() : '';
+      if (!id) return false;
+      if (seen.has(id)) return false;
+      seen.add(id);
+      return true;
+    });
+  }, [notionPages, notionParentPageId, notionParentPageTitle]);
 
   const onNotionConnectOrDisconnect = async () => {
     setBusy(true);
@@ -320,22 +362,51 @@ export default function Settings() {
       const status = unwrap(await send<ApiResponse<any>>(NOTION_MESSAGE_TYPES.GET_AUTH_STATUS, {}));
       const accessToken = String(status?.token?.accessToken || '');
       if (!accessToken) throw new Error('Notion not connected');
-      const pages = await searchNotionParentPages(accessToken);
+      const savedId = String(notionParentPageId || '').trim();
+      const savedTitle = String(notionParentPageTitle || '').trim();
+
+      let pages = await searchNotionParentPages(accessToken);
+      let resolvedSaved = savedId ? pages.find((p) => p.id === savedId) ?? null : null;
+      if (savedId && !resolvedSaved) {
+        const retrieved = await retrieveNotionParentPage(accessToken, savedId);
+        if (retrieved) {
+          pages = [retrieved, ...pages.filter((p) => p.id !== retrieved.id)];
+          resolvedSaved = retrieved;
+        }
+      }
+
       setNotionPages(pages);
 
-      const saved = String(notionParentPageId || '').trim();
-      const hasSaved = saved && pages.some((p) => p.id === saved);
-      const next = hasSaved ? saved : (pages[0]?.id || '');
-      if (next && next !== saved) {
-        setNotionParentPageId(next);
-        await storageSet({ notion_parent_page_id: next });
-      }
+      const nextId = savedId || (pages[0]?.id || '');
+      const nextTitle = (resolvedSaved?.title || (savedId ? savedTitle : pages[0]?.title) || '').trim();
+      if (nextId) setNotionParentPageId(nextId);
+      if (nextTitle) setNotionParentPageTitle(nextTitle);
+
+      const payload: Record<string, unknown> = {};
+      if (nextId && nextId !== savedId) payload.notion_parent_page_id = nextId;
+      if (nextTitle && nextTitle !== savedTitle) payload.notion_parent_page_title = nextTitle;
+      if (Object.keys(payload).length) await storageSet(payload);
     } catch (e) {
       setError((e as any)?.message ?? String(e ?? 'failed to load pages'));
     } finally {
       setLoadingNotionPages(false);
     }
   };
+
+  useEffect(() => {
+    if (!notionConnected) {
+      notionPagesAutoLoadRef.current = false;
+      return;
+    }
+    if (notionPagesAutoLoadRef.current) return;
+    if (notionPages.length) {
+      notionPagesAutoLoadRef.current = true;
+      return;
+    }
+    notionPagesAutoLoadRef.current = true;
+    onLoadNotionPages().catch(() => {});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [notionConnected]);
 
   const onSaveNotionParentPage = async (id: string) => {
     const next = String(id || '').trim();
@@ -344,7 +415,11 @@ export default function Settings() {
     setError(null);
     try {
       setNotionParentPageId(next);
-      await storageSet({ notion_parent_page_id: next });
+      const match = notionPages.find((p) => p && String(p.id || '').trim() === next) ?? null;
+      if (match && match.title) setNotionParentPageTitle(String(match.title || '').trim());
+      const payload: Record<string, unknown> = { notion_parent_page_id: next };
+      if (match && match.title) payload.notion_parent_page_title = String(match.title || '').trim();
+      await storageSet(payload);
     } catch (e) {
       setError((e as any)?.message ?? String(e ?? 'failed'));
     } finally {
@@ -584,8 +659,8 @@ export default function Settings() {
               onChange={(e) => onSaveNotionParentPage(e.target.value).catch(() => {})}
               style={{ width: '100%' }}
             >
-              {notionPages.length ? null : <option value="">{notionConnected ? 'Click refresh →' : 'Connect Notion first'}</option>}
-              {notionPages.map((p) => (
+              {notionPageOptions.length ? null : <option value="">{notionConnected ? 'Click refresh →' : 'Connect Notion first'}</option>}
+              {notionPageOptions.map((p) => (
                 <option key={p.id} value={p.id}>
                   {p.title}
                 </option>

--- a/Extensions/WebClipper/src/ui/styles/popup.css
+++ b/Extensions/WebClipper/src/ui/styles/popup.css
@@ -1255,6 +1255,47 @@ input[type="checkbox"] {
   white-space: nowrap;
 }
 
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 14px;
+  background: rgba(10, 10, 10, 0.32);
+  backdrop-filter: blur(4px);
+}
+
+.modalCard {
+  width: 100%;
+  max-width: 360px;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  padding: 12px;
+}
+
+.modalTitle {
+  font-weight: 860;
+  letter-spacing: -0.01em;
+  color: var(--text);
+}
+
+.modalBody {
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.modalActions {
+  margin-top: 12px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
 @keyframes rise-in {
   from {
     opacity: 0;


### PR DESCRIPTION
Introduce a confirmation modal for deleting conversations to prevent accidental deletions. Enhance handling of Notion pages by adding a title state and ensuring proper retrieval of parent page details.