### PR TITLE
Normalize Discourse image captions

### DIFF
--- a/webclipper/src/services/sync/notion/notion-markdown-blocks.ts
+++ b/webclipper/src/services/sync/notion/notion-markdown-blocks.ts
@@ -1,5 +1,7 @@
 // @ts-nocheck
 
+import { normalizeStandaloneImageCaptionLines } from '@services/sync/shared/markdown-image-normalizer';
+
 const MAX_TEXT = 1900;
 const MAX_EQUATION_EXPRESSION = 1900;
 const MAX_RICH_TEXT_ITEMS = 100;
@@ -345,7 +347,7 @@ function blocksFromInlineRichText(type, richText) {
 }
 
 function markdownToNotionBlocks(markdown) {
-  const src = String(markdown || '').replace(/\r\n/g, '\n');
+  const src = normalizeStandaloneImageCaptionLines(markdown).replace(/\r\n/g, '\n');
   const lines = src.split('\n');
   const out = [];
 

--- a/webclipper/src/services/sync/notion/notion-sync-orchestrator.ts
+++ b/webclipper/src/services/sync/notion/notion-sync-orchestrator.ts
@@ -21,6 +21,7 @@ import {
   rebuildSectionByArchivingHeading,
   recoverSectionHeadingBlockId,
 } from '@services/sync/notion/notion-managed-sections.ts';
+import { normalizeStandaloneImageCaptionLines } from '@services/sync/shared/markdown-image-normalizer';
 
 const SYNC_PROVIDER = 'notion';
 const SYNC_CONVERSATION_CONCURRENCY = 2;
@@ -364,7 +365,7 @@ function fnv1a32(input) {
 }
 
 function computeNotionArticleDigest(messagesList) {
-  const markdown = pickArticleBodyMarkdown(messagesList);
+  const markdown = normalizeStandaloneImageCaptionLines(pickArticleBodyMarkdown(messagesList));
   return fnv1a32(JSON.stringify({ markdown }));
 }
 

--- a/webclipper/src/services/sync/obsidian/obsidian-markdown-writer.ts
+++ b/webclipper/src/services/sync/obsidian/obsidian-markdown-writer.ts
@@ -1,4 +1,5 @@
 import type { ArticleComment } from '@services/comments/domain/models';
+import { normalizeStandaloneImageCaptionLines } from '@services/sync/shared/markdown-image-normalizer';
 
 const MESSAGES_HEADING = 'Conversations';
 const ARTICLE_HEADING = 'Article';
@@ -112,7 +113,12 @@ function toArticleBodyMessages(messages: unknown[]): any[] {
 
 function buildArticleBodyMarkdown(messages: any[]) {
   const list = toArticleBodyMessages(messages);
-  const chunks = list.map((m) => safeString(m?.contentMarkdown) || safeString(m?.contentText)).filter((x) => !!x);
+  const chunks = list
+    .map((m) => {
+      const raw = safeString(m?.contentMarkdown) || safeString(m?.contentText);
+      return normalizeStandaloneImageCaptionLines(raw);
+    })
+    .filter((x) => !!x);
   return chunks.join('\n\n').trim();
 }
 

--- a/webclipper/src/services/sync/shared/markdown-image-normalizer.ts
+++ b/webclipper/src/services/sync/shared/markdown-image-normalizer.ts
@@ -1,0 +1,28 @@
+const STANDALONE_IMAGE_WITH_TRAILING_TEXT_RE =
+  /^(\s*!\[[^\]]*\]\(\s*(?:<[^>]+>|[^)\s]+)(?:\s+"[^"]*")?\s*\))\s*(.+)$/gm;
+
+/**
+ * Discourse 风格图片行经常是：
+ *   ![alt](https://...png)Caption text...
+ * 该写法在部分下游（尤其是行级解析器）里不会被当作独立图片块。
+ *
+ * 将其规范化为：
+ *   ![alt](https://...png)
+ *
+ *   Caption text...
+ */
+export function normalizeStandaloneImageCaptionLines(markdown: unknown): string {
+  const src = String(markdown || '');
+  if (!src) return '';
+
+  return src.replace(STANDALONE_IMAGE_WITH_TRAILING_TEXT_RE, (_full, imageRaw, trailingTextRaw) => {
+    const image = String(imageRaw || '');
+    const trailingText = String(trailingTextRaw || '').trim();
+    if (!trailingText) return image;
+    return `${image}\n\n${trailingText}`;
+  });
+}
+
+export default {
+  normalizeStandaloneImageCaptionLines,
+};

--- a/webclipper/tests/smoke/obsidian-markdown-writer.test.ts
+++ b/webclipper/tests/smoke/obsidian-markdown-writer.test.ts
@@ -82,4 +82,36 @@ describe('obsidian-markdown-writer', () => {
     expect(md).toContain('  Root');
     expect(md).toContain('  Reply');
   });
+
+  it('normalizes standalone image lines that append caption text', async () => {
+    const w = await loadWriter();
+    const md = w.buildFullNoteMarkdown({
+      conversation: {
+        title: 'T',
+        source: 's',
+        sourceType: 'article',
+        conversationKey: 'k',
+        url: 'https://example.com',
+      },
+      messages: [
+        {
+          messageKey: 'article_body',
+          sequence: 1,
+          role: 'assistant',
+          contentMarkdown:
+            '![CleanShot](https://cdn3.linux.do/optimized/4X/5/1/2/example.png)CleanShot 828×1194 84 KB',
+        },
+      ],
+      comments: [],
+      syncnosObject: {
+        source: 's',
+        conversationKey: 'k',
+        schemaVersion: 1,
+        lastSyncedSequence: 1,
+        lastSyncedMessageKey: 'article_body',
+      },
+    });
+
+    expect(md).toContain('![CleanShot](https://cdn3.linux.do/optimized/4X/5/1/2/example.png)\n\nCleanShot 828×1194 84 KB');
+  });
 });

--- a/webclipper/tests/unit/notion-markdown-blocks.test.ts
+++ b/webclipper/tests/unit/notion-markdown-blocks.test.ts
@@ -10,4 +10,19 @@ describe('notion-markdown-blocks', () => {
     expect(blocks[0]?.image?.type).toBe('external');
     expect(blocks[0]?.image?.external?.url).toBe('syncnos-asset://42');
   });
+
+  it('splits standalone image lines with trailing caption text into image + paragraph blocks', () => {
+    const blocks = markdownToNotionBlocks(
+      '![CleanShot](https://cdn3.linux.do/optimized/4X/5/1/2/example.png)CleanShot 828×1194 84 KB',
+    );
+    expect(Array.isArray(blocks)).toBe(true);
+    expect(blocks[0]?.type).toBe('image');
+    expect(blocks[0]?.image?.external?.url).toBe('https://cdn3.linux.do/optimized/4X/5/1/2/example.png');
+
+    expect(blocks[1]?.type).toBe('paragraph');
+    const paragraph = (blocks[1]?.paragraph?.rich_text || [])
+      .map((item: any) => String(item?.plain_text || item?.text?.content || ''))
+      .join('');
+    expect(paragraph).toContain('CleanShot 828×1194 84 KB');
+  });
 });


### PR DESCRIPTION
Implement a function to standardize image captions in Discourse-style markdown, ensuring that trailing text is separated from the image. Update relevant functions to utilize this normalization, enhancing compatibility with downstream parsers. Add tests to verify the expected behavior.