### PR TITLE
Skip store publish for prerelease tags

### DIFF
--- a/.github/workflows/webclipper-amo-publish.yml
+++ b/.github/workflows/webclipper-amo-publish.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   publish_amo:
     runs-on: ubuntu-latest
+    if: ${{ !(contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc')) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/webclipper-cws-publish.yml
+++ b/.github/workflows/webclipper-cws-publish.yml
@@ -30,6 +30,7 @@ permissions:
 jobs:
   publish_cws:
     runs-on: ubuntu-latest
+    if: ${{ !(contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc')) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/webclipper-edge-publish.yml
+++ b/.github/workflows/webclipper-edge-publish.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   publish_edge_addons:
     runs-on: ubuntu-latest
+    if: ${{ !(contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc')) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
Prevent publish workflows for AMO, CWS, and Edge from running on prerelease tags such as alpha, beta, and rc. This change ensures that only GitHub assets are built for these tags.