### PR TITLE
修复：引用区清空按钮改为真正 overlay 右上角

### DIFF
--- a/webclipper/src/ui/comments/react/ThreadedCommentsPanel.tsx
+++ b/webclipper/src/ui/comments/react/ThreadedCommentsPanel.tsx
@@ -709,11 +709,12 @@ export function ThreadedCommentsPanel({
         </div>
 	        <div
 	          className="webclipper-inpage-comments-panel__quote"
-	          style={{ display: snapshot.quoteText ? 'block' : 'none' }}
+	          style={{ display: snapshot.quoteText ? 'block' : 'none', position: 'relative' }}
 	        >
 	          <button
 	            type="button"
 	            className={['webclipper-inpage-comments-panel__quote-clear', buttonIconCircleGhostClassName()].join(' ')}
+	            style={{ position: 'absolute', top: 4, right: 4, zIndex: 2 }}
 	            aria-label="Clear quote"
 	            onClick={() => {
 	              lastAutoSelectionSignatureRef.current = '';


### PR DESCRIPTION
背景
- 当前引用区的清空按钮在部分场景未应用 overlay 样式，表现为与引用文本并排（类似 HStack），占据引用区宽度。

改动
- 在组件层补充 inline 定位兜底：引用容器强制 relative、按钮强制 absolute(top/right=4,zIndex=2)
- 保持按钮视觉风格继续复用 Settings 宽屏弹层右上角关闭按钮

验证
- npm --prefix webclipper run lint
- npm --prefix webclipper run compile
