### PR TITLE
Avoid global tokens CSS pollution in Firefox

### DIFF
--- a/webclipper/src/entrypoints/content.ts
+++ b/webclipper/src/entrypoints/content.ts
@@ -1,5 +1,3 @@
-import '@ui/styles/tokens.css';
-
 import { createContentController } from '@services/bootstrap/content-controller.ts';
 import { registerCurrentPageCaptureContentHandlers } from '@services/bootstrap/current-page-capture-content-handlers.ts';
 import { createCurrentPageCaptureService } from '@services/bootstrap/current-page-capture.ts';

--- a/webclipper/src/ui/inpage/inpage-button-shadow.ts
+++ b/webclipper/src/ui/inpage/inpage-button-shadow.ts
@@ -1,4 +1,5 @@
 import inpageButtonCssRaw from '@ui/styles/inpage-button.css?raw';
+import tokensCssRaw from '@ui/styles/tokens.css?raw';
 type InpageRuntime = { getURL?: (path: string) => string } | null;
 
 const INPAGE_BTN_ID = 'webclipper-inpage-btn';
@@ -18,6 +19,10 @@ const EASTER_DURATION_MS = Object.freeze({
   7: 1100,
 });
 
+function toHostTokensCss(css: string) {
+  return css.replaceAll(':root', ':host');
+}
+
 function toButtonHostCss(css: string) {
   return css
     .replaceAll('.webclipper-inpage-btn:hover', ':host(:hover)')
@@ -31,7 +36,12 @@ function toButtonHostCss(css: string) {
     .replace(/\.webclipper-inpage-btn(?!_)/g, ':host');
 }
 
-const BUTTON_SHADOW_CSS = toButtonHostCss(String(inpageButtonCssRaw || ''));
+const BUTTON_SHADOW_CSS = [
+  toHostTokensCss(String(tokensCssRaw || '')),
+  toButtonHostCss(String(inpageButtonCssRaw || '')),
+]
+  .filter(Boolean)
+  .join('\n');
 
 let runtime: InpageRuntime = null;
 

--- a/webclipper/src/ui/inpage/inpage-tip-shadow.ts
+++ b/webclipper/src/ui/inpage/inpage-tip-shadow.ts
@@ -1,11 +1,19 @@
 import inpageTipCssRaw from '@ui/styles/inpage-tip.css?raw';
+import tokensCssRaw from '@ui/styles/tokens.css?raw';
 const BUBBLE_ID = 'webclipper-inpage-bubble';
 const INPAGE_BTN_ID = 'webclipper-inpage-btn';
 const VISIBLE_MS = 1800;
 const ANIM_CLASS = 'is-enter';
 const VIEWPORT_PAD = 10;
 const ANCHOR_GAP = 10;
-const BUBBLE_SHADOW_CSS = String(inpageTipCssRaw || '');
+
+function toHostTokensCss(css: string) {
+  return css.replaceAll(':root', ':host');
+}
+
+const BUBBLE_SHADOW_CSS = [toHostTokensCss(String(tokensCssRaw || '')), String(inpageTipCssRaw || '')]
+  .filter(Boolean)
+  .join('\n');
 
 type TipKind = 'default' | 'error';
 


### PR DESCRIPTION
Prevent overriding site CSS variables in Firefox by injecting tokens into inpage Shadow DOM styles instead of importing tokens.css directly in the main content script.