### PR TITLE
修复：更新后不再自动打开设置页

### DIFF
--- a/webclipper/src/entrypoints/background.ts
+++ b/webclipper/src/entrypoints/background.ts
@@ -21,7 +21,7 @@ function getBackgroundInstanceId(): string {
   return backgroundInstanceId;
 }
 
-async function openAboutSectionAfterInstallOrUpdate(): Promise<void> {
+async function openAboutSectionAfterInstall(): Promise<void> {
   await openOrFocusExtensionAppTab({ route: '/settings?section=about' });
 }
 
@@ -60,8 +60,9 @@ export default defineBackground(() => {
     registerClipperContextMenu();
     onInstalled((details) => {
       ensureDefaultNotionOAuthClientId().catch(() => {});
-      if (details?.reason !== 'install' && details?.reason !== 'update') return;
-      openAboutSectionAfterInstallOrUpdate().catch(() => {});
+      // Do not auto-open tabs after extension updates.
+      if (details?.reason !== 'install') return;
+      openAboutSectionAfterInstall().catch(() => {});
     });
   } catch (_e) {
     // ignore


### PR DESCRIPTION
Fixes #252

- 扩展更新后不再自动打开 Settings -> About 标签页（仅首次安装时打开）。
- 顺带修复 Gemini 抓取中会混入隐藏 UI 文案（如“你说 / Gemini 说 / 停止回答提示”）的问题。
