### PR TITLE
Improve filename sanitization logic

### DIFF
--- a/webclipper/src/conversations/domain/markdown.ts
+++ b/webclipper/src/conversations/domain/markdown.ts
@@ -17,8 +17,10 @@ function formatIso(ts?: number) {
 export function sanitizeFilenamePart(value: unknown, fallback: string, maxLen: number = 80) {
   const raw = String(value ?? '').trim();
   const cleaned = raw
-    .replace(/[\\/:*?"<>|]/g, '_')
-    .replace(/\s+/g, ' ')
+    .replace(/[\\/:*?"<>|]+/g, '-')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
     .trim();
   const limit = Number.isFinite(Number(maxLen)) ? Math.max(1, Math.floor(Number(maxLen))) : 80;
   return cleaned.slice(0, limit) || fallback;

--- a/webclipper/tests/unit/file-naming.test.ts
+++ b/webclipper/tests/unit/file-naming.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildConversationBasename, stableConversationId10 } from '../../src/conversations/domain/file-naming';
+
+describe('file-naming', () => {
+  it('generates space-free conversation basenames for Obsidian-safe files', () => {
+    const convo = {
+      source: 'doubao',
+      title: '问候与帮助 - 豆包',
+      conversationKey: 'k1',
+    };
+
+    const id10 = stableConversationId10(convo);
+    const basename = buildConversationBasename(convo);
+
+    expect(basename).toBe(`doubao-问候与帮助-豆包-${id10}`);
+    expect(basename).not.toMatch(/\s/);
+  });
+});


### PR DESCRIPTION
Update the `sanitizeFilenamePart` function to enhance the filename cleaning process by replacing unwanted characters and ensuring no leading or trailing hyphens. Add tests to verify the generation of space-free conversation basenames for Obsidian-safe files.