### PR TITLE
Update changelog link on About page

### DIFF
--- a/webclipper/src/ui/settings/sections/AboutSection.tsx
+++ b/webclipper/src/ui/settings/sections/AboutSection.tsx
@@ -52,7 +52,7 @@ export function AboutSection() {
             id="btnAboutChangelog"
             className={buttonClassName}
             type="button"
-            onClick={() => openUrl('https://github.com/chiimagnus/SyncNos/releases').catch(() => {})}
+            onClick={() => openUrl('https://chiimagnus.notion.site/syncnos-changelog').catch(() => {})}
           >
             {t('changelog')}
           </button>


### PR DESCRIPTION
Update the changelog link to point to the Notion page instead of the GitHub releases page.