### PR TITLE
Fix comment composer behavior and shortcuts

### DIFF
--- a/webclipper/src/services/comments/sidebar/article-comments-sidebar-controller.ts
+++ b/webclipper/src/services/comments/sidebar/article-comments-sidebar-controller.ts
@@ -160,6 +160,8 @@ export function createArticleCommentsSidebarController(input: {
           commentText: value,
           locator: quoteText && pendingRootLocator ? pendingRootLocator : null,
         });
+        composerSelectionRequestSeq += 1;
+        session.setQuoteText('');
         pendingRootLocator = null;
         await refresh();
         const createdRootId = Number(created?.id);

--- a/webclipper/src/ui/comments/panel.ts
+++ b/webclipper/src/ui/comments/panel.ts
@@ -105,7 +105,6 @@ export function mountThreadedCommentsPanel(
   const surfaceBg = String(options.surfaceBg || '').trim();
   let focusComposerSignal = 0;
   let escapeSignal = 0;
-  let shortcutSubmitInFlight = false;
   let noticeTimer: ReturnType<typeof setTimeout> | null = null;
   const handlersRef: { current: ThreadedCommentsPanelHandlers } = {
     current: {
@@ -264,6 +263,8 @@ export function mountThreadedCommentsPanel(
       'textarea.webclipper-inpage-comments-panel__composer-textarea,textarea.webclipper-inpage-comments-panel__reply-textarea',
     ) as HTMLTextAreaElement | null;
     if (!textarea) return;
+    const text = String(textarea.value || '').trim();
+    if (!text) return;
 
     try {
       keyEvent.preventDefault();
@@ -281,57 +282,19 @@ export function mountThreadedCommentsPanel(
       // ignore
     }
 
-    if (shortcutSubmitInFlight || panelStore.getSnapshot().busy) return;
-    const text = String(textarea.value || '').trim();
-    if (!text) return;
-
     if (textarea.classList.contains('webclipper-inpage-comments-panel__composer-textarea')) {
-      const onSave = handlersRef.current.onSave;
-      if (typeof onSave !== 'function') return;
-      shortcutSubmitInFlight = true;
-      void Promise.resolve(onSave(text))
-        .then((result) => {
-          const createdRootId = Number((result as any)?.createdRootId);
-          if (Number.isFinite(createdRootId) && createdRootId > 0) {
-            syncReactUpdate(() => {
-              panelStore.setPendingFocusRootId(Math.round(createdRootId));
-            });
-          }
-          try {
-            textarea.value = '';
-            textarea.dispatchEvent(new Event('input', { bubbles: true }));
-          } catch (_e) {
-            // ignore
-          }
-        })
-        .finally(() => {
-          shortcutSubmitInFlight = false;
-        });
+      syncReactUpdate(() => {
+        panelStore.requestShortcutSubmit({ kind: 'composer', text });
+      });
       return;
     }
 
-    const onReply = handlersRef.current.onReply;
-    if (typeof onReply !== 'function') return;
     const thread = textarea.closest('.webclipper-inpage-comments-panel__thread') as HTMLElement | null;
     const rootId = Number(thread?.getAttribute('data-thread-root-id') || 0);
     if (!Number.isFinite(rootId) || rootId <= 0) return;
-
-    shortcutSubmitInFlight = true;
-    void Promise.resolve(onReply(Math.round(rootId), text))
-      .then(() => {
-        syncReactUpdate(() => {
-          panelStore.setPendingFocusRootId(Math.round(rootId));
-        });
-        try {
-          textarea.value = '';
-          textarea.dispatchEvent(new Event('input', { bubbles: true }));
-        } catch (_e) {
-          // ignore
-        }
-      })
-      .finally(() => {
-        shortcutSubmitInFlight = false;
-      });
+    syncReactUpdate(() => {
+      panelStore.requestShortcutSubmit({ kind: 'reply', rootId: Math.round(rootId), text });
+    });
   };
   const onShadowFocusIn = () => {
     syncReactUpdate(() => {

--- a/webclipper/src/ui/comments/react/ThreadedCommentsPanel.tsx
+++ b/webclipper/src/ui/comments/react/ThreadedCommentsPanel.tsx
@@ -108,6 +108,7 @@ export function ThreadedCommentsPanel({
   const composerTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const composerTextRef = useRef('');
   const lastFocusedComposerSignalRef = useRef(0);
+  const lastFocusedComposerQuoteTextRef = useRef('');
   const lastHandledEscapeSignalRef = useRef(0);
   const lastHandledShortcutSubmitSignalRef = useRef(0);
   const lastAutoSelectionSignatureRef = useRef('');
@@ -301,6 +302,22 @@ export function ThreadedCommentsPanel({
     focusComposer();
     lastFocusedComposerSignalRef.current = signal;
   }, [busy, snapshot.focusComposerSignal]);
+
+  useLayoutEffect(() => {
+    if (!snapshot.open) {
+      lastFocusedComposerQuoteTextRef.current = '';
+      return;
+    }
+    const quoteText = String(snapshot.quoteText || '').trim();
+    if (!quoteText) {
+      lastFocusedComposerQuoteTextRef.current = '';
+      return;
+    }
+    if (busy) return;
+    if (lastFocusedComposerQuoteTextRef.current === quoteText) return;
+    focusComposer();
+    lastFocusedComposerQuoteTextRef.current = quoteText;
+  }, [busy, snapshot.open, snapshot.quoteText]);
 
   useLayoutEffect(() => {
     if (!snapshot.open) {

--- a/webclipper/src/ui/comments/react/ThreadedCommentsPanel.tsx
+++ b/webclipper/src/ui/comments/react/ThreadedCommentsPanel.tsx
@@ -109,6 +109,7 @@ export function ThreadedCommentsPanel({
   const composerTextRef = useRef('');
   const lastFocusedComposerSignalRef = useRef(0);
   const lastHandledEscapeSignalRef = useRef(0);
+  const lastHandledShortcutSubmitSignalRef = useRef(0);
   const lastAutoSelectionSignatureRef = useRef('');
   const pendingAutoSelectionRequestRef = useRef(false);
   const pendingAutoSelectionSignatureRef = useRef('empty');
@@ -405,6 +406,23 @@ export function ThreadedCommentsPanel({
     updateArmedDeleteId(null);
   }, [openCommentChatWithRootId, snapshot.escapeSignal, updateArmedDeleteId]);
 
+  useLayoutEffect(() => {
+    if (!snapshot.open) return;
+    const request = snapshot.shortcutSubmit;
+    const signal = Number(request?.signal || 0);
+    if (!Number.isFinite(signal) || signal <= 0) return;
+    if (signal <= lastHandledShortcutSubmitSignalRef.current) return;
+    if (busy) return;
+    lastHandledShortcutSubmitSignalRef.current = signal;
+    if (request?.kind === 'reply') {
+      const rootId = Number(request.rootId);
+      if (!Number.isFinite(rootId) || rootId <= 0) return;
+      void submitReply(Math.round(rootId), request.text);
+      return;
+    }
+    void submitComposer(request?.text);
+  }, [busy, snapshot.open, snapshot.shortcutSubmit]);
+
   const normalizedItems = Array.isArray(snapshot.comments)
     ? snapshot.comments.filter((item) => Number.isFinite(Number(item?.id)))
     : [];
@@ -444,6 +462,15 @@ export function ThreadedCommentsPanel({
       if (unmountedRef.current) return;
       replyTextsRef.current = { ...replyTextsRef.current, [rootId]: '' };
       setReplyText(rootId, '');
+      try {
+        const textarea = replyTextareaRefs.current[rootId] || null;
+        if (textarea) {
+          textarea.value = '';
+          autosizeTextarea(textarea);
+        }
+      } catch (_error) {
+        // ignore
+      }
       const targetRootId = resolveTargetRootIdForReply(rootId);
       if (targetRootId == null) return;
       pendingReplyFocusRootIdRef.current = targetRootId;
@@ -743,14 +770,6 @@ export function ThreadedCommentsPanel({
             value={composerText}
             onInput={(event) => updateComposerText(event.currentTarget.value)}
             onChange={(event) => updateComposerText(event.currentTarget.value)}
-            onKeyDown={(event) => {
-              if ((event.nativeEvent as KeyboardEvent).isComposing) return;
-              if (event.key !== 'Enter') return;
-              if (!(event.metaKey || event.ctrlKey)) return;
-              if (event.shiftKey || event.altKey) return;
-              event.preventDefault();
-              void submitComposer(event.currentTarget.value);
-            }}
             disabled={false}
           />
           <button
@@ -946,14 +965,6 @@ export function ThreadedCommentsPanel({
                       onChange={(event) => {
                         updateReplyText(rootId, event.currentTarget.value);
                         autosizeTextarea(event.currentTarget);
-                      }}
-                      onKeyDown={(event) => {
-                        if ((event.nativeEvent as KeyboardEvent).isComposing) return;
-                        if (event.key !== 'Enter') return;
-                        if (!(event.metaKey || event.ctrlKey)) return;
-                        if (event.shiftKey || event.altKey) return;
-                        event.preventDefault();
-                        void submitReply(rootId, event.currentTarget.value);
                       }}
                       disabled={false}
                     />

--- a/webclipper/src/ui/comments/react/panel-store.ts
+++ b/webclipper/src/ui/comments/react/panel-store.ts
@@ -14,6 +14,7 @@ export type ThreadedCommentsPanelStore = {
   setNotice: (input: { message: string; visible: boolean }) => void;
   setHasFocusWithinPanel: (value: boolean) => void;
   setPendingFocusRootId: (rootId: number | null) => void;
+  requestShortcutSubmit: (input: { kind: 'composer' | 'reply'; rootId?: number | null; text: string }) => void;
 };
 
 function cloneComments(items: ThreadedCommentItem[]): ThreadedCommentItem[] {
@@ -38,7 +39,9 @@ export function createThreadedCommentsPanelStore(): ThreadedCommentsPanelStore {
     noticeVisible: false,
     hasFocusWithinPanel: false,
     pendingFocusRootId: null,
+    shortcutSubmit: null,
   };
+  let shortcutSubmitSignal = 0;
 
   const listeners = new Set<() => void>();
 
@@ -107,6 +110,21 @@ export function createThreadedCommentsPanelStore(): ThreadedCommentsPanelStore {
       const normalized = Number(rootId);
       patch({
         pendingFocusRootId: Number.isFinite(normalized) && normalized > 0 ? Math.round(normalized) : null,
+      });
+    },
+    requestShortcutSubmit(input) {
+      const kind = input?.kind === 'reply' ? 'reply' : 'composer';
+      const text = String(input?.text || '').trim();
+      if (!text) return;
+      shortcutSubmitSignal += 1;
+      const rootId = Number(input?.rootId);
+      patch({
+        shortcutSubmit: {
+          signal: shortcutSubmitSignal,
+          kind,
+          rootId: kind === 'reply' && Number.isFinite(rootId) && rootId > 0 ? Math.round(rootId) : null,
+          text,
+        },
       });
     },
   };

--- a/webclipper/src/ui/comments/react/types.ts
+++ b/webclipper/src/ui/comments/react/types.ts
@@ -25,6 +25,12 @@ export type ThreadedCommentsPanelSnapshot = {
   noticeVisible: boolean;
   hasFocusWithinPanel: boolean;
   pendingFocusRootId: number | null;
+  shortcutSubmit: {
+    signal: number;
+    kind: 'composer' | 'reply';
+    rootId: number | null;
+    text: string;
+  } | null;
 };
 
 export type ThreadedCommentsPanelProps = {

--- a/webclipper/tests/unit/article-comments-sidebar-controller.test.ts
+++ b/webclipper/tests/unit/article-comments-sidebar-controller.test.ts
@@ -90,7 +90,7 @@ describe('article-comments-sidebar-controller', () => {
     expect(panel.getState().comments.length).toBe(1);
   });
 
-  it('save root: returns structured result, refreshes list, and keeps quote until explicit clear', async () => {
+  it('save root: returns structured result, refreshes list, and clears composer quote', async () => {
     const panel = createMockPanel();
     const session = createCommentSidebarSession(panel.api as any);
 
@@ -119,7 +119,7 @@ describe('article-comments-sidebar-controller', () => {
       locator: null,
     });
     expect(adapter.list).toHaveBeenCalled();
-    expect(session.getSnapshot().quoteText).toBe('Quoted');
+    expect(session.getSnapshot().quoteText).toBe('');
   });
 
   it('updates quote and locator from composer selection requests', async () => {
@@ -166,10 +166,11 @@ describe('article-comments-sidebar-controller', () => {
       commentText: 'root comment',
       locator,
     });
+    expect(session.getSnapshot().quoteText).toBe('');
 
     await handlers.onComposerSelectionRequest({ trigger: 'button' });
     expect(resolveComposerSelection).toHaveBeenNthCalledWith(2, { trigger: 'button' });
-    expect(session.getSnapshot().quoteText).toBe('Quoted from page');
+    expect(session.getSnapshot().quoteText).toBe('');
   });
 
   it('ignores stale composer selection responses and keeps latest result', async () => {

--- a/webclipper/tests/unit/threaded-comments-panel-focus-regression.test.ts
+++ b/webclipper/tests/unit/threaded-comments-panel-focus-regression.test.ts
@@ -118,4 +118,29 @@ describe('Threaded comments panel focus regression', () => {
 
     mounted.cleanup();
   });
+
+  it('focuses the composer after quote text is applied', async () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const mounted = mountThreadedCommentsPanel(host, { overlay: false, showHeader: false });
+    mounted.api.setComments([]);
+
+    const panel = host.querySelector('webclipper-threaded-comments-panel') as HTMLElement | null;
+    expect(panel).toBeTruthy();
+    const shadow = panel!.shadowRoot!;
+
+    const composer = shadow.querySelector(
+      '.webclipper-inpage-comments-panel__composer-textarea',
+    ) as HTMLTextAreaElement | null;
+    expect(composer).toBeTruthy();
+    expect(shadow.activeElement).not.toBe(composer);
+
+    mounted.api.setQuoteText('Quoted passage');
+    await flushReactScheduler();
+
+    expect(shadow.activeElement).toBe(composer);
+
+    mounted.cleanup();
+  });
 });

--- a/webclipper/tests/unit/threaded-comments-panel-shortcuts.test.ts
+++ b/webclipper/tests/unit/threaded-comments-panel-shortcuts.test.ts
@@ -81,7 +81,13 @@ describe('Threaded comments panel shortcuts', () => {
     textarea!.value = 'hello';
 
     textarea!.dispatchEvent(
-      new window.KeyboardEvent('keydown', { key: 'Enter', metaKey: true, bubbles: true, cancelable: true }),
+      new window.KeyboardEvent('keydown', {
+        key: 'Enter',
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+      }),
     );
     await flushPromises();
 
@@ -111,7 +117,13 @@ describe('Threaded comments panel shortcuts', () => {
     textarea!.value = 'reply';
 
     textarea!.dispatchEvent(
-      new window.KeyboardEvent('keydown', { key: 'Enter', metaKey: true, bubbles: true, cancelable: true }),
+      new window.KeyboardEvent('keydown', {
+        key: 'Enter',
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+      }),
     );
     await flushPromises();
 


### PR DESCRIPTION
Reset the reply textarea height after sending a comment, clear the composer quote upon sending, and ensure the composer gains focus when quote text is applied. Unify the submission logic for Cmd/Ctrl+Enter to avoid duplication.