### PR TITLE
popup评论跳转app定位会话 + 移除详情头Chat-with

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,8 @@ npm --prefix webclipper run check            # 产物校验
    - `webclipper/src/ui/shared/SelectMenu.tsx`（source/site 筛选菜单的 `adaptiveMaxHeight` 与可视区域计算）
    - `webclipper/src/ui/popup/PopupShell.tsx` / `webclipper/src/ui/app/AppShell.tsx`（列表统计跳转 Insight 的路由入口）
    - `webclipper/src/ui/conversations/ConversationListPane.tsx` / `pending-open.ts`（来源筛选持久化与窄屏 detail bridge）
-   - `webclipper/src/viewmodels/conversations/conversations-context.tsx` / `DetailHeaderActionBar.tsx` / `DetailNavigationHeader.tsx`（详情头 `open / tools` 槽位分发与窄屏一致性；Chat with AI 动作也复用 `tools` 槽位）
+   - `webclipper/src/viewmodels/conversations/conversations-context.tsx` / `DetailHeaderActionBar.tsx` / `DetailNavigationHeader.tsx`（详情头 `open / tools` 槽位分发与窄屏一致性；`tools` 仅用于本地工具动作（例如 cache-images），不包含 Chat with）
+   - `webclipper/src/ui/comments/react/ThreadedCommentsPanel.tsx` / `webclipper/src/services/integrations/chatwith/chatwith-comments-header-actions.ts`（Chat with 仅归属评论侧栏：sidebar header + comment-level）
 4. 默认验证顺序使用：
    - `npm --prefix webclipper run compile`
    - `npm --prefix webclipper run test`

--- a/webclipper/src/services/integrations/chatwith/chatwith-comment-actions.ts
+++ b/webclipper/src/services/integrations/chatwith/chatwith-comment-actions.ts
@@ -1,6 +1,6 @@
 import { loadChatWithSettings, type ChatWithAiPlatform } from '@services/integrations/chatwith/chatwith-settings';
 import { writeTextToClipboard } from '@services/integrations/chatwith/chatwith-clipboard';
-import { resolveSingleEnabledChatWithActionLabel } from '@services/integrations/chatwith/chatwith-detail-header-actions';
+import { resolveSingleEnabledChatWithActionLabel } from '@services/integrations/chatwith/chatwith-comments-header-actions';
 import { buildChatWithCommentPayloadV1 } from '@services/integrations/chatwith/chatwith-comment-payload';
 import {
   openChatWithPlatform,

--- a/webclipper/src/services/integrations/chatwith/chatwith-comments-header-actions.ts
+++ b/webclipper/src/services/integrations/chatwith/chatwith-comments-header-actions.ts
@@ -88,7 +88,7 @@ function buildChatWithPlatformAction(input: {
   };
 }
 
-export async function resolveChatWithDetailHeaderActions({
+export async function resolveChatWithCommentsHeaderActions({
   conversation,
   detail,
   port,

--- a/webclipper/src/ui/AGENTS.md
+++ b/webclipper/src/ui/AGENTS.md
@@ -349,7 +349,6 @@ WebClipper 圆角必须统一复用 `webclipper/src/ui/styles/tokens.css` 的半
 | 槽位    | 典型动作                          | 真源                                                                                       | UI 约束                       |
 | ------- | --------------------------------- | ------------------------------------------------------------------------------------------ | ----------------------------- |
 | `open`  | Open in Notion / Open in Obsidian | `src/services/integrations/openin/*`, `src/services/integrations/detail-header-actions.ts` | 单动作直出，多动作菜单        |
-| `tools` | Chat with ChatGPT / Claude / ...  | `src/services/integrations/chatwith/chatwith-detail-header-actions.ts`                     | 先复制 payload，再跳转外链    |
 | `tools` | `cache-images`                    | `src/viewmodels/conversations/conversations-context.tsx`                                   | 触发后应回馈计数并刷新 detail |
 
 - 槽位契约定义在 `src/services/integrations/detail-header-action-types.ts`，不要在组件内硬编码“动作分组字符串”。
@@ -361,7 +360,7 @@ WebClipper 圆角必须统一复用 `webclipper/src/ui/styles/tokens.css` 的半
 
 最小手工验证（popup + app 都要过）：
 
-- detail：`open / tools` 槽位都可显示且可点击（Chat with AI 与 cache-images 同属 `tools`）。
+- detail：`open / tools` 槽位都可显示且可点击（`tools` 仅包含本地工具，例如 `cache-images`；不包含 Chat with）。
 - 窄屏模式：header 动作槽位与宽屏详情页一致，无缺槽位或错位分组。
 
 ## B7 · Markdown 阅读风格协议（Medium / Notion / Book）

--- a/webclipper/src/ui/app/AppShell.tsx
+++ b/webclipper/src/ui/app/AppShell.tsx
@@ -17,9 +17,9 @@ import { createThreadedCommentChatWithConfig } from '@ui/comments';
 import type { ThreadedCommentsPanelChatWithAction } from '@ui/comments';
 import { defaultDetailHeaderActionPort, type DetailHeaderAction } from '@services/integrations/detail-header-actions';
 import {
-  resolveChatWithDetailHeaderActions,
+  resolveChatWithCommentsHeaderActions,
   resolveSingleEnabledChatWithActionLabel,
-} from '@services/integrations/chatwith/chatwith-detail-header-actions';
+} from '@services/integrations/chatwith/chatwith-comments-header-actions';
 import type { ChatWithOpenPlatformPort } from '@services/integrations/chatwith/chatwith-open-port';
 import { CHATWITH_MESSAGE_TYPES } from '@services/protocols/message-contracts';
 import { createRuntimeClient } from '@services/shared/runtime-client';
@@ -462,7 +462,7 @@ export default function AppShell() {
         throw new Error('Conversation detail is not ready yet');
       }
 
-      const actions: DetailHeaderAction[] = await resolveChatWithDetailHeaderActions({
+      const actions: DetailHeaderAction[] = await resolveChatWithCommentsHeaderActions({
         conversation: selectedConversation,
         detail: currentDetail,
         port: defaultDetailHeaderActionPort,

--- a/webclipper/src/ui/conversations/ConversationsScene.tsx
+++ b/webclipper/src/ui/conversations/ConversationsScene.tsx
@@ -89,7 +89,7 @@ export function ConversationsScene({
   });
   const selectedConversationCanonicalUrl = canonicalizeArticleUrl((selectedConversation as any)?.url);
   const canOpenCommentsFromDetail =
-    Boolean(commentsSidebarRuntime) &&
+    (typeof onOpenCommentsExternally === 'function' || Boolean(commentsSidebarRuntime)) &&
     isArticleConversationLike(selectedConversation) &&
     Boolean(selectedConversationCanonicalUrl);
 

--- a/webclipper/src/ui/conversations/ConversationsScene.tsx
+++ b/webclipper/src/ui/conversations/ConversationsScene.tsx
@@ -30,6 +30,7 @@ export type ConversationsSceneProps = {
   onPopupNotionSyncStarted?: () => void;
   onOpenInsightsSection?: () => void;
   onOpenSettingsSection?: (section: string) => void;
+  onOpenCommentsExternally?: () => void;
   commentsSidebarRuntime?: ArticleCommentsSidebarRuntime;
   narrowCommentsOpenSource?: 'popup' | 'app';
   resolveCommentsSidebarChatWithActions?: () => Promise<ThreadedCommentsPanelChatWithAction[]>;
@@ -60,6 +61,7 @@ export function ConversationsScene({
   onPopupNotionSyncStarted,
   onOpenInsightsSection,
   onOpenSettingsSection,
+  onOpenCommentsExternally,
   commentsSidebarRuntime,
   narrowCommentsOpenSource = 'popup',
   resolveCommentsSidebarChatWithActions,
@@ -167,6 +169,10 @@ export function ConversationsScene({
                 onTriggerCommentsSidebar={
                   canOpenCommentsFromDetail
                     ? () => {
+                        if (typeof onOpenCommentsExternally === 'function') {
+                          onOpenCommentsExternally();
+                          return;
+                        }
                         if (!commentsSidebarRuntime) return;
                         openComments();
                         void commentsSidebarRuntime.sidebarController.open({

--- a/webclipper/src/ui/inpage/inpage-comments-panel-shadow.ts
+++ b/webclipper/src/ui/inpage/inpage-comments-panel-shadow.ts
@@ -16,9 +16,9 @@ import { normalizePositiveInt } from '@services/shared/numbers';
 import { canonicalizeArticleUrl } from '@services/url-cleaning/http-url';
 import type { ChatWithOpenPlatformPort } from '@services/integrations/chatwith/chatwith-open-port';
 import {
-  resolveChatWithDetailHeaderActions,
+  resolveChatWithCommentsHeaderActions,
   resolveSingleEnabledChatWithActionLabel,
-} from '@services/integrations/chatwith/chatwith-detail-header-actions';
+} from '@services/integrations/chatwith/chatwith-comments-header-actions';
 import { defaultDetailHeaderActionPort, type DetailHeaderAction } from '@services/integrations/detail-header-actions';
 
 export type InpageCommentItem = ThreadedCommentItem;
@@ -148,7 +148,7 @@ async function resolveInpageChatWithActions(): Promise<ThreadedCommentsPanelChat
     publishedAt: resolved?.data?.publishedAt,
   });
 
-  const actions: DetailHeaderAction[] = await resolveChatWithDetailHeaderActions({
+  const actions: DetailHeaderAction[] = await resolveChatWithCommentsHeaderActions({
     conversation,
     detail,
     port: defaultDetailHeaderActionPort,

--- a/webclipper/src/ui/popup/PopupShell.tsx
+++ b/webclipper/src/ui/popup/PopupShell.tsx
@@ -11,7 +11,7 @@ import { useArticleCommentsSidebarRuntime } from '@viewmodels/comments/useArticl
 import { buttonFilledClassName, buttonTintClassName, headerButtonClassName } from '@ui/shared/button-styles';
 import { AppTooltipHost, tooltipAttrs } from '@ui/shared/AppTooltip';
 import { usePopupCurrentPageCapture } from '@viewmodels/popup/usePopupCurrentPageCapture';
-import { usePopupOpenInpageCommentsSidebar } from '@viewmodels/popup/usePopupOpenInpageCommentsSidebar';
+import { usePopupOpenAppCommentsConversation } from '@viewmodels/popup/usePopupOpenAppCommentsConversation';
 
 const POPUP_NOTION_SYNC_NUDGE_DISMISSED_KEY = 'webclipper_popup_notion_sync_open_tab_dont_show_v1';
 
@@ -113,7 +113,7 @@ function PopupShellFrame() {
   const { refreshList, refreshActiveDetail } = useConversationsApp();
   const [notionSyncNudgeOpen, setNotionSyncNudgeOpen] = useState(false);
   const [notionSyncNudgeDontShowAgain, setNotionSyncNudgeDontShowAgain] = useState(false);
-  const commentsButton = usePopupOpenInpageCommentsSidebar();
+  const commentsButton = usePopupOpenAppCommentsConversation();
   const { buttonDisabled, buttonLabel, capture, status } = usePopupCurrentPageCapture({
     onCaptured: async () => {
       await refreshList();

--- a/webclipper/src/ui/popup/PopupShell.tsx
+++ b/webclipper/src/ui/popup/PopupShell.tsx
@@ -3,6 +3,7 @@ import { MessageSquareText, Settings as SettingsIcon } from 'lucide-react';
 
 import { openOrFocusExtensionAppTab } from '@services/shared/webext';
 import { storageGet, storageSet } from '@services/shared/storage';
+import { buildConversationRouteFromLoc, encodeConversationLoc } from '@services/shared/conversation-loc';
 
 import { t } from '@i18n';
 import { useConversationsApp, ConversationsProvider } from '@viewmodels/conversations/conversations-context';
@@ -110,7 +111,7 @@ export default function PopupShell() {
 
 function PopupShellFrame() {
   const commentsSidebarRuntime = useArticleCommentsSidebarRuntime();
-  const { refreshList, refreshActiveDetail } = useConversationsApp();
+  const { refreshList, refreshActiveDetail, selectedConversation } = useConversationsApp();
   const [notionSyncNudgeOpen, setNotionSyncNudgeOpen] = useState(false);
   const [notionSyncNudgeDontShowAgain, setNotionSyncNudgeDontShowAgain] = useState(false);
   const commentsButton = usePopupOpenAppCommentsConversation();
@@ -120,6 +121,20 @@ function PopupShellFrame() {
       await refreshActiveDetail();
     },
   });
+
+  const onOpenSelectedConversationComments = useCallback(() => {
+    void (async () => {
+      const convo: any = selectedConversation;
+      const source = String(convo?.source || '').trim();
+      const conversationKey = String(convo?.conversationKey || '').trim();
+      if (!source || !conversationKey) return;
+
+      const loc = encodeConversationLoc({ source, conversationKey });
+      const route = buildConversationRouteFromLoc(loc);
+      const opened = await openOrFocusExtensionAppTab({ route });
+      if (opened) window.close();
+    })();
+  }, [selectedConversation]);
 
   const onOpenSettings = useCallback(async () => {
     await openOrFocusExtensionAppTab({ route: '/settings' });
@@ -256,6 +271,7 @@ function PopupShellFrame() {
               onOpenSettingsSection={(section) => {
                 void onOpenProviderSettings(section).catch(() => {});
               }}
+              onOpenCommentsExternally={onOpenSelectedConversationComments}
               commentsSidebarRuntime={commentsSidebarRuntime}
               narrowCommentsOpenSource="popup"
             />

--- a/webclipper/src/ui/popup/PopupShell.tsx
+++ b/webclipper/src/ui/popup/PopupShell.tsx
@@ -8,7 +8,6 @@ import { buildConversationRouteFromLoc, encodeConversationLoc } from '@services/
 import { t } from '@i18n';
 import { useConversationsApp, ConversationsProvider } from '@viewmodels/conversations/conversations-context';
 import { ConversationsScene } from '@ui/conversations/ConversationsScene';
-import { useArticleCommentsSidebarRuntime } from '@viewmodels/comments/useArticleCommentsSidebarRuntime';
 import { buttonFilledClassName, buttonTintClassName, headerButtonClassName } from '@ui/shared/button-styles';
 import { AppTooltipHost, tooltipAttrs } from '@ui/shared/AppTooltip';
 import { usePopupCurrentPageCapture } from '@viewmodels/popup/usePopupCurrentPageCapture';
@@ -110,7 +109,6 @@ export default function PopupShell() {
 }
 
 function PopupShellFrame() {
-  const commentsSidebarRuntime = useArticleCommentsSidebarRuntime();
   const { refreshList, refreshActiveDetail, selectedConversation } = useConversationsApp();
   const [notionSyncNudgeOpen, setNotionSyncNudgeOpen] = useState(false);
   const [notionSyncNudgeDontShowAgain, setNotionSyncNudgeDontShowAgain] = useState(false);
@@ -272,7 +270,6 @@ function PopupShellFrame() {
                 void onOpenProviderSettings(section).catch(() => {});
               }}
               onOpenCommentsExternally={onOpenSelectedConversationComments}
-              commentsSidebarRuntime={commentsSidebarRuntime}
               narrowCommentsOpenSource="popup"
             />
           </div>

--- a/webclipper/src/viewmodels/popup/usePopupOpenAppCommentsConversation.ts
+++ b/webclipper/src/viewmodels/popup/usePopupOpenAppCommentsConversation.ts
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { UI_MESSAGE_TYPES } from '@services/protocols/message-contracts';
+import { ARTICLE_MESSAGE_TYPES } from '@platform/messaging/message-contracts';
 import { send } from '@services/shared/runtime';
+import { openOrFocusExtensionAppTab } from '@services/shared/webext';
+import { encodeConversationLoc, buildConversationRouteFromLoc } from '@services/shared/conversation-loc';
+import { canonicalizeArticleUrl } from '@services/url-cleaning/http-url';
 import { t } from '@i18n';
 
 type ApiResponse<T> = {
@@ -16,6 +20,12 @@ type CaptureState = {
   label: string;
   collectorId: string | null;
   reason?: string;
+};
+
+type ResolvedArticle = {
+  conversationId: number;
+  url: string | null;
+  title: string | null;
 };
 
 function unwrap<T>(response: ApiResponse<T>): T {
@@ -34,7 +44,7 @@ function hasRuntimeSendMessage(): boolean {
   return typeof chromeSend === 'function';
 }
 
-export function usePopupOpenInpageCommentsSidebar() {
+export function usePopupOpenAppCommentsConversation() {
   const runtimeAvailable = useMemo(() => hasRuntimeSendMessage(), []);
   const mountedRef = useRef(true);
   useEffect(() => {
@@ -105,13 +115,16 @@ export function usePopupOpenInpageCommentsSidebar() {
     if (checking || opening || !eligible) return false;
     if (mountedRef.current) setOpening(true);
     try {
-      const response = await send<ApiResponse<{ opened: boolean }>>(
-        UI_MESSAGE_TYPES.OPEN_CURRENT_TAB_INPAGE_COMMENTS_PANEL,
-        {
-          source: 'popup',
-        },
-      );
-      return response?.ok === true;
+      const response = await send<ApiResponse<ResolvedArticle>>(ARTICLE_MESSAGE_TYPES.RESOLVE_OR_CAPTURE_ACTIVE_TAB, {});
+      const resolved = unwrap(response);
+
+      const canonicalUrl = canonicalizeArticleUrl(resolved?.url);
+      if (!canonicalUrl) return false;
+
+      const loc = encodeConversationLoc({ source: 'web', conversationKey: `article:${canonicalUrl}` });
+      const route = buildConversationRouteFromLoc(loc);
+      const opened = await openOrFocusExtensionAppTab({ route });
+      return Boolean(opened);
     } catch (_error) {
       return false;
     } finally {

--- a/webclipper/src/viewmodels/popup/usePopupOpenAppCommentsConversation.ts
+++ b/webclipper/src/viewmodels/popup/usePopupOpenAppCommentsConversation.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { UI_MESSAGE_TYPES } from '@services/protocols/message-contracts';
-import { ARTICLE_MESSAGE_TYPES } from '@platform/messaging/message-contracts';
+import { ARTICLE_MESSAGE_TYPES, UI_MESSAGE_TYPES } from '@services/protocols/message-contracts';
 import { send } from '@services/shared/runtime';
 import { openOrFocusExtensionAppTab } from '@services/shared/webext';
 import { encodeConversationLoc, buildConversationRouteFromLoc } from '@services/shared/conversation-loc';

--- a/webclipper/tests/smoke/app-shell-comments-sidebar.test.ts
+++ b/webclipper/tests/smoke/app-shell-comments-sidebar.test.ts
@@ -369,7 +369,7 @@ describe('AppShell comments sidebar', () => {
 
     await vi.waitFor(() => {
       const quoteText = shadow?.querySelector('.webclipper-inpage-comments-panel__quote-text')?.textContent?.trim();
-      expect(quoteText).toBe('');
+      expect(quoteText ?? '').toBe('');
     });
 
     act(() => {
@@ -466,7 +466,7 @@ describe('AppShell comments sidebar', () => {
     const initialQuoteText = shadow
       ?.querySelector('.webclipper-inpage-comments-panel__quote-text')
       ?.textContent?.trim();
-    expect(initialQuoteText).toBe('');
+    expect(initialQuoteText ?? '').toBe('');
 
     act(() => {
       document.dispatchEvent(new window.Event('selectionchange'));
@@ -475,7 +475,7 @@ describe('AppShell comments sidebar', () => {
 
     await vi.waitFor(() => {
       const quoteText = shadow?.querySelector('.webclipper-inpage-comments-panel__quote-text')?.textContent?.trim();
-      expect(quoteText).toBe('');
+      expect(quoteText ?? '').toBe('');
     });
   });
 

--- a/webclipper/tests/smoke/popup-shell-header-actions.test.ts
+++ b/webclipper/tests/smoke/popup-shell-header-actions.test.ts
@@ -4,6 +4,9 @@ import ReactDOM from 'react-dom/client';
 import { JSDOM } from 'jsdom';
 import type { ReactNode } from 'react';
 
+const sendMock = vi.fn();
+const openOrFocusExtensionAppTabMock = vi.fn();
+
 vi.mock('../../src/platform/runtime/runtime', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../src/platform/runtime/runtime')>();
   return {
@@ -14,6 +17,14 @@ vi.mock('../../src/platform/runtime/runtime', async (importOriginal) => {
 
 vi.mock('../../src/platform/webext/tabs', () => ({
   tabsCreate: vi.fn(),
+}));
+
+vi.mock('../../src/services/shared/runtime', () => ({
+  send: (...args: any[]) => sendMock(...args),
+}));
+
+vi.mock('../../src/services/shared/webext', () => ({
+  openOrFocusExtensionAppTab: (...args: any[]) => openOrFocusExtensionAppTabMock(...args),
 }));
 
 vi.mock('../../src/ui/shared/AppTooltip', async (importOriginal) => {
@@ -152,6 +163,10 @@ function setupDom() {
   Object.defineProperty(globalThis, 'HTMLElement', { configurable: true, value: dom.window.HTMLElement });
   Object.defineProperty(globalThis, 'Node', { configurable: true, value: dom.window.Node });
   Object.defineProperty(globalThis, 'localStorage', { configurable: true, value: dom.window.localStorage });
+  Object.defineProperty(globalThis, 'chrome', {
+    configurable: true,
+    value: { runtime: { sendMessage: () => {} } },
+  });
   Object.defineProperty(globalThis, 'MutationObserver', {
     configurable: true,
     value: dom.window.MutationObserver,
@@ -178,6 +193,7 @@ function cleanupDom() {
   delete (globalThis as any).HTMLElement;
   delete (globalThis as any).Node;
   delete (globalThis as any).localStorage;
+  delete (globalThis as any).chrome;
   delete (globalThis as any).MutationObserver;
   delete (globalThis as any).Event;
   delete (globalThis as any).CustomEvent;
@@ -190,6 +206,8 @@ describe('PopupShell header actions', () => {
 
   beforeEach(() => {
     setupDom();
+    sendMock.mockReset();
+    openOrFocusExtensionAppTabMock.mockReset();
     root = ReactDOM.createRoot(document.getElementById('root')!);
   });
 
@@ -262,5 +280,64 @@ describe('PopupShell header actions', () => {
 
     expect(document.querySelector('[aria-label="Open destinations"]')).toBeTruthy();
     expect(document.querySelector('[aria-label="Open in Notion"]')).toBeFalsy();
+  });
+
+  it('opens app.html and jumps to the resolved article conversation from the comments button', async () => {
+    const { UI_MESSAGE_TYPES } = await import('../../src/services/protocols/message-contracts');
+    const { ARTICLE_MESSAGE_TYPES } = await import('../../src/platform/messaging/message-contracts');
+    const { encodeConversationLoc, buildConversationRouteFromLoc } = await import('../../src/services/shared/conversation-loc');
+
+    sendMock.mockImplementation(async (type: string) => {
+      if (type === UI_MESSAGE_TYPES.GET_ACTIVE_TAB_CAPTURE_STATE) {
+        return {
+          ok: true,
+          data: { available: true, kind: 'article', label: 'Fetch Article', collectorId: 'web' },
+          error: null,
+        };
+      }
+      if (type === ARTICLE_MESSAGE_TYPES.RESOLVE_OR_CAPTURE_ACTIVE_TAB) {
+        return {
+          ok: true,
+          data: { conversationId: 1, url: 'https://example.com/a#x', title: 'A' },
+          error: null,
+        };
+      }
+      throw new Error(`unexpected message: ${type}`);
+    });
+
+    openOrFocusExtensionAppTabMock.mockResolvedValue({ id: 99, url: '/app.html' });
+    (window as any).close = vi.fn();
+
+    act(() => {
+      root!.render(createElement(PopupShell));
+    });
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith(UI_MESSAGE_TYPES.GET_ACTIVE_TAB_CAPTURE_STATE, {});
+    });
+
+    const commentsBtn = document.querySelector('[aria-label="Comment"]') as HTMLButtonElement | null;
+    expect(commentsBtn).toBeTruthy();
+
+    await vi.waitFor(() => {
+      expect(commentsBtn!.disabled).toBe(false);
+    });
+
+    act(() => {
+      commentsBtn!.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    });
+
+    const expectedLoc = encodeConversationLoc({
+      source: 'web',
+      conversationKey: 'article:https://example.com/a',
+    });
+    const expectedRoute = buildConversationRouteFromLoc(expectedLoc);
+
+    await vi.waitFor(() => {
+      expect(openOrFocusExtensionAppTabMock).toHaveBeenCalledWith({ route: expectedRoute });
+      expect((window as any).close).toHaveBeenCalledTimes(1);
+    });
+
+    expect(sendMock).not.toHaveBeenCalledWith(UI_MESSAGE_TYPES.OPEN_CURRENT_TAB_INPAGE_COMMENTS_PANEL, expect.anything());
   });
 });

--- a/webclipper/tests/unit/chatwith-comment-actions.test.ts
+++ b/webclipper/tests/unit/chatwith-comment-actions.test.ts
@@ -17,7 +17,7 @@ vi.mock('../../src/services/integrations/chatwith/chatwith-clipboard', () => ({
   writeTextToClipboard: (...args: any[]) => writeTextToClipboardMock(...args),
 }));
 
-vi.mock('../../src/services/integrations/chatwith/chatwith-detail-header-actions', () => ({
+vi.mock('../../src/services/integrations/chatwith/chatwith-comments-header-actions', () => ({
   resolveSingleEnabledChatWithActionLabel: (...args: any[]) => resolveSingleEnabledChatWithActionLabelMock(...args),
 }));
 

--- a/webclipper/tests/unit/chatwith-comments-header-actions.test.ts
+++ b/webclipper/tests/unit/chatwith-comments-header-actions.test.ts
@@ -22,7 +22,7 @@ vi.mock('../../src/services/integrations/chatwith/chatwith-open-port', () => ({
   openChatWithPlatform: (...args: any[]) => openChatWithPlatformMock(...args),
 }));
 
-describe('resolveChatWithDetailHeaderActions', () => {
+describe('resolveChatWithCommentsHeaderActions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     loadChatWithSettingsMock.mockResolvedValue({
@@ -35,10 +35,10 @@ describe('resolveChatWithDetailHeaderActions', () => {
   });
 
   it('passes articleKey context to openPort when conversation is an article', async () => {
-    const { resolveChatWithDetailHeaderActions } =
-      await import('../../src/services/integrations/chatwith/chatwith-detail-header-actions');
+    const { resolveChatWithCommentsHeaderActions } =
+      await import('../../src/services/integrations/chatwith/chatwith-comments-header-actions');
 
-    const actions = await resolveChatWithDetailHeaderActions({
+    const actions = await resolveChatWithCommentsHeaderActions({
       conversation: {
         id: 1,
         sourceType: 'article',
@@ -71,10 +71,10 @@ describe('resolveChatWithDetailHeaderActions', () => {
   });
 
   it('does not pass articleKey context for non-article conversations', async () => {
-    const { resolveChatWithDetailHeaderActions } =
-      await import('../../src/services/integrations/chatwith/chatwith-detail-header-actions');
+    const { resolveChatWithCommentsHeaderActions } =
+      await import('../../src/services/integrations/chatwith/chatwith-comments-header-actions');
 
-    const actions = await resolveChatWithDetailHeaderActions({
+    const actions = await resolveChatWithCommentsHeaderActions({
       conversation: {
         id: 1,
         sourceType: 'chat',

--- a/webclipper/tests/unit/conversations-scene-popup-comments-external.test.ts
+++ b/webclipper/tests/unit/conversations-scene-popup-comments-external.test.ts
@@ -106,14 +106,6 @@ describe('ConversationsScene (popup) comments external override', () => {
         createElement(ConversationsScene, {
           inlineNarrowDetailHeader: true,
           onOpenCommentsExternally: () => openExternalMock(),
-          commentsSidebarRuntime: {
-            sidebarController: { open: (...args: any[]) => sidebarOpenMock(...args) },
-            sidebarSnapshot: {},
-            sidebarSession: {},
-            setLocatorRoot: vi.fn(),
-            getLocatorRoot: vi.fn(),
-            subscribeSidebarClose: () => () => {},
-          },
         } as any),
       );
     });
@@ -135,4 +127,3 @@ describe('ConversationsScene (popup) comments external override', () => {
     cleanupDom();
   });
 });
-

--- a/webclipper/tests/unit/conversations-scene-popup-comments-external.test.ts
+++ b/webclipper/tests/unit/conversations-scene-popup-comments-external.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, createElement } from 'react';
+import ReactDOM from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+
+const openCommentsMock = vi.fn();
+const openExternalMock = vi.fn();
+const sidebarOpenMock = vi.fn();
+
+vi.mock('../../src/ui/shared/hooks/useIsNarrowScreen', () => ({
+  useIsNarrowScreen: () => true,
+}));
+
+vi.mock('../../src/ui/shared/hooks/useNarrowListDetailCommentsRoute', () => ({
+  useNarrowListDetailCommentsRoute: () => ({
+    route: 'detail',
+    openDetail: vi.fn(),
+    openComments: (...args: any[]) => openCommentsMock(...args),
+    returnToDetail: vi.fn(),
+    returnToList: vi.fn(),
+    listRestoreKey: 'k',
+  }),
+}));
+
+vi.mock('../../src/viewmodels/conversations/conversations-context', () => ({
+  useConversationsApp: () => ({
+    selectedConversation: {
+      id: 1,
+      source: 'web',
+      sourceType: 'article',
+      conversationKey: 'article:https://example.com/a',
+      url: 'https://example.com/a',
+      title: 'A',
+    },
+    openConversationExternalBySourceKey: vi.fn(),
+    openConversationExternalById: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/ui/conversations/ConversationListPane', () => ({
+  ConversationListPane: () => createElement('div', { 'data-list': '1' }),
+}));
+
+vi.mock('../../src/ui/conversations/ArticleCommentsSection', () => ({
+  ArticleCommentsSection: () => createElement('div', { 'data-comments': '1' }),
+}));
+
+vi.mock('../../src/ui/conversations/ConversationDetailPane', () => ({
+  ConversationDetailPane: (props: any) =>
+    createElement(
+      'button',
+      {
+        type: 'button',
+        'data-detail-comment': '1',
+        onClick: () => props?.onTriggerCommentsSidebar?.(),
+      },
+      'comment',
+    ),
+}));
+
+import { ConversationsScene } from '../../src/ui/conversations/ConversationsScene';
+
+function setupDom() {
+  const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+    url: 'https://example.com/',
+    pretendToBeVisual: true,
+  });
+
+  Object.defineProperty(globalThis, 'window', { configurable: true, value: dom.window });
+  Object.defineProperty(globalThis, 'document', { configurable: true, value: dom.window.document });
+  Object.defineProperty(globalThis, 'navigator', { configurable: true, value: dom.window.navigator });
+  Object.defineProperty(globalThis, 'HTMLElement', { configurable: true, value: dom.window.HTMLElement });
+  Object.defineProperty(globalThis, 'Node', { configurable: true, value: dom.window.Node });
+  Object.defineProperty(globalThis, 'MutationObserver', {
+    configurable: true,
+    value: dom.window.MutationObserver,
+  });
+  Object.defineProperty(globalThis, 'Event', { configurable: true, value: dom.window.Event });
+  Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+    configurable: true,
+    value: true,
+  });
+}
+
+function cleanupDom() {
+  delete (globalThis as any).window;
+  delete (globalThis as any).document;
+  delete (globalThis as any).navigator;
+  delete (globalThis as any).HTMLElement;
+  delete (globalThis as any).Node;
+  delete (globalThis as any).MutationObserver;
+  delete (globalThis as any).Event;
+  delete (globalThis as any).IS_REACT_ACT_ENVIRONMENT;
+}
+
+describe('ConversationsScene (popup) comments external override', () => {
+  it('prefers onOpenCommentsExternally over narrow comments route', () => {
+    setupDom();
+    openCommentsMock.mockReset();
+    openExternalMock.mockReset();
+    sidebarOpenMock.mockReset();
+
+    const root = ReactDOM.createRoot(document.getElementById('root')!);
+    act(() => {
+      root.render(
+        createElement(ConversationsScene, {
+          inlineNarrowDetailHeader: true,
+          onOpenCommentsExternally: () => openExternalMock(),
+          commentsSidebarRuntime: {
+            sidebarController: { open: (...args: any[]) => sidebarOpenMock(...args) },
+            sidebarSnapshot: {},
+            sidebarSession: {},
+            setLocatorRoot: vi.fn(),
+            getLocatorRoot: vi.fn(),
+            subscribeSidebarClose: () => () => {},
+          },
+        } as any),
+      );
+    });
+
+    const commentBtn = document.querySelector('[data-detail-comment="1"]') as HTMLButtonElement | null;
+    expect(commentBtn).toBeTruthy();
+
+    act(() => {
+      commentBtn!.click();
+    });
+
+    expect(openExternalMock).toHaveBeenCalledTimes(1);
+    expect(openCommentsMock).toHaveBeenCalledTimes(0);
+    expect(sidebarOpenMock).toHaveBeenCalledTimes(0);
+
+    act(() => {
+      root.unmount();
+    });
+    cleanupDom();
+  });
+});
+

--- a/webclipper/tests/unit/threaded-comments-panel-auto-attach-selection.test.ts
+++ b/webclipper/tests/unit/threaded-comments-panel-auto-attach-selection.test.ts
@@ -241,8 +241,7 @@ describe('Threaded comments panel auto-attach selection trigger', () => {
     await flushReactScheduler();
 
     const quoteEl = shadow.querySelector('.webclipper-inpage-comments-panel__quote') as HTMLElement | null;
-    expect(quoteEl).toBeTruthy();
-    expect((quoteEl as HTMLElement).style.display).toBe('none');
+    expect(quoteEl).toBeFalsy();
 
     document.dispatchEvent(new window.Event('selectionchange'));
     document.dispatchEvent(new window.Event('pointerup'));


### PR DESCRIPTION
This pull request refactors how "Chat with" actions are handled in the UI, moving them out of the generic "tools" slot in detail headers and consolidating their logic and UI placement to the comments sidebar. It also updates the popup and app shell to open the comments sidebar externally in the extension app, and improves test coverage and mocks. The changes clarify the separation of concerns between local tools and integration actions, making the UI and codebase more maintainable.

**Refactor and separation of "Chat with" actions:**

- Moved "Chat with" actions out of the `tools` slot in the detail header. The `tools` slot is now reserved for local tool actions (e.g., `cache-images`), and "Chat with" is only available in the comments sidebar UI. This is reflected in both documentation and code logic. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L60-R61) [[2]](diffhunk://#diff-8965af52ce3835f1c0fa497b1ab47f1509ce4f48b81c7fac0856302329417c63L352) [[3]](diffhunk://#diff-8965af52ce3835f1c0fa497b1ab47f1509ce4f48b81c7fac0856302329417c63L364-R363)
- Renamed and refactored related files and functions from `chatwith-detail-header-actions` to `chatwith-comments-header-actions`, and updated all imports and usages accordingly. [[1]](diffhunk://#diff-5e2cbc4c4a92b84e64900f9573b63ae9282c6191c35896abe13b7dbc5015f37fL3-R3) [[2]](diffhunk://#diff-a529922274479250b4cec00f090b9d8dbccee21e5f2bdf1ddf6a6e63861e9591L91-R91) [[3]](diffhunk://#diff-d23f41a36a3e171c7882b02e8c703f3f8fe1ac7e76bd881b28b4b4b7e822e921L20-R22) [[4]](diffhunk://#diff-d23f41a36a3e171c7882b02e8c703f3f8fe1ac7e76bd881b28b4b4b7e822e921L465-R465) [[5]](diffhunk://#diff-7b28418365a5e3fde85337c98dbd9cbab01fabc2760d764282f702eefd89d4a9L19-R21) [[6]](diffhunk://#diff-7b28418365a5e3fde85337c98dbd9cbab01fabc2760d764282f702eefd89d4a9L151-R151)

**Popup and comments sidebar integration:**

- Updated the popup to use a new hook (`usePopupOpenAppCommentsConversation`) that opens the comments sidebar externally in the extension app, instead of opening an in-page sidebar. This includes new logic to resolve the current article and route. [[1]](diffhunk://#diff-c6cd93dc090c0a9ff09146cd9949e4f51a46a8a637f743ec0895ffab492fdab2R6-R14) [[2]](diffhunk://#diff-c6cd93dc090c0a9ff09146cd9949e4f51a46a8a637f743ec0895ffab492fdab2L112-R136) [[3]](diffhunk://#diff-c6cd93dc090c0a9ff09146cd9949e4f51a46a8a637f743ec0895ffab492fdab2L259-R272) [[4]](diffhunk://#diff-5d84dd2471a76a4286a6b31156bf67ae4125fc371e7e2c4c30d2b88e3b3d95c7R4-R8) [[5]](diffhunk://#diff-5d84dd2471a76a4286a6b31156bf67ae4125fc371e7e2c4c30d2b88e3b3d95c7R25-R30) [[6]](diffhunk://#diff-5d84dd2471a76a4286a6b31156bf67ae4125fc371e7e2c4c30d2b88e3b3d95c7L37-R47) [[7]](diffhunk://#diff-5d84dd2471a76a4286a6b31156bf67ae4125fc371e7e2c4c30d2b88e3b3d95c7L108-R127)

**UI and props updates:**

- Added a new prop `onOpenCommentsExternally` to `ConversationsScene`, and updated logic to call this when appropriate, allowing external opening of the comments sidebar from the popup. [[1]](diffhunk://#diff-f06656569b40438eddf887a905947d52ba811524d80ce3217a45ab5d5290dea2R33) [[2]](diffhunk://#diff-f06656569b40438eddf887a905947d52ba811524d80ce3217a45ab5d5290dea2R64) [[3]](diffhunk://#diff-f06656569b40438eddf887a905947d52ba811524d80ce3217a45ab5d5290dea2L90-R92) [[4]](diffhunk://#diff-f06656569b40438eddf887a905947d52ba811524d80ce3217a45ab5d5290dea2R172-R175)

**Testing improvements:**

- Updated smoke tests and mocks to accommodate the new logic for opening the comments sidebar and to fix potential issues with undefined text content. [[1]](diffhunk://#diff-81c7809103f8bcc4091f0fa2a3ccb3a64aac50cb9185a29286e6914040b5df37L372-R372) [[2]](diffhunk://#diff-81c7809103f8bcc4091f0fa2a3ccb3a64aac50cb9185a29286e6914040b5df37L469-R469) [[3]](diffhunk://#diff-81c7809103f8bcc4091f0fa2a3ccb3a64aac50cb9185a29286e6914040b5df37L478-R478) [[4]](diffhunk://#diff-20e8633227b894710ca98164b3c42fe306100f59cd8b37952d763cec9ebc3ccbR7-R9) [[5]](diffhunk://#diff-20e8633227b894710ca98164b3c42fe306100f59cd8b37952d763cec9ebc3ccbR22-R29) [[6]](diffhunk://#diff-20e8633227b894710ca98164b3c42fe306100f59cd8b37952d763cec9ebc3ccbR166-R169)