### PR TITLE
chore(release): v1.2.4

### DIFF
--- a/webclipper/wxt.config.ts
+++ b/webclipper/wxt.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   entrypointsDir: 'src/entrypoints',
   manifest: {
     name: 'SyncNos-AI+Web Clipper',
-    version: '1.2.3',
+    version: '1.2.4',
     description:
       'Clip AI chats to local storage, export to JSON or Markdown, and sync to Notion on demand.',
     permissions: [


### PR DESCRIPTION
Bump WebClipper manifest version to 1.2.4.

Verified: npm --prefix webclipper run compile/test/build