### PR TITLE
fix(comments): restore quote attach + add selection debug

### DIFF
--- a/webclipper/src/services/bootstrap/inpage-comments-panel-content-handlers.ts
+++ b/webclipper/src/services/bootstrap/inpage-comments-panel-content-handlers.ts
@@ -35,6 +35,25 @@ function pickQuoteFromSelection(): string {
   }
 }
 
+function debugSelection(event: string, payload: Record<string, unknown>) {
+  const anyGlobal = globalThis as any;
+  const enabled =
+    anyGlobal.__SYNCNOS_DEBUG_COMMENTS_SELECTION__ === true ||
+    (() => {
+      try {
+        return String(anyGlobal.localStorage?.getItem?.('__SYNCNOS_DEBUG_COMMENTS_SELECTION__') || '') === '1';
+      } catch (_e) {
+        return false;
+      }
+    })();
+  if (!enabled) return;
+  try {
+    console.log('[CommentsSelection][inpage]', event, payload);
+  } catch (_e) {
+    // ignore
+  }
+}
+
 function pickLocatorFromSelection(): any | null {
   try {
     const selection = globalThis.getSelection?.();
@@ -60,11 +79,14 @@ function resolveInpageSelectionPayload(): {
 } {
   const selectionText = pickQuoteFromSelection();
   if (!selectionText) {
+    debugSelection('resolve_selection', { ok: false, reason: 'empty_text' });
     return { selectionText: '', locator: null };
   }
+  const locator = pickLocatorFromSelection();
+  debugSelection('resolve_selection', { ok: true, selectionTextLen: selectionText.length, locatorOk: Boolean(locator) });
   return {
     selectionText,
-    locator: pickLocatorFromSelection(),
+    locator,
   };
 }
 

--- a/webclipper/src/ui/comments/react/ThreadedCommentsPanel.tsx
+++ b/webclipper/src/ui/comments/react/ThreadedCommentsPanel.tsx
@@ -441,6 +441,13 @@ export function ThreadedCommentsPanel({
       scheduleCommit(null);
     };
 
+    const onMouseUp = () => {
+      if (!autoSelectionDirtyRef.current) return;
+      autoSelectionDirtyRef.current = false;
+      debugCommentsSelection('mouseup_commit', {});
+      scheduleCommit(null);
+    };
+
     const onKeyUp = (event: KeyboardEvent) => {
       if (event.shiftKey || event.ctrlKey || event.metaKey || event.altKey) return;
       if (!autoSelectionDirtyRef.current) return;
@@ -451,10 +458,12 @@ export function ThreadedCommentsPanel({
 
     document.addEventListener('selectionchange', onSelectionChange, true);
     document.addEventListener('pointerup', onPointerUp, true);
+    document.addEventListener('mouseup', onMouseUp, true);
     document.addEventListener('keyup', onKeyUp, true);
     return () => {
       document.removeEventListener('selectionchange', onSelectionChange, true);
       document.removeEventListener('pointerup', onPointerUp, true);
+      document.removeEventListener('mouseup', onMouseUp, true);
       document.removeEventListener('keyup', onKeyUp, true);
       autoSelectionDirtyRef.current = false;
       if (pendingAutoSelectionCommitRafRef.current != null) {

--- a/webclipper/src/ui/comments/react/ThreadedCommentsPanel.tsx
+++ b/webclipper/src/ui/comments/react/ThreadedCommentsPanel.tsx
@@ -66,6 +66,25 @@ function buildSelectionSignature(selection: Selection | null | undefined): strin
   return `${text}#${anchorPath}:${anchorOffset}|${focusPath}:${focusOffset}`;
 }
 
+function isCommentsSelectionDebugEnabled(): boolean {
+  const anyGlobal = globalThis as any;
+  if (anyGlobal.__SYNCNOS_DEBUG_COMMENTS_SELECTION__ === true) return true;
+  try {
+    return String(anyGlobal.localStorage?.getItem?.('__SYNCNOS_DEBUG_COMMENTS_SELECTION__') || '') === '1';
+  } catch (_e) {
+    return false;
+  }
+}
+
+function debugCommentsSelection(event: string, payload: Record<string, unknown>) {
+  if (!isCommentsSelectionDebugEnabled()) return;
+  try {
+    console.log('[CommentsSelection]', event, payload);
+  } catch (_e) {
+    // ignore
+  }
+}
+
 export function ThreadedCommentsPanel({
   variant,
   fullWidth,
@@ -228,16 +247,24 @@ export function ThreadedCommentsPanel({
     (trigger: 'button' | 'auto', autoSignature?: string | null) => {
       if (trigger === 'auto') {
         const normalizedSignature = String(autoSignature || 'empty');
-        if (normalizedSignature === 'empty') return;
+        if (normalizedSignature === 'empty') {
+          debugCommentsSelection('auto_skip_empty_signature', {});
+          return;
+        }
         const latestHandlers = readHandlers?.() || snapshot.handlers;
         const handler = latestHandlers.onComposerSelectionRequest;
         if (typeof handler !== 'function') {
           pendingAutoSelectionRequestRef.current = true;
           pendingAutoSelectionSignatureRef.current = normalizedSignature;
+          debugCommentsSelection('auto_defer_no_handler', {});
           return;
         }
-        if (normalizedSignature === lastAutoSelectionSignatureRef.current) return;
+        if (normalizedSignature === lastAutoSelectionSignatureRef.current) {
+          debugCommentsSelection('auto_dedupe_signature', {});
+          return;
+        }
         lastAutoSelectionSignatureRef.current = normalizedSignature;
+        debugCommentsSelection('auto_request', {});
         void Promise.resolve(handler({ trigger })).catch(() => {
           // ignore
         });
@@ -246,6 +273,7 @@ export function ThreadedCommentsPanel({
       const latestHandlers = readHandlers?.() || snapshot.handlers;
       const handler = latestHandlers.onComposerSelectionRequest;
       if (typeof handler !== 'function') return;
+      debugCommentsSelection('button_request', {});
       void Promise.resolve(handler({ trigger })).catch(() => {
         // ignore
       });
@@ -367,17 +395,49 @@ export function ThreadedCommentsPanel({
             nextSignature = 'empty';
           }
         }
+        if (isCommentsSelectionDebugEnabled()) {
+          let textLen = 0;
+          let rangeCount = 0;
+          try {
+            const sel = globalThis.getSelection?.();
+            rangeCount = Number((sel as any)?.rangeCount || 0) || 0;
+            textLen = String(sel?.toString?.() || '').trim().length;
+          } catch (_e) {
+            // ignore
+          }
+          debugCommentsSelection('auto_commit', {
+            signatureKind: nextSignature === 'empty' ? 'empty' : 'non-empty',
+            selectionTextLen: textLen,
+            selectionRangeCount: rangeCount,
+          });
+        }
         requestComposerSelection('auto', nextSignature);
       });
     };
 
     const onSelectionChange = () => {
       autoSelectionDirtyRef.current = true;
+      if (isCommentsSelectionDebugEnabled()) {
+        let textLen = 0;
+        let rangeCount = 0;
+        try {
+          const sel = globalThis.getSelection?.();
+          rangeCount = Number((sel as any)?.rangeCount || 0) || 0;
+          textLen = String(sel?.toString?.() || '').trim().length;
+        } catch (_e) {
+          // ignore
+        }
+        debugCommentsSelection('selectionchange', {
+          selectionTextLen: textLen,
+          selectionRangeCount: rangeCount,
+        });
+      }
     };
 
     const onPointerUp = () => {
       if (!autoSelectionDirtyRef.current) return;
       autoSelectionDirtyRef.current = false;
+      debugCommentsSelection('pointerup_commit', {});
       scheduleCommit(null);
     };
 
@@ -385,6 +445,7 @@ export function ThreadedCommentsPanel({
       if (event.shiftKey || event.ctrlKey || event.metaKey || event.altKey) return;
       if (!autoSelectionDirtyRef.current) return;
       autoSelectionDirtyRef.current = false;
+      debugCommentsSelection('keyup_commit', { key: String(event.key || '') });
       scheduleCommit(null);
     };
 

--- a/webclipper/src/ui/inpage/inpage-comments-panel-shadow.ts
+++ b/webclipper/src/ui/inpage/inpage-comments-panel-shadow.ts
@@ -193,12 +193,32 @@ const inpageCommentChatWithConfig = createThreadedCommentChatWithConfig({
   resolveOpenPort: () => createInpageChatWithOpenPort(),
 });
 
+function isCommentsSelectionDebugEnabled(): boolean {
+  const anyGlobal = globalThis as any;
+  if (anyGlobal.__SYNCNOS_DEBUG_COMMENTS_SELECTION__ === true) return true;
+  try {
+    return String(anyGlobal.localStorage?.getItem?.('__SYNCNOS_DEBUG_COMMENTS_SELECTION__') || '') === '1';
+  } catch (_e) {
+    return false;
+  }
+}
+
+function debugInpagePanel(event: string, payload: Record<string, unknown>) {
+  if (!isCommentsSelectionDebugEnabled()) return;
+  try {
+    console.log('[CommentsSelection][inpage-panel]', event, payload);
+  } catch (_e) {
+    // ignore
+  }
+}
+
 function ensurePanel(): { el: HTMLElement; api: CommentSidebarPanelApi } {
   if (singleton && document.getElementById(PANEL_ID) === singleton.el) return singleton;
 
   const existing = document.getElementById(PANEL_ID) as HTMLElement | null;
   if (existing && (existing as any).__webclipperPanelApi) {
     singleton = { el: existing, api: (existing as any).__webclipperPanelApi as CommentSidebarPanelApi };
+    debugInpagePanel('ensure_existing_panel', { ok: true });
     return singleton;
   }
 
@@ -223,16 +243,22 @@ function ensurePanel(): { el: HTMLElement; api: CommentSidebarPanelApi } {
 
   (el as any).__webclipperPanelApi = api;
   singleton = { el, api };
+  debugInpagePanel('ensure_new_panel', {
+    ok: true,
+    viewportWidth: Number(globalThis.innerWidth || 0) || 0,
+  });
   return singleton;
 }
 
 const apiRef: InpageCommentsPanelApi = {
   open(input) {
     const { api } = ensurePanel();
+    debugInpagePanel('open', { focusComposer: input?.focusComposer === true });
     api.open({ focusComposer: input?.focusComposer === true });
   },
   close() {
     if (!singleton) return;
+    debugInpagePanel('close', {});
     singleton.api.close();
   },
   isOpen() {

--- a/webclipper/src/viewmodels/comments/useArticleCommentsSidebarRuntime.ts
+++ b/webclipper/src/viewmodels/comments/useArticleCommentsSidebarRuntime.ts
@@ -27,25 +27,65 @@ export function useArticleCommentsSidebarRuntime(input: { onClose?: () => void }
   const closeListenersRef = useRef<Set<() => void>>(new Set());
   const locatorRootRef = useRef<Element | null>(null);
 
+  const debugSelection = (event: string, payload: Record<string, unknown>) => {
+    const anyGlobal = globalThis as any;
+    const enabled =
+      anyGlobal.__SYNCNOS_DEBUG_COMMENTS_SELECTION__ === true ||
+      (() => {
+        try {
+          return String(anyGlobal.localStorage?.getItem?.('__SYNCNOS_DEBUG_COMMENTS_SELECTION__') || '') === '1';
+        } catch (_e) {
+          return false;
+        }
+      })();
+    if (!enabled) return;
+    try {
+      console.log('[CommentsSelection][app]', event, payload);
+    } catch (_e) {
+      // ignore
+    }
+  };
+
   const resolveAppSelectionPayload = () => {
     const root = locatorRootRef.current;
-    if (!root) return { selectionText: '', locator: null };
+    if (!root) {
+      debugSelection('resolve_selection', { ok: false, reason: 'missing_locator_root' });
+      return { selectionText: '', locator: null };
+    }
     try {
       const selection = globalThis.getSelection?.();
-      if (!selection || selection.rangeCount <= 0) return { selectionText: '', locator: null };
+      if (!selection || selection.rangeCount <= 0) {
+        debugSelection('resolve_selection', {
+          ok: false,
+          reason: 'no_selection_range',
+          selectionRangeCount: Number((selection as any)?.rangeCount || 0) || 0,
+        });
+        return { selectionText: '', locator: null };
+      }
       const text = String(selection.toString() || '').trim();
-      if (!text) return { selectionText: '', locator: null };
+      if (!text) {
+        debugSelection('resolve_selection', { ok: false, reason: 'empty_text' });
+        return { selectionText: '', locator: null };
+      }
 
       const anchorNode = selection.anchorNode as Node | null;
       const focusNode = selection.focusNode as Node | null;
       if ((anchorNode && !root.contains(anchorNode)) || (focusNode && !root.contains(focusNode))) {
+        debugSelection('resolve_selection', {
+          ok: false,
+          reason: 'selection_outside_locator_root',
+          selectionTextLen: text.length,
+        });
         return { selectionText: '', locator: null };
       }
 
       const range = selection.getRangeAt(0)?.cloneRange?.();
-      if (!range) return { selectionText: text, locator: null };
+      if (!range) {
+        debugSelection('resolve_selection', { ok: true, selectionTextLen: text.length, locatorOk: false });
+        return { selectionText: text, locator: null };
+      }
 
-      return {
+      const payload = {
         selectionText: text,
         locator:
           buildArticleCommentLocatorFromRange({
@@ -54,7 +94,14 @@ export function useArticleCommentsSidebarRuntime(input: { onClose?: () => void }
             range,
           }) ?? null,
       };
+      debugSelection('resolve_selection', {
+        ok: true,
+        selectionTextLen: payload.selectionText.length,
+        locatorOk: Boolean(payload.locator),
+      });
+      return payload;
     } catch (_error) {
+      debugSelection('resolve_selection', { ok: false, reason: 'exception' });
       return { selectionText: '', locator: null };
     }
   };


### PR DESCRIPTION
## What
- Fix: selection auto-attach now commits on `mouseup` as a fallback when `pointerup` is not delivered, so mouse text selection updates the quote area without requiring a keypress.
- Debug: add gated selection tracing logs (off by default) for app.html + inpage.

## How to debug
- Enable: `localStorage.setItem("__SYNCNOS_DEBUG_COMMENTS_SELECTION__","1")` or `globalThis.__SYNCNOS_DEBUG_COMMENTS_SELECTION__ = true`
- Logs: `[CommentsSelection]`, `[CommentsSelection][app]`, `[CommentsSelection][inpage]`, `[CommentsSelection][inpage-panel]`

## Verification
- `npm --prefix webclipper run compile`
- `npm --prefix webclipper run test`
