### PR TITLE
修复：评论侧栏引用区 ❌ 按钮样式对齐 Settings 关闭按钮

### DIFF
--- a/webclipper/src/platform/webext/tabs.ts
+++ b/webclipper/src/platform/webext/tabs.ts
@@ -18,7 +18,7 @@ function debugTabsCreate(createProperties: any) {
     const url = String(createProperties?.url || '').trim();
     if (!shouldLogTabsCreate(url)) return;
     const stack = new Error('tabs.create stack').stack || '';
-    // eslint-disable-next-line no-console
+     
     console.log('[SyncNos][tabs.create]', {
       at: new Date().toISOString(),
       url,

--- a/webclipper/src/services/bootstrap/inpage-comments-panel-content-handlers.ts
+++ b/webclipper/src/services/bootstrap/inpage-comments-panel-content-handlers.ts
@@ -11,9 +11,23 @@ type RuntimeClient = {
   send?: (type: string, payload?: Record<string, unknown>) => Promise<any>;
 };
 
+function isSelectionWithinLocatorRoot(selection: Selection | null, locatorRoot: Element | null): boolean {
+  if (!selection || !locatorRoot) return false;
+  const anchorNode = selection.anchorNode;
+  const focusNode = selection.focusNode;
+  if (!anchorNode || !focusNode) return false;
+  try {
+    return locatorRoot.contains(anchorNode) && locatorRoot.contains(focusNode);
+  } catch (_e) {
+    return false;
+  }
+}
+
 function pickQuoteFromSelection(): string {
   try {
     const selection = globalThis.getSelection?.();
+    const locatorRoot = document.body || document.documentElement;
+    if (!isSelectionWithinLocatorRoot(selection || null, locatorRoot)) return '';
     const text = selection ? String(selection.toString() || '') : '';
     return text.trim();
   } catch (_e) {
@@ -25,12 +39,14 @@ function pickLocatorFromSelection(): any | null {
   try {
     const selection = globalThis.getSelection?.();
     if (!selection || selection.rangeCount <= 0) return null;
+    const locatorRoot = document.body || document.documentElement;
+    if (!isSelectionWithinLocatorRoot(selection, locatorRoot)) return null;
     const range = selection.getRangeAt(0);
     const text = String(selection.toString() || '').trim();
     if (!text) return null;
     return buildArticleCommentLocatorFromRange({
       env: 'inpage',
-      root: document.body || document.documentElement,
+      root: locatorRoot,
       range,
     });
   } catch (_e) {

--- a/webclipper/src/services/comments/sidebar/article-comments-sidebar-controller.ts
+++ b/webclipper/src/services/comments/sidebar/article-comments-sidebar-controller.ts
@@ -87,8 +87,9 @@ export function createArticleCommentsSidebarController(input: {
 
   const applyComposerSelection = (payload?: ArticleCommentsSidebarControllerComposerSelectionPayload | null) => {
     const quoteText = normalizeCommentSidebarQuoteText(payload?.selectionText);
+    if (!quoteText) return;
     session.setQuoteText(quoteText);
-    pendingRootLocator = quoteText ? normalizeLocator(payload?.locator) : null;
+    pendingRootLocator = normalizeLocator(payload?.locator);
   };
 
   const ensureContext = async (
@@ -196,7 +197,7 @@ export function createArticleCommentsSidebarController(input: {
           payload: ArticleCommentsSidebarControllerComposerSelectionPayload | null | undefined,
         ) => {
           if (requestSeq !== composerSelectionRequestSeq) return;
-          applyComposerSelection(payload ?? { selectionText: '', locator: null });
+          applyComposerSelection(payload);
         };
         try {
           const resolved = resolveComposerSelection(request);
@@ -206,14 +207,19 @@ export function createArticleCommentsSidebarController(input: {
                 applyIfLatest(payload as ArticleCommentsSidebarControllerComposerSelectionPayload | null | undefined);
               })
               .catch(() => {
-                applyIfLatest({ selectionText: '', locator: null });
+                applyIfLatest(null);
               });
             return;
           }
           applyIfLatest(resolved as ArticleCommentsSidebarControllerComposerSelectionPayload | null | undefined);
         } catch (_error) {
-          applyIfLatest({ selectionText: '', locator: null });
+          applyIfLatest(null);
         }
+      },
+      onComposerQuoteClearRequest: () => {
+        composerSelectionRequestSeq += 1;
+        session.setQuoteText('');
+        pendingRootLocator = null;
       },
     };
 

--- a/webclipper/src/services/comments/sidebar/comment-sidebar-contract.ts
+++ b/webclipper/src/services/comments/sidebar/comment-sidebar-contract.ts
@@ -27,6 +27,7 @@ export type CommentSidebarHandlers = {
   onDelete?: (id: number) => void | Promise<void>;
   onClose?: () => void;
   onComposerSelectionRequest?: (input: CommentSidebarComposerSelectionRequest) => void | Promise<void>;
+  onComposerQuoteClearRequest?: () => void | Promise<void>;
 };
 
 export type CommentSidebarPanelApi = {

--- a/webclipper/src/services/comments/sidebar/comment-sidebar-session.ts
+++ b/webclipper/src/services/comments/sidebar/comment-sidebar-session.ts
@@ -24,12 +24,6 @@ function hasAnyHandlers(handlers: CommentSidebarHandlers): boolean {
   return !!handlers && Object.keys(handlers).length > 0;
 }
 
-function isOkResult(result: unknown): boolean {
-  if (result === true) return true;
-  if (!result || typeof result !== 'object') return false;
-  return (result as any).ok === true;
-}
-
 export function createCommentSidebarSession(initialPanel?: CommentSidebarPanelApi | null): CommentSidebarSession {
   let panel: CommentSidebarPanelApi | null = initialPanel ?? null;
   let busy = false;
@@ -186,16 +180,14 @@ export function createCommentSidebarSession(initialPanel?: CommentSidebarPanelAp
   function setHandlers(nextHandlers: CommentSidebarHandlers) {
     const base = nextHandlers || {};
     const wrapped: CommentSidebarHandlers = { ...base };
-    if (typeof base.onSave === 'function') {
-      wrapped.onSave = async (text) => {
-        const res = await base.onSave?.(text);
-        if (isOkResult(res)) setQuoteText('');
-        return res as any;
-      };
-    }
     if (typeof base.onComposerSelectionRequest === 'function') {
       wrapped.onComposerSelectionRequest = async (input) => {
         await base.onComposerSelectionRequest?.(input);
+      };
+    }
+    if (typeof base.onComposerQuoteClearRequest === 'function') {
+      wrapped.onComposerQuoteClearRequest = async () => {
+        await base.onComposerQuoteClearRequest?.();
       };
     }
     handlers = wrapped;

--- a/webclipper/src/ui/app/AppShell.tsx
+++ b/webclipper/src/ui/app/AppShell.tsx
@@ -517,14 +517,16 @@ export default function AppShell() {
         return () => window.clearTimeout(timer);
       }
 
-      const lastActive = settingsLastActiveElementRef.current;
-      settingsLastActiveElementRef.current = null;
-      if (!lastActive) return;
-      if (!document.contains(lastActive)) return;
-      try {
-        lastActive.focus({ preventScroll: true });
-      } catch {}
-    }, [showSettingsSheet]);
+	      const lastActive = settingsLastActiveElementRef.current;
+	      settingsLastActiveElementRef.current = null;
+	      if (!lastActive) return;
+	      if (!document.contains(lastActive)) return;
+	      try {
+	        lastActive.focus({ preventScroll: true });
+	      } catch (e) {
+	        void e;
+	      }
+	    }, [showSettingsSheet]);
 
     useEffect(() => {
       if (!locMountedRef.current) {

--- a/webclipper/src/ui/comments/react/ThreadedCommentsPanel.tsx
+++ b/webclipper/src/ui/comments/react/ThreadedCommentsPanel.tsx
@@ -1,4 +1,5 @@
 import { t } from '@i18n';
+import { buttonIconCircleGhostClassName } from '@ui/shared/button-styles';
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 
@@ -706,31 +707,34 @@ export function ThreadedCommentsPanel({
         >
           {snapshot.noticeMessage}
         </div>
-        <div
-          className="webclipper-inpage-comments-panel__quote"
-          style={{ display: snapshot.quoteText ? 'block' : 'none' }}
-        >
-          <button
-            type="button"
-            className="webclipper-inpage-comments-panel__quote-clear webclipper-btn webclipper-btn--icon"
-            aria-label="Clear quote"
-            onClick={() => {
-              lastAutoSelectionSignatureRef.current = '';
-              pendingAutoSelectionRequestRef.current = false;
-              pendingAutoSelectionSignatureRef.current = 'empty';
+	        <div
+	          className="webclipper-inpage-comments-panel__quote"
+	          style={{ display: snapshot.quoteText ? 'block' : 'none' }}
+	        >
+	          <button
+	            type="button"
+	            className={['webclipper-inpage-comments-panel__quote-clear', buttonIconCircleGhostClassName()].join(' ')}
+	            aria-label="Clear quote"
+	            onClick={() => {
+	              lastAutoSelectionSignatureRef.current = '';
+	              pendingAutoSelectionRequestRef.current = false;
+	              pendingAutoSelectionSignatureRef.current = 'empty';
               autoSelectionDirtyRef.current = false;
               const latestHandlers = readHandlers?.() || snapshot.handlers;
               const handler = latestHandlers.onComposerQuoteClearRequest;
               if (typeof handler !== 'function') return;
-              void Promise.resolve(handler()).catch(() => {
-                // ignore
-              });
-            }}
-          >
-            ×
-          </button>
-          <div className="webclipper-inpage-comments-panel__quote-text">{snapshot.quoteText}</div>
-        </div>
+	              void Promise.resolve(handler()).catch(() => {
+	                // ignore
+	              });
+	            }}
+	          >
+	            <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+	              <path d="M4 4L12 12" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+	              <path d="M12 4L4 12" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+	            </svg>
+	          </button>
+	          <div className="webclipper-inpage-comments-panel__quote-text">{snapshot.quoteText}</div>
+	        </div>
         <div className="webclipper-inpage-comments-panel__reply-composer is-root" data-webclipper-root-composer="1">
           <textarea
             ref={composerTextareaRef}

--- a/webclipper/src/ui/comments/react/ThreadedCommentsPanel.tsx
+++ b/webclipper/src/ui/comments/react/ThreadedCommentsPanel.tsx
@@ -710,6 +710,25 @@ export function ThreadedCommentsPanel({
           className="webclipper-inpage-comments-panel__quote"
           style={{ display: snapshot.quoteText ? 'block' : 'none' }}
         >
+          <button
+            type="button"
+            className="webclipper-inpage-comments-panel__quote-clear webclipper-btn webclipper-btn--icon"
+            aria-label="Clear quote"
+            onClick={() => {
+              lastAutoSelectionSignatureRef.current = '';
+              pendingAutoSelectionRequestRef.current = false;
+              pendingAutoSelectionSignatureRef.current = 'empty';
+              autoSelectionDirtyRef.current = false;
+              const latestHandlers = readHandlers?.() || snapshot.handlers;
+              const handler = latestHandlers.onComposerQuoteClearRequest;
+              if (typeof handler !== 'function') return;
+              void Promise.resolve(handler()).catch(() => {
+                // ignore
+              });
+            }}
+          >
+            ×
+          </button>
           <div className="webclipper-inpage-comments-panel__quote-text">{snapshot.quoteText}</div>
         </div>
         <div className="webclipper-inpage-comments-panel__reply-composer is-root" data-webclipper-root-composer="1">

--- a/webclipper/src/ui/comments/react/ThreadedCommentsPanel.tsx
+++ b/webclipper/src/ui/comments/react/ThreadedCommentsPanel.tsx
@@ -307,7 +307,11 @@ export function ThreadedCommentsPanel({
       pendingAutoSelectionSignatureRef.current = 'empty';
       autoSelectionDirtyRef.current = false;
       if (pendingAutoSelectionCommitRafRef.current != null) {
-        cancelAnimationFrame(pendingAutoSelectionCommitRafRef.current);
+        if (typeof globalThis.cancelAnimationFrame === 'function') {
+          globalThis.cancelAnimationFrame(pendingAutoSelectionCommitRafRef.current);
+        } else {
+          clearTimeout(pendingAutoSelectionCommitRafRef.current);
+        }
         pendingAutoSelectionCommitRafRef.current = null;
       }
       return;
@@ -316,11 +320,22 @@ export function ThreadedCommentsPanel({
 
   useLayoutEffect(() => {
     if (!snapshot.open) return;
+    const scheduleNextFrame = (cb: () => void) => {
+      if (typeof globalThis.requestAnimationFrame === 'function') return globalThis.requestAnimationFrame(cb);
+      return setTimeout(cb, 0) as unknown as number;
+    };
+    const cancelNextFrame = (id: number) => {
+      if (typeof globalThis.cancelAnimationFrame === 'function') {
+        globalThis.cancelAnimationFrame(id);
+        return;
+      }
+      clearTimeout(id);
+    };
     const scheduleCommit = (signature?: string | null) => {
       if (pendingAutoSelectionCommitRafRef.current != null) {
-        cancelAnimationFrame(pendingAutoSelectionCommitRafRef.current);
+        cancelNextFrame(pendingAutoSelectionCommitRafRef.current);
       }
-      pendingAutoSelectionCommitRafRef.current = requestAnimationFrame(() => {
+      pendingAutoSelectionCommitRafRef.current = scheduleNextFrame(() => {
         pendingAutoSelectionCommitRafRef.current = null;
         let nextSignature = String(signature || '');
         if (!nextSignature) {
@@ -360,7 +375,7 @@ export function ThreadedCommentsPanel({
       document.removeEventListener('keyup', onKeyUp, true);
       autoSelectionDirtyRef.current = false;
       if (pendingAutoSelectionCommitRafRef.current != null) {
-        cancelAnimationFrame(pendingAutoSelectionCommitRafRef.current);
+        cancelNextFrame(pendingAutoSelectionCommitRafRef.current);
         pendingAutoSelectionCommitRafRef.current = null;
       }
     };

--- a/webclipper/src/ui/comments/react/ThreadedCommentsPanel.tsx
+++ b/webclipper/src/ui/comments/react/ThreadedCommentsPanel.tsx
@@ -109,9 +109,10 @@ export function ThreadedCommentsPanel({
   const lastFocusedComposerSignalRef = useRef(0);
   const lastHandledEscapeSignalRef = useRef(0);
   const lastAutoSelectionSignatureRef = useRef('');
-  const suppressEmptyAutoSelectionUntilRef = useRef(0);
   const pendingAutoSelectionRequestRef = useRef(false);
-  const pendingAutoSelectionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingAutoSelectionSignatureRef = useRef('empty');
+  const pendingAutoSelectionCommitRafRef = useRef<number | null>(null);
+  const autoSelectionDirtyRef = useRef(false);
   const replyTextareaRefs = useRef<Record<number, HTMLTextAreaElement | null>>({});
   const replyTextsRef = useRef<Record<number, string>>({});
   const pendingReplyFocusRootIdRef = useRef<number | null>(null);
@@ -220,38 +221,24 @@ export function ThreadedCommentsPanel({
     });
   };
 
-  const isPanelTextInputFocused = () => {
-    const composer = composerTextareaRef.current;
-    let activeElement: Element | null = null;
-    const rootNode = composer?.getRootNode?.();
-    if (rootNode && typeof (rootNode as ShadowRoot).activeElement !== 'undefined') {
-      activeElement = ((rootNode as ShadowRoot).activeElement as Element | null) ?? null;
-    } else {
-      activeElement = (document.activeElement as Element | null) ?? null;
-    }
-    if (!activeElement) return false;
-    try {
-      return Boolean(
-        activeElement.closest(
-          '.webclipper-inpage-comments-panel__composer-textarea,.webclipper-inpage-comments-panel__reply-textarea',
-        ),
-      );
-    } catch (_error) {
-      return false;
-    }
-  };
-
   const requestComposerSelection = useCallback(
     (trigger: 'button' | 'auto', autoSignature?: string | null) => {
       if (trigger === 'auto') {
         const normalizedSignature = String(autoSignature || 'empty');
-        if (normalizedSignature === 'empty') {
-          if (isPanelTextInputFocused()) return;
-          const suppressUntil = Number(suppressEmptyAutoSelectionUntilRef.current || 0);
-          if (Date.now() <= suppressUntil) return;
+        if (normalizedSignature === 'empty') return;
+        const latestHandlers = readHandlers?.() || snapshot.handlers;
+        const handler = latestHandlers.onComposerSelectionRequest;
+        if (typeof handler !== 'function') {
+          pendingAutoSelectionRequestRef.current = true;
+          pendingAutoSelectionSignatureRef.current = normalizedSignature;
+          return;
         }
         if (normalizedSignature === lastAutoSelectionSignatureRef.current) return;
         lastAutoSelectionSignatureRef.current = normalizedSignature;
+        void Promise.resolve(handler({ trigger })).catch(() => {
+          // ignore
+        });
+        return;
       }
       const latestHandlers = readHandlers?.() || snapshot.handlers;
       const handler = latestHandlers.onComposerSelectionRequest;
@@ -262,10 +249,6 @@ export function ThreadedCommentsPanel({
     },
     [readHandlers, snapshot.handlers],
   );
-
-  const suppressNextEmptyAutoSelection = () => {
-    suppressEmptyAutoSelectionUntilRef.current = Date.now() + 320;
-  };
 
   const updateArmedDeleteId = useCallback(
     (next: number | null) => {
@@ -321,46 +304,67 @@ export function ThreadedCommentsPanel({
     if (!snapshot.open) {
       lastAutoSelectionSignatureRef.current = '';
       pendingAutoSelectionRequestRef.current = false;
-      if (pendingAutoSelectionTimerRef.current) {
-        clearTimeout(pendingAutoSelectionTimerRef.current);
-        pendingAutoSelectionTimerRef.current = null;
+      pendingAutoSelectionSignatureRef.current = 'empty';
+      autoSelectionDirtyRef.current = false;
+      if (pendingAutoSelectionCommitRafRef.current != null) {
+        cancelAnimationFrame(pendingAutoSelectionCommitRafRef.current);
+        pendingAutoSelectionCommitRafRef.current = null;
       }
       return;
     }
+  }, [snapshot.open]);
+
+  useLayoutEffect(() => {
+    if (!snapshot.open) return;
+    const scheduleCommit = (signature?: string | null) => {
+      if (pendingAutoSelectionCommitRafRef.current != null) {
+        cancelAnimationFrame(pendingAutoSelectionCommitRafRef.current);
+      }
+      pendingAutoSelectionCommitRafRef.current = requestAnimationFrame(() => {
+        pendingAutoSelectionCommitRafRef.current = null;
+        let nextSignature = String(signature || '');
+        if (!nextSignature) {
+          try {
+            nextSignature = buildSelectionSignature(globalThis.getSelection?.());
+          } catch (_error) {
+            nextSignature = 'empty';
+          }
+        }
+        requestComposerSelection('auto', nextSignature);
+      });
+    };
 
     const onSelectionChange = () => {
-      if (pendingAutoSelectionTimerRef.current) {
-        clearTimeout(pendingAutoSelectionTimerRef.current);
-        pendingAutoSelectionTimerRef.current = null;
-      }
-      pendingAutoSelectionTimerRef.current = setTimeout(() => {
-        pendingAutoSelectionTimerRef.current = null;
-        const latestHandlers = readHandlers?.() || snapshot.handlers;
-        if (typeof latestHandlers.onComposerSelectionRequest !== 'function') {
-          pendingAutoSelectionRequestRef.current = true;
-          return;
-        }
-        pendingAutoSelectionRequestRef.current = false;
-        let signature = 'empty';
-        try {
-          signature = buildSelectionSignature(globalThis.getSelection?.());
-        } catch (_error) {
-          signature = 'empty';
-        }
-        requestComposerSelection('auto', signature);
-      }, 300);
+      autoSelectionDirtyRef.current = true;
     };
 
-    document.addEventListener('selectionchange', onSelectionChange);
+    const onPointerUp = () => {
+      if (!autoSelectionDirtyRef.current) return;
+      autoSelectionDirtyRef.current = false;
+      scheduleCommit(null);
+    };
+
+    const onKeyUp = (event: KeyboardEvent) => {
+      if (event.shiftKey || event.ctrlKey || event.metaKey || event.altKey) return;
+      if (!autoSelectionDirtyRef.current) return;
+      autoSelectionDirtyRef.current = false;
+      scheduleCommit(null);
+    };
+
+    document.addEventListener('selectionchange', onSelectionChange, true);
+    document.addEventListener('pointerup', onPointerUp, true);
+    document.addEventListener('keyup', onKeyUp, true);
     return () => {
-      document.removeEventListener('selectionchange', onSelectionChange);
-      pendingAutoSelectionRequestRef.current = false;
-      if (pendingAutoSelectionTimerRef.current) {
-        clearTimeout(pendingAutoSelectionTimerRef.current);
-        pendingAutoSelectionTimerRef.current = null;
+      document.removeEventListener('selectionchange', onSelectionChange, true);
+      document.removeEventListener('pointerup', onPointerUp, true);
+      document.removeEventListener('keyup', onKeyUp, true);
+      autoSelectionDirtyRef.current = false;
+      if (pendingAutoSelectionCommitRafRef.current != null) {
+        cancelAnimationFrame(pendingAutoSelectionCommitRafRef.current);
+        pendingAutoSelectionCommitRafRef.current = null;
       }
     };
-  }, [readHandlers, requestComposerSelection, snapshot.handlers, snapshot.open]);
+  }, [requestComposerSelection, snapshot.open]);
 
   useLayoutEffect(() => {
     if (!snapshot.open) return;
@@ -368,12 +372,8 @@ export function ThreadedCommentsPanel({
     const latestHandlers = readHandlers?.() || snapshot.handlers;
     if (typeof latestHandlers.onComposerSelectionRequest !== 'function') return;
     pendingAutoSelectionRequestRef.current = false;
-    let signature = 'empty';
-    try {
-      signature = buildSelectionSignature(globalThis.getSelection?.());
-    } catch (_error) {
-      signature = 'empty';
-    }
+    const signature = pendingAutoSelectionSignatureRef.current;
+    pendingAutoSelectionSignatureRef.current = 'empty';
     requestComposerSelection('auto', signature);
   }, [readHandlers, requestComposerSelection, snapshot.handlers, snapshot.open]);
 
@@ -704,12 +704,6 @@ export function ThreadedCommentsPanel({
             placeholder="Write a comment…"
             rows={1}
             value={composerText}
-            onPointerDown={() => {
-              suppressNextEmptyAutoSelection();
-            }}
-            onFocus={() => {
-              suppressNextEmptyAutoSelection();
-            }}
             onInput={(event) => updateComposerText(event.currentTarget.value)}
             onChange={(event) => updateComposerText(event.currentTarget.value)}
             onKeyDown={(event) => {
@@ -908,12 +902,6 @@ export function ThreadedCommentsPanel({
                       placeholder="Reply…"
                       rows={1}
                       value={replyTexts[rootId] || ''}
-                      onPointerDown={() => {
-                        suppressNextEmptyAutoSelection();
-                      }}
-                      onFocus={() => {
-                        suppressNextEmptyAutoSelection();
-                      }}
                       onInput={(event) => {
                         updateReplyText(rootId, event.currentTarget.value);
                         autosizeTextarea(event.currentTarget);

--- a/webclipper/src/ui/comments/react/types.ts
+++ b/webclipper/src/ui/comments/react/types.ts
@@ -10,6 +10,7 @@ export type ThreadedCommentsPanelHandlers = {
   onDelete?: (id: number) => void | Promise<void>;
   onClose?: () => void;
   onComposerSelectionRequest?: (input: ThreadedCommentsPanelComposerSelectionRequest) => void | Promise<void>;
+  onComposerQuoteClearRequest?: () => void | Promise<void>;
 };
 
 export type ThreadedCommentsPanelSnapshot = {

--- a/webclipper/src/ui/comments/types.ts
+++ b/webclipper/src/ui/comments/types.ts
@@ -27,6 +27,7 @@ export type ThreadedCommentsPanelApi = {
     onDelete?: (id: number) => void | Promise<void>;
     onClose?: () => void;
     onComposerSelectionRequest?: (input: ThreadedCommentsPanelComposerSelectionRequest) => void | Promise<void>;
+    onComposerQuoteClearRequest?: () => void | Promise<void>;
   }) => void;
 };
 

--- a/webclipper/src/ui/styles/inpage-comments-panel.css
+++ b/webclipper/src/ui/styles/inpage-comments-panel.css
@@ -232,19 +232,9 @@
 
 .webclipper-inpage-comments-panel__quote-clear {
   position: absolute;
-  top: 6px;
-  right: 6px;
-  width: 26px;
-  height: 26px;
-  padding: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--panel-text-muted);
-}
-
-.webclipper-inpage-comments-panel__quote-clear:is(:hover, :focus-visible) {
-  color: var(--panel-danger);
+  top: 4px;
+  right: 4px;
+  z-index: 2;
 }
 
 .webclipper-inpage-comments-panel__notice {

--- a/webclipper/src/ui/styles/inpage-comments-panel.css
+++ b/webclipper/src/ui/styles/inpage-comments-panel.css
@@ -223,9 +223,28 @@
 .webclipper-inpage-comments-panel__quote {
   margin: 0 0 10px 0;
   padding: var(--comments-panel-body-padding-y);
+  padding-right: calc(var(--comments-panel-body-padding-y) + 30px);
+  position: relative;
   border-radius: var(--radius-card);
   border: 1px solid var(--quote-border);
   background: var(--quote-bg);
+}
+
+.webclipper-inpage-comments-panel__quote-clear {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--panel-text-muted);
+}
+
+.webclipper-inpage-comments-panel__quote-clear:is(:hover, :focus-visible) {
+  color: var(--panel-danger);
 }
 
 .webclipper-inpage-comments-panel__notice {

--- a/webclipper/tests/smoke/app-shell-comments-sidebar.test.ts
+++ b/webclipper/tests/smoke/app-shell-comments-sidebar.test.ts
@@ -319,7 +319,7 @@ describe('AppShell comments sidebar', () => {
     });
   });
 
-  it('attaches selected text on selectionchange and ignores reply interactions', async () => {
+  it('attaches selected text on pointerup commit and ignores reply interactions', async () => {
     commentsByUrl.set('https://example.com/article', [{ id: 101, parentId: null, commentText: 'Root comment' }]);
 
     act(() => {
@@ -352,12 +352,12 @@ describe('AppShell comments sidebar', () => {
     await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
     document.dispatchEvent(new window.Event('selectionchange'));
+    document.dispatchEvent(new window.Event('pointerup'));
 
-    // Auto-attach is debounced in the panel runtime; wait for it to apply.
-    await new Promise<void>((resolve) => setTimeout(resolve, 350));
-
-    const quoteText = shadow?.querySelector('.webclipper-inpage-comments-panel__quote-text')?.textContent?.trim();
-    expect(quoteText).toBe(selectedText);
+    await vi.waitFor(() => {
+      const quoteText = shadow?.querySelector('.webclipper-inpage-comments-panel__quote-text')?.textContent?.trim();
+      expect(quoteText).toBe(selectedText);
+    });
 
     restoreSelection?.();
 
@@ -369,6 +369,7 @@ describe('AppShell comments sidebar', () => {
       composer!.dispatchEvent(new window.Event('pointerdown', { bubbles: true }));
       composer!.dispatchEvent(new window.FocusEvent('focusin', { bubbles: true }));
       document.dispatchEvent(new window.Event('selectionchange'));
+      document.dispatchEvent(new window.Event('pointerup'));
     });
 
     const quoteAfterComposerClick = shadow
@@ -380,6 +381,7 @@ describe('AppShell comments sidebar', () => {
       composer!.value = 'typing root';
       composer!.dispatchEvent(new window.Event('input', { bubbles: true }));
       document.dispatchEvent(new window.Event('selectionchange'));
+      document.dispatchEvent(new window.Event('pointerup'));
     });
 
     const quoteAfterComposerTyping = shadow
@@ -398,6 +400,7 @@ describe('AppShell comments sidebar', () => {
       reply.dispatchEvent(new window.Event('pointerdown', { bubbles: true }));
       reply.dispatchEvent(new window.FocusEvent('focusin', { bubbles: true }));
       document.dispatchEvent(new window.Event('selectionchange'));
+      document.dispatchEvent(new window.Event('pointerup'));
     });
 
     const quoteAfterReply = shadow?.querySelector('.webclipper-inpage-comments-panel__quote-text')?.textContent?.trim();
@@ -407,6 +410,7 @@ describe('AppShell comments sidebar', () => {
       reply.value = 'typing reply';
       reply.dispatchEvent(new window.Event('input', { bubbles: true }));
       document.dispatchEvent(new window.Event('selectionchange'));
+      document.dispatchEvent(new window.Event('pointerup'));
     });
 
     const quoteAfterReplyTyping = shadow
@@ -443,6 +447,7 @@ describe('AppShell comments sidebar', () => {
 
     act(() => {
       document.dispatchEvent(new window.Event('selectionchange'));
+      document.dispatchEvent(new window.Event('pointerup'));
     });
 
     await vi.waitFor(() => {

--- a/webclipper/tests/smoke/app-shell-comments-sidebar.test.ts
+++ b/webclipper/tests/smoke/app-shell-comments-sidebar.test.ts
@@ -359,6 +359,29 @@ describe('AppShell comments sidebar', () => {
       expect(quoteText).toBe(selectedText);
     });
 
+    const clearBtn = shadow?.querySelector(
+      '.webclipper-inpage-comments-panel__quote-clear',
+    ) as HTMLButtonElement | null;
+    expect(clearBtn).toBeTruthy();
+    act(() => {
+      clearBtn!.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    });
+
+    await vi.waitFor(() => {
+      const quoteText = shadow?.querySelector('.webclipper-inpage-comments-panel__quote-text')?.textContent?.trim();
+      expect(quoteText).toBe('');
+    });
+
+    act(() => {
+      document.dispatchEvent(new window.Event('selectionchange'));
+      document.dispatchEvent(new window.Event('pointerup'));
+    });
+
+    await vi.waitFor(() => {
+      const quoteText = shadow?.querySelector('.webclipper-inpage-comments-panel__quote-text')?.textContent?.trim();
+      expect(quoteText).toBe(selectedText);
+    });
+
     restoreSelection?.();
 
     const composer = shadow?.querySelector(

--- a/webclipper/tests/smoke/inpage-comments-sidebar-toggle.test.ts
+++ b/webclipper/tests/smoke/inpage-comments-sidebar-toggle.test.ts
@@ -150,6 +150,11 @@ describe('inpage comments sidebar toggle', () => {
     await flushReactScheduler();
     expect(onComposerSelectionRequest).toHaveBeenCalledTimes(1);
 
+    document.dispatchEvent(new window.Event('selectionchange'));
+    document.dispatchEvent(new window.KeyboardEvent('keyup', { key: 'Shift', shiftKey: false }));
+    await flushReactScheduler();
+    expect(onComposerSelectionRequest).toHaveBeenCalledTimes(1);
+
     expect(shadow?.querySelector('.webclipper-inpage-comments-panel__attach-selection')).toBeFalsy();
 
     const reply = shadow?.querySelector(

--- a/webclipper/tests/smoke/inpage-comments-sidebar-toggle.test.ts
+++ b/webclipper/tests/smoke/inpage-comments-sidebar-toggle.test.ts
@@ -14,6 +14,10 @@ function setupDom() {
   Object.defineProperty(globalThis, 'navigator', { configurable: true, value: dom.window.navigator });
   Object.defineProperty(globalThis, 'HTMLElement', { configurable: true, value: dom.window.HTMLElement });
   Object.defineProperty(globalThis, 'Node', { configurable: true, value: dom.window.Node });
+  Object.defineProperty(globalThis, 'getSelection', {
+    configurable: true,
+    value: dom.window.getSelection.bind(dom.window),
+  });
   Object.defineProperty(globalThis, 'getComputedStyle', {
     configurable: true,
     value: dom.window.getComputedStyle.bind(dom.window),
@@ -33,6 +37,7 @@ function cleanupDom() {
   delete (globalThis as any).navigator;
   delete (globalThis as any).HTMLElement;
   delete (globalThis as any).Node;
+  delete (globalThis as any).getSelection;
   delete (globalThis as any).getComputedStyle;
   delete (globalThis as any).IS_REACT_ACT_ENVIRONMENT;
 }
@@ -98,7 +103,7 @@ describe('inpage comments sidebar toggle', () => {
     expect(api.isOpen()).toBe(false);
   });
 
-  it('triggers composer selection request only from document selectionchange', async () => {
+  it('triggers composer selection request on pointerup commit (not selectionchange only)', async () => {
     const api = getInpageCommentsPanelApi();
     const onComposerSelectionRequest = vi.fn();
 
@@ -111,8 +116,26 @@ describe('inpage comments sidebar toggle', () => {
     const shadow = host?.shadowRoot;
     expect(shadow).toBeTruthy();
 
+    const selectionMock = {
+      rangeCount: 1,
+      anchorNode: document.body,
+      focusNode: document.body,
+      anchorOffset: 0,
+      focusOffset: 4,
+      toString: () => 'Quote',
+      getRangeAt: () => {
+        const range = document.createRange();
+        range.selectNodeContents(document.body);
+        return range;
+      },
+      removeAllRanges: () => {},
+      addRange: () => {},
+    } as any;
+    const selectionSpy = vi.spyOn(globalThis, 'getSelection').mockImplementation(() => selectionMock as Selection);
+
     document.dispatchEvent(new window.Event('selectionchange'));
-    vi.advanceTimersByTime(300);
+    document.dispatchEvent(new window.Event('pointerup'));
+    await flushReactScheduler();
 
     expect(onComposerSelectionRequest).toHaveBeenCalledTimes(1);
     expect(onComposerSelectionRequest).toHaveBeenLastCalledWith({ trigger: 'auto' });
@@ -121,10 +144,10 @@ describe('inpage comments sidebar toggle', () => {
       '.webclipper-inpage-comments-panel__composer-textarea',
     ) as HTMLTextAreaElement | null;
     expect(composer).toBeTruthy();
-    composer?.dispatchEvent(new window.Event('pointerdown', { bubbles: true }));
-    composer?.dispatchEvent(new window.FocusEvent('focus', { bubbles: true }));
+    selectionSpy.mockImplementation(() => ({ ...selectionMock, toString: () => '' }) as Selection);
     document.dispatchEvent(new window.Event('selectionchange'));
-    vi.advanceTimersByTime(300);
+    document.dispatchEvent(new window.Event('pointerup'));
+    await flushReactScheduler();
     expect(onComposerSelectionRequest).toHaveBeenCalledTimes(1);
 
     expect(shadow?.querySelector('.webclipper-inpage-comments-panel__attach-selection')).toBeFalsy();
@@ -133,12 +156,11 @@ describe('inpage comments sidebar toggle', () => {
       '.webclipper-inpage-comments-panel__reply-textarea',
     ) as HTMLTextAreaElement | null;
     expect(reply).toBeTruthy();
-    reply?.dispatchEvent(new window.Event('pointerdown', { bubbles: true }));
-    reply?.dispatchEvent(new window.FocusEvent('focus', { bubbles: true }));
     document.dispatchEvent(new window.Event('selectionchange'));
-    vi.advanceTimersByTime(300);
-
-    await Promise.resolve();
+    document.dispatchEvent(new window.Event('pointerup'));
+    await flushReactScheduler();
     expect(onComposerSelectionRequest).toHaveBeenCalledTimes(1);
+
+    selectionSpy.mockRestore();
   });
 });

--- a/webclipper/tests/unit/article-comments-sidebar-controller.test.ts
+++ b/webclipper/tests/unit/article-comments-sidebar-controller.test.ts
@@ -90,7 +90,7 @@ describe('article-comments-sidebar-controller', () => {
     expect(panel.getState().comments.length).toBe(1);
   });
 
-  it('save root: returns structured result, refreshes list, and clears quote via session wrapper', async () => {
+  it('save root: returns structured result, refreshes list, and keeps quote until explicit clear', async () => {
     const panel = createMockPanel();
     const session = createCommentSidebarSession(panel.api as any);
 
@@ -119,7 +119,7 @@ describe('article-comments-sidebar-controller', () => {
       locator: null,
     });
     expect(adapter.list).toHaveBeenCalled();
-    expect(session.getSnapshot().quoteText).toBe('');
+    expect(session.getSnapshot().quoteText).toBe('Quoted');
   });
 
   it('updates quote and locator from composer selection requests', async () => {
@@ -169,7 +169,7 @@ describe('article-comments-sidebar-controller', () => {
 
     await handlers.onComposerSelectionRequest({ trigger: 'button' });
     expect(resolveComposerSelection).toHaveBeenNthCalledWith(2, { trigger: 'button' });
-    expect(session.getSnapshot().quoteText).toBe('');
+    expect(session.getSnapshot().quoteText).toBe('Quoted from page');
   });
 
   it('ignores stale composer selection responses and keeps latest result', async () => {

--- a/webclipper/tests/unit/comment-sidebar-session.test.ts
+++ b/webclipper/tests/unit/comment-sidebar-session.test.ts
@@ -189,24 +189,32 @@ describe('comment-sidebar-session', () => {
     });
   });
 
-  it('forwards onComposerSelectionRequest while keeping onSave clear-quote wrapper', async () => {
+  it('forwards composer selection + quote clear requests and does not clear quote implicitly on save', async () => {
     const { panel, calls } = createPanelMock();
     const session = createCommentSidebarSession(panel);
 
     const onComposerSelectionRequest = vi.fn(async () => {});
+    const onComposerQuoteClearRequest = vi.fn(async () => {
+      session.setQuoteText('');
+    });
     const onSave = vi.fn(async () => ({ ok: true }));
 
     session.setQuoteText('quoted text');
-    session.setHandlers({ onSave, onComposerSelectionRequest });
+    session.setHandlers({ onSave, onComposerSelectionRequest, onComposerQuoteClearRequest });
 
     const latestHandlers = calls.handlers[calls.handlers.length - 1];
     expect(typeof latestHandlers.onComposerSelectionRequest).toBe('function');
     expect(typeof latestHandlers.onSave).toBe('function');
+    expect(typeof latestHandlers.onComposerQuoteClearRequest).toBe('function');
 
     await latestHandlers.onComposerSelectionRequest?.({ trigger: 'button' } as any);
     expect(onComposerSelectionRequest).toHaveBeenCalledWith({ trigger: 'button' });
 
     await latestHandlers.onSave?.('hello');
+    expect(session.getSnapshot().quoteText).toBe('quoted text');
+
+    await latestHandlers.onComposerQuoteClearRequest?.();
+    expect(onComposerQuoteClearRequest).toHaveBeenCalledTimes(1);
     expect(session.getSnapshot().quoteText).toBe('');
   });
 });

--- a/webclipper/tests/unit/threaded-comments-panel-auto-attach-selection.test.ts
+++ b/webclipper/tests/unit/threaded-comments-panel-auto-attach-selection.test.ts
@@ -126,6 +126,37 @@ describe('Threaded comments panel auto-attach selection trigger', () => {
     mounted.cleanup();
   });
 
+  it('commits keyboard selection only after modifier is released (shift + arrow)', async () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const onComposerSelectionRequest = vi.fn();
+    const mounted = mountThreadedCommentsPanel(host, { overlay: false, showHeader: true });
+    mounted.api.setHandlers({ onComposerSelectionRequest } as any);
+
+    const selectionState = installMutableSelectionMock('Quoted text');
+
+    document.dispatchEvent(new window.Event('selectionchange'));
+    document.dispatchEvent(new window.KeyboardEvent('keyup', { key: 'ArrowRight', shiftKey: true }));
+    await flushReactScheduler();
+
+    expect(onComposerSelectionRequest).toHaveBeenCalledTimes(0);
+
+    document.dispatchEvent(new window.KeyboardEvent('keyup', { key: 'Shift', shiftKey: false }));
+    await flushReactScheduler();
+
+    expect(onComposerSelectionRequest).toHaveBeenCalledTimes(1);
+
+    selectionState.text = '';
+    document.dispatchEvent(new window.Event('selectionchange'));
+    document.dispatchEvent(new window.KeyboardEvent('keyup', { key: 'Shift', shiftKey: false }));
+    await flushReactScheduler();
+
+    expect(onComposerSelectionRequest).toHaveBeenCalledTimes(1);
+
+    mounted.cleanup();
+  });
+
   it('does not clear quote when composer/reply interactions cause empty selectionchange', async () => {
     const host = document.createElement('div');
     document.body.appendChild(host);

--- a/webclipper/tests/unit/threaded-comments-panel-auto-attach-selection.test.ts
+++ b/webclipper/tests/unit/threaded-comments-panel-auto-attach-selection.test.ts
@@ -102,7 +102,7 @@ describe('Threaded comments panel auto-attach selection trigger', () => {
     cleanupDom();
   });
 
-  it('requests selection on document selectionchange and dedupes identical signatures', async () => {
+  it('requests selection on pointerup commit and dedupes identical signatures', async () => {
     const host = document.createElement('div');
     document.body.appendChild(host);
 
@@ -117,8 +117,7 @@ describe('Threaded comments panel auto-attach selection trigger', () => {
 
     document.dispatchEvent(new window.Event('selectionchange'));
     document.dispatchEvent(new window.Event('selectionchange'));
-
-    vi.advanceTimersByTime(300);
+    document.dispatchEvent(new window.Event('pointerup'));
     await flushReactScheduler();
 
     expect(onComposerSelectionRequest).toHaveBeenCalledTimes(1);
@@ -143,7 +142,7 @@ describe('Threaded comments panel auto-attach selection trigger', () => {
     mounted.api.setComments([{ id: 1, parentId: null, createdAt: Date.now(), commentText: 'root' }]);
 
     document.dispatchEvent(new window.Event('selectionchange'));
-    vi.advanceTimersByTime(300);
+    document.dispatchEvent(new window.Event('pointerup'));
     await flushReactScheduler();
 
     expect(onComposerSelectionRequest).toHaveBeenCalledTimes(1);
@@ -156,10 +155,8 @@ describe('Threaded comments panel auto-attach selection trigger', () => {
     ) as HTMLTextAreaElement | null;
     expect(composer).toBeTruthy();
 
-    composer!.dispatchEvent(new window.Event('pointerdown', { bubbles: true }));
-    composer!.dispatchEvent(new window.FocusEvent('focusin', { bubbles: true }));
     document.dispatchEvent(new window.Event('selectionchange'));
-    vi.advanceTimersByTime(300);
+    document.dispatchEvent(new window.Event('pointerup'));
     await flushReactScheduler();
 
     expect(onComposerSelectionRequest).toHaveBeenCalledTimes(1);
@@ -169,10 +166,8 @@ describe('Threaded comments panel auto-attach selection trigger', () => {
     ) as HTMLTextAreaElement | null;
     expect(reply).toBeTruthy();
 
-    reply!.dispatchEvent(new window.Event('pointerdown', { bubbles: true }));
-    reply!.dispatchEvent(new window.FocusEvent('focusin', { bubbles: true }));
     document.dispatchEvent(new window.Event('selectionchange'));
-    vi.advanceTimersByTime(300);
+    document.dispatchEvent(new window.Event('pointerup'));
     await flushReactScheduler();
 
     expect(onComposerSelectionRequest).toHaveBeenCalledTimes(1);

--- a/webclipper/tests/unit/threaded-comments-panel-auto-attach-selection.test.ts
+++ b/webclipper/tests/unit/threaded-comments-panel-auto-attach-selection.test.ts
@@ -175,6 +175,53 @@ describe('Threaded comments panel auto-attach selection trigger', () => {
     mounted.cleanup();
   });
 
+  it('clears quote only via explicit ❌ and allows reattaching the same selection', async () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const onComposerSelectionRequest = vi.fn();
+    const mounted = mountThreadedCommentsPanel(host, { overlay: false, showHeader: true });
+
+    mounted.api.setHandlers({
+      onComposerSelectionRequest,
+      onComposerQuoteClearRequest: () => {
+        mounted.api.setQuoteText('');
+      },
+    } as any);
+
+    const panel = host.querySelector('webclipper-threaded-comments-panel') as HTMLElement | null;
+    expect(panel).toBeTruthy();
+    const shadow = panel!.shadowRoot!;
+
+    const selectionState = installMutableSelectionMock('Same quote');
+
+    document.dispatchEvent(new window.Event('selectionchange'));
+    document.dispatchEvent(new window.Event('pointerup'));
+    await flushReactScheduler();
+
+    expect(onComposerSelectionRequest).toHaveBeenCalledTimes(1);
+
+    mounted.api.setQuoteText(selectionState.text);
+    await flushReactScheduler();
+
+    const clearBtn = shadow.querySelector('.webclipper-inpage-comments-panel__quote-clear') as HTMLButtonElement | null;
+    expect(clearBtn).toBeTruthy();
+    clearBtn!.click();
+    await flushReactScheduler();
+
+    const quoteEl = shadow.querySelector('.webclipper-inpage-comments-panel__quote') as HTMLElement | null;
+    expect(quoteEl).toBeTruthy();
+    expect((quoteEl as HTMLElement).style.display).toBe('none');
+
+    document.dispatchEvent(new window.Event('selectionchange'));
+    document.dispatchEvent(new window.Event('pointerup'));
+    await flushReactScheduler();
+
+    expect(onComposerSelectionRequest).toHaveBeenCalledTimes(2);
+
+    mounted.cleanup();
+  });
+
   it('renders comments header title and no manual attach-selection button', async () => {
     const host = document.createElement('div');
     document.body.appendChild(host);


### PR DESCRIPTION
背景
- 评论侧栏引用区的清空按钮（❌）样式与应用内 Settings 宽屏弹层右上角关闭按钮不一致。

改动
- 复用 Settings 关闭按钮的样式类（buttonIconCircleGhostClassName）
- 图标改为与 Settings 一致的 X SVG
- 引用区 CSS 只保留定位，避免覆盖按钮尺寸/交互态

验证
- npm --prefix webclipper run lint
- npm --prefix webclipper run compile
