### PR TITLE
Refactor markdown renderer to separate math rendering logic

### DIFF
--- a/webclipper/src/entrypoints/app/main.tsx
+++ b/webclipper/src/entrypoints/app/main.tsx
@@ -4,7 +4,6 @@ import AppShell from '@ui/app/AppShell';
 import '@ui/styles/tokens.css';
 import '@ui/styles/buttons.css';
 import '@ui/styles/tailwind.css';
-import 'katex/dist/katex.min.css';
 import '@entrypoints/app/style.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/webclipper/src/entrypoints/popup/main.tsx
+++ b/webclipper/src/entrypoints/popup/main.tsx
@@ -4,7 +4,6 @@ import PopupShell from '@ui/popup/PopupShell';
 import '@ui/styles/tokens.css';
 import '@ui/styles/buttons.css';
 import '@ui/styles/tailwind.css';
-import 'katex/dist/katex.min.css';
 import '@entrypoints/popup/style.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/webclipper/src/ui/shared/ChatMessageBubble.tsx
+++ b/webclipper/src/ui/shared/ChatMessageBubble.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
-import { createMarkdownRenderer } from '@ui/shared/markdown';
+import { createMarkdownRenderer } from '@ui/shared/markdown-core';
 import { getImageCacheAssetById } from '@services/conversations/data/image-cache-read';
 
 type BubbleRole = 'user' | 'assistant';
@@ -75,7 +75,31 @@ export type ChatMessageBubbleProps = {
 };
 
 // Shared singleton to avoid per-message renderer instantiation.
-const sharedMd = createMarkdownRenderer({ openLinksInNewTab: true });
+const sharedMd = createMarkdownRenderer({ openLinksInNewTab: true, renderMath: false });
+let sharedMathMd: ReturnType<typeof createMarkdownRenderer> | null = null;
+let sharedMathMdPromise: Promise<ReturnType<typeof createMarkdownRenderer>> | null = null;
+
+const MATH_BLOCK_RE = /\$\$[\s\S]+?\$\$/;
+const MATH_INLINE_RE = /(^|[^\\])\$(?!\$)[^$\n]+?\$(?!\$)/;
+const MATH_BRACKET_RE = /\\\([\s\S]+?\\\)|\\\[[\s\S]+?\\\]/;
+
+function markdownLikelyContainsMath(markdown: string): boolean {
+  const text = String(markdown || '');
+  if (!text) return false;
+  return MATH_BLOCK_RE.test(text) || MATH_INLINE_RE.test(text) || MATH_BRACKET_RE.test(text);
+}
+
+async function ensureSharedMathRenderer(): Promise<ReturnType<typeof createMarkdownRenderer>> {
+  if (sharedMathMd) return sharedMathMd;
+  if (!sharedMathMdPromise) {
+    sharedMathMdPromise = import('@ui/shared/markdown-math').then((mod) => {
+      const renderer = mod.createKatexMarkdownRenderer({ openLinksInNewTab: true });
+      sharedMathMd = renderer;
+      return renderer;
+    });
+  }
+  return sharedMathMdPromise;
+}
 
 export function ChatMessageBubble({
   role,
@@ -87,8 +111,30 @@ export function ChatMessageBubble({
 }: ChatMessageBubbleProps) {
   const bubbleRole = normalizeRole(role);
   const markdownRef = useRef<HTMLDivElement | null>(null);
+  const [mathRenderer, setMathRenderer] = useState<ReturnType<typeof createMarkdownRenderer> | null>(
+    () => sharedMathMd,
+  );
 
   const [assetSrcById, setAssetSrcById] = useState<Map<number, string>>(() => new Map());
+  const containsMath = useMemo(() => markdownLikelyContainsMath(markdown), [markdown]);
+
+  useEffect(() => {
+    if (!containsMath || sharedMathMd) return;
+    let disposed = false;
+    void ensureSharedMathRenderer()
+      .then(() => {
+        if (disposed) return;
+        setMathRenderer(sharedMathMd);
+      })
+      .catch((error) => {
+        console.warn('[Markdown] failed to load math renderer', {
+          error: error instanceof Error ? error.message : String(error || ''),
+        });
+      });
+    return () => {
+      disposed = true;
+    };
+  }, [containsMath]);
 
   useEffect(() => {
     const ids = collectOrderedSyncnosAssetIds(String(markdown || ''));
@@ -136,8 +182,10 @@ export function ChatMessageBubble({
   }, [markdown, conversationId]);
 
   const html = useMemo(() => {
-    return sharedMd.render(String(markdown || ''), { syncnosAssetSrcById: assetSrcById } as any);
-  }, [markdown, assetSrcById]);
+    const activeMathRenderer = mathRenderer || sharedMathMd;
+    const renderer = containsMath && activeMathRenderer ? activeMathRenderer : sharedMd;
+    return renderer.render(String(markdown || ''), { syncnosAssetSrcById: assetSrcById } as any);
+  }, [markdown, assetSrcById, containsMath, mathRenderer]);
   const innerHtml = useMemo(() => ({ __html: html }), [html]);
 
   // NOTE: asset URLs are resolved before render via markdown-it env;

--- a/webclipper/src/ui/shared/markdown-core.ts
+++ b/webclipper/src/ui/shared/markdown-core.ts
@@ -1,0 +1,138 @@
+import MarkdownIt from 'markdown-it';
+import linkAttributes from 'markdown-it-link-attributes';
+
+export type MarkdownRendererOptions = {
+  /**
+   * If true, rendered links will open in a new tab.
+   * Defaults to true to keep popup/app behavior consistent.
+   */
+  openLinksInNewTab?: boolean;
+  /**
+   * If true, render `$...$` and `$$...$$` using KaTeX.
+   * Defaults to true.
+   */
+  renderMath?: boolean;
+};
+
+export type MarkdownMathRuntime = {
+  texmathPlugin: unknown;
+  katexEngine: {
+    renderToString: (expression: string, options?: Record<string, unknown>) => string;
+  };
+};
+
+export function createMarkdownRenderer(options: MarkdownRendererOptions = {}, mathRuntime?: MarkdownMathRuntime) {
+  const openLinksInNewTab = options.openLinksInNewTab ?? true;
+  const renderMath = options.renderMath ?? true;
+  const inst = new MarkdownIt({
+    html: false,
+    breaks: true,
+    linkify: true,
+    typographer: false,
+  });
+
+  function isHttpUrl(url: unknown): boolean {
+    const text = String(url || '').trim();
+    return /^https?:\/\//i.test(text);
+  }
+
+  function isDataImageUrl(url: unknown): boolean {
+    const text = String(url || '').trim();
+    if (!text) return false;
+    return /^data:image\/[a-z0-9.+-]+(?:;charset=[a-z0-9._-]+)?(?:;base64)?,/i.test(text);
+  }
+
+  function parseSyncnosAssetId(url: unknown): number | null {
+    const text = String(url || '').trim();
+    const matched = /^syncnos-asset:\/\/(\d+)$/i.exec(text);
+    if (!matched) return null;
+    const id = Number(matched[1]);
+    if (!Number.isFinite(id) || id <= 0) return null;
+    return id;
+  }
+
+  function sanitizeUrlForDisplay(url: unknown): string {
+    const text = String(url || '').trim();
+    if (!text) return '';
+    try {
+      const u = new URL(text);
+      const keys: string[] = [];
+      for (const [k] of u.searchParams.entries()) keys.push(k);
+      const uniqueKeys = Array.from(new Set(keys));
+      const q = uniqueKeys.length ? `?keys=${uniqueKeys.slice(0, 12).join(',')}` : '';
+      return `${u.origin}${u.pathname}${q}`;
+    } catch (_e) {
+      return text.length > 160 ? `${text.slice(0, 157)}...` : text;
+    }
+  }
+
+  try {
+    inst.enable(['table']);
+  } catch (_e) {
+    // ignore
+  }
+
+  if (renderMath) {
+    if (mathRuntime) {
+      inst.use(mathRuntime.texmathPlugin as any, {
+        engine: mathRuntime.katexEngine as any,
+        delimiters: 'dollars',
+        katexOptions: {
+          throwOnError: false,
+          strict: 'ignore',
+        },
+      });
+    }
+  }
+
+  const defaultImageRender =
+    inst.renderer.rules.image ||
+    ((tokens, idx, opts, env, self) => {
+      return self.renderToken(tokens, idx, opts);
+    });
+
+  inst.renderer.rules.image = (tokens, idx, opts, env, self) => {
+    const token = tokens[idx];
+    const src = token && typeof token.attrGet === 'function' ? String(token.attrGet('src') || '') : '';
+    const alt = token && typeof token.content === 'string' ? token.content : '';
+
+    const safeSrc = String(src || '').trim();
+    if (!safeSrc) return defaultImageRender(tokens, idx, opts, env, self);
+
+    const escapedAlt = inst.utils.escapeHtml(String(alt || ''));
+    const titleRaw = token && typeof token.attrGet === 'function' ? String(token.attrGet('title') || '') : '';
+    const titleAttr = titleRaw ? ` title="${inst.utils.escapeHtml(titleRaw)}"` : '';
+    const assetId = parseSyncnosAssetId(safeSrc);
+    if (assetId) {
+      const envMap = env && typeof env === 'object' ? (env as any).syncnosAssetSrcById : null;
+      const resolved = envMap && (typeof envMap.get === 'function' ? envMap.get(assetId) : (envMap as any)[assetId]);
+      const safeResolved = typeof resolved === 'string' ? resolved.trim() : '';
+      // Use a tiny valid image as fallback to avoid noisy console errors.
+      const placeholderSrc = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+      const finalSrc = safeResolved || placeholderSrc;
+      const escapedFinal = inst.utils.escapeHtml(finalSrc);
+      return `<img src="${escapedFinal}" alt="${escapedAlt}" data-syncnos-asset-id="${assetId}"${titleAttr}>`;
+    }
+
+    const escapedSrc = inst.utils.escapeHtml(safeSrc);
+
+    const img = `<img src="${escapedSrc}" alt="${escapedAlt}"${titleAttr}>`;
+
+    if (!isHttpUrl(safeSrc) || isDataImageUrl(safeSrc)) return img;
+
+    const linkText = inst.utils.escapeHtml(sanitizeUrlForDisplay(safeSrc));
+    const a = `<a href="${escapedSrc}" target="_blank" rel="noreferrer noopener">${linkText || 'Image link'}</a>`;
+    return `<span class="syncnos-md-image">${img}<br><span class="syncnos-md-image-link">${a}</span></span>`;
+  };
+
+  if (openLinksInNewTab) {
+    inst.use(linkAttributes as any, {
+      attrs: {
+        target: '_blank',
+        rel: 'noreferrer noopener',
+      },
+    });
+  }
+
+  return inst;
+}

--- a/webclipper/src/ui/shared/markdown-math.ts
+++ b/webclipper/src/ui/shared/markdown-math.ts
@@ -1,0 +1,15 @@
+import { renderToString as renderKatexToString } from 'katex';
+import texmath from 'markdown-it-texmath';
+import { createMarkdownRenderer, type MarkdownMathRuntime, type MarkdownRendererOptions } from '@ui/shared/markdown-core';
+import 'katex/dist/katex.min.css';
+
+const katexMathRuntime: MarkdownMathRuntime = {
+  texmathPlugin: texmath as any,
+  katexEngine: {
+    renderToString: renderKatexToString,
+  },
+};
+
+export function createKatexMarkdownRenderer(options: MarkdownRendererOptions = {}) {
+  return createMarkdownRenderer({ ...options, renderMath: true }, katexMathRuntime);
+}

--- a/webclipper/src/ui/shared/markdown.ts
+++ b/webclipper/src/ui/shared/markdown.ts
@@ -1,131 +1,22 @@
-import MarkdownIt from 'markdown-it';
-import katex from 'katex';
+import { renderToString as renderKatexToString } from 'katex';
 import texmath from 'markdown-it-texmath';
-import linkAttributes from 'markdown-it-link-attributes';
+import {
+  createMarkdownRenderer as createMarkdownRendererCore,
+  type MarkdownMathRuntime,
+  type MarkdownRendererOptions,
+} from '@ui/shared/markdown-core';
 
-export type MarkdownRendererOptions = {
-  /**
-   * If true, rendered links will open in a new tab.
-   * Defaults to true to keep popup/app behavior consistent.
-   */
-  openLinksInNewTab?: boolean;
-  /**
-   * If true, render `$...$` and `$$...$$` using KaTeX.
-   * Defaults to true.
-   */
-  renderMath?: boolean;
+export type { MarkdownMathRuntime, MarkdownRendererOptions } from '@ui/shared/markdown-core';
+
+const defaultMathRuntime: MarkdownMathRuntime = {
+  texmathPlugin: texmath as any,
+  katexEngine: {
+    renderToString: renderKatexToString,
+  },
 };
 
 export function createMarkdownRenderer(options: MarkdownRendererOptions = {}) {
-  const openLinksInNewTab = options.openLinksInNewTab ?? true;
   const renderMath = options.renderMath ?? true;
-  const inst = new MarkdownIt({
-    html: false,
-    breaks: true,
-    linkify: true,
-    typographer: false,
-  });
-
-  function isHttpUrl(url: unknown): boolean {
-    const text = String(url || '').trim();
-    return /^https?:\/\//i.test(text);
-  }
-
-  function isDataImageUrl(url: unknown): boolean {
-    const text = String(url || '').trim();
-    if (!text) return false;
-    return /^data:image\/[a-z0-9.+-]+(?:;charset=[a-z0-9._-]+)?(?:;base64)?,/i.test(text);
-  }
-
-  function parseSyncnosAssetId(url: unknown): number | null {
-    const text = String(url || '').trim();
-    const matched = /^syncnos-asset:\/\/(\d+)$/i.exec(text);
-    if (!matched) return null;
-    const id = Number(matched[1]);
-    if (!Number.isFinite(id) || id <= 0) return null;
-    return id;
-  }
-
-  function sanitizeUrlForDisplay(url: unknown): string {
-    const text = String(url || '').trim();
-    if (!text) return '';
-    try {
-      const u = new URL(text);
-      const keys: string[] = [];
-      for (const [k] of u.searchParams.entries()) keys.push(k);
-      const uniqueKeys = Array.from(new Set(keys));
-      const q = uniqueKeys.length ? `?keys=${uniqueKeys.slice(0, 12).join(',')}` : '';
-      return `${u.origin}${u.pathname}${q}`;
-    } catch (_e) {
-      return text.length > 160 ? `${text.slice(0, 157)}...` : text;
-    }
-  }
-
-  try {
-    inst.enable(['table']);
-  } catch (_e) {
-    // ignore
-  }
-
-  if (renderMath) {
-    inst.use(texmath as any, {
-      engine: katex as any,
-      delimiters: 'dollars',
-      katexOptions: {
-        throwOnError: false,
-        strict: 'ignore',
-      },
-    });
-  }
-
-  const defaultImageRender =
-    inst.renderer.rules.image ||
-    ((tokens, idx, opts, env, self) => {
-      return self.renderToken(tokens, idx, opts);
-    });
-
-  inst.renderer.rules.image = (tokens, idx, opts, env, self) => {
-    const token = tokens[idx];
-    const src = token && typeof token.attrGet === 'function' ? String(token.attrGet('src') || '') : '';
-    const alt = token && typeof token.content === 'string' ? token.content : '';
-
-    const safeSrc = String(src || '').trim();
-    if (!safeSrc) return defaultImageRender(tokens, idx, opts, env, self);
-
-    const escapedAlt = inst.utils.escapeHtml(String(alt || ''));
-    const titleRaw = token && typeof token.attrGet === 'function' ? String(token.attrGet('title') || '') : '';
-    const titleAttr = titleRaw ? ` title="${inst.utils.escapeHtml(titleRaw)}"` : '';
-    const assetId = parseSyncnosAssetId(safeSrc);
-    if (assetId) {
-      const envMap = env && typeof env === 'object' ? (env as any).syncnosAssetSrcById : null;
-      const resolved = envMap && (typeof envMap.get === 'function' ? envMap.get(assetId) : (envMap as any)[assetId]);
-      const safeResolved = typeof resolved === 'string' ? resolved.trim() : '';
-      // Use a tiny valid image as fallback to avoid noisy console errors.
-      const placeholderSrc = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
-      const finalSrc = safeResolved || placeholderSrc;
-      const escapedFinal = inst.utils.escapeHtml(finalSrc);
-      return `<img src="${escapedFinal}" alt="${escapedAlt}" data-syncnos-asset-id="${assetId}"${titleAttr}>`;
-    }
-
-    const escapedSrc = inst.utils.escapeHtml(safeSrc);
-
-    const img = `<img src="${escapedSrc}" alt="${escapedAlt}"${titleAttr}>`;
-
-    if (!isHttpUrl(safeSrc) || isDataImageUrl(safeSrc)) return img;
-
-    const linkText = inst.utils.escapeHtml(sanitizeUrlForDisplay(safeSrc));
-    const a = `<a href="${escapedSrc}" target="_blank" rel="noreferrer noopener">${linkText || 'Image link'}</a>`;
-    return `<span class="syncnos-md-image">${img}<br><span class="syncnos-md-image-link">${a}</span></span>`;
-  };
-
-  if (openLinksInNewTab) {
-    inst.use(linkAttributes as any, {
-      attrs: {
-        target: '_blank',
-        rel: 'noreferrer noopener',
-      },
-    });
-  }
-
-  return inst;
+  if (!renderMath) return createMarkdownRendererCore({ ...options, renderMath: false });
+  return createMarkdownRendererCore({ ...options, renderMath: true }, defaultMathRuntime);
 }


### PR DESCRIPTION
Refactor the markdown renderer to improve code structure and isolate the math rendering functionality. This change enhances maintainability and optimizes the rendering process for mathematical expressions.