### PR TITLE
Change message role to 'article' for better content representation

### DIFF
--- a/webclipper/src/collectors/web/article-fetch.ts
+++ b/webclipper/src/collectors/web/article-fetch.ts
@@ -511,7 +511,7 @@ export async function fetchActiveTabArticle({ tabId }: { tabId?: number } = {}) 
   await syncConversationMessages(Number((conversation as any).id), [
     {
       messageKey: 'article_body',
-      role: 'assistant',
+      role: 'article',
       contentText: body,
       contentMarkdown: markdown,
       sequence: 1,

--- a/webclipper/src/ui/conversations/ConversationDetailPane.tsx
+++ b/webclipper/src/ui/conversations/ConversationDetailPane.tsx
@@ -29,6 +29,7 @@ export function ConversationDetailPane({ onBack, hideHeader = false }: Conversat
   const chatWithActions = safeActions.filter((action) => action.slot === 'chat-with');
 
   const outlineButtonClass = buttonTintClassName();
+  const isArticle = String((selected as any)?.sourceType || '').trim().toLowerCase() === 'article';
 
   return (
     <section>
@@ -87,8 +88,8 @@ export function ConversationDetailPane({ onBack, hideHeader = false }: Conversat
               return (
                 <ChatMessageBubble
                   key={String((m as any).id)}
-                  role={(m as any).role}
-                  headerLeft={String((m as any).role || t('messageRoleFallback'))}
+                  role={isArticle ? undefined : (m as any).role}
+                  headerLeft={isArticle ? undefined : String((m as any).role || t('messageRoleFallback'))}
                   markdown={text}
                 />
               );

--- a/webclipper/tests/smoke/article-fetch-service.test.ts
+++ b/webclipper/tests/smoke/article-fetch-service.test.ts
@@ -96,7 +96,7 @@ describe("article-fetch-service", () => {
     expect(Array.isArray(messages)).toBe(true);
     expect(messages[0]).toMatchObject({
       messageKey: "article_body",
-      role: "assistant",
+      role: "article",
       sequence: 1,
       contentText: "Hello world article text.",
       contentMarkdown: "## Heading\n\n![img](https://example.com/a.png)\n\nHello world article text."


### PR DESCRIPTION
Update the message role to 'article' to more accurately reflect the content source, enhancing clarity in the conversation context. Adjustments made in the relevant components ensure consistent handling of this new role.