### PR TITLE
fix: restore imported conversations in filtered list

### DIFF
--- a/webclipper/src/services/conversations/data/storage-idb.ts
+++ b/webclipper/src/services/conversations/data/storage-idb.ts
@@ -20,6 +20,8 @@ let cachedDb: IDBDatabase | null = null;
 let openingDb: Promise<IDBDatabase> | null = null;
 let conversationListStatsCacheKey: string | null = null;
 let conversationListStatsCacheValue: { summary: ConversationListSummary; facets: ConversationListFacets } | null = null;
+let conversationListDerivedKeysBackfilled = false;
+let conversationListDerivedKeysBackfillPromise: Promise<void> | null = null;
 
 async function openDb(): Promise<IDBDatabase> {
   if (cachedDb) return cachedDb;
@@ -46,6 +48,8 @@ export async function __closeDbForTests(): Promise<void> {
     openingDb = null;
     conversationListStatsCacheKey = null;
     conversationListStatsCacheValue = null;
+    conversationListDerivedKeysBackfilled = false;
+    conversationListDerivedKeysBackfillPromise = null;
   }
 }
 
@@ -146,6 +150,45 @@ function toComparableCursor(cursor: ConversationListCursor | null | undefined): 
 function invalidateConversationListStatsCache(): void {
   conversationListStatsCacheKey = null;
   conversationListStatsCacheValue = null;
+}
+
+async function ensureConversationListDerivedKeysBackfilled(): Promise<void> {
+  if (conversationListDerivedKeysBackfilled) return;
+  if (conversationListDerivedKeysBackfillPromise) return await conversationListDerivedKeysBackfillPromise;
+
+  conversationListDerivedKeysBackfillPromise = (async () => {
+    const db = await openDb();
+    const { t, stores } = tx(db, ['conversations'], 'readwrite');
+
+    let changed = false;
+    const request = stores.conversations.openCursor();
+    await new Promise<void>((resolve, reject) => {
+      request.onerror = () => reject(request.error || new Error('cursor failed'));
+      request.onsuccess = () => {
+        const cursor = request.result as IDBCursorWithValue | null;
+        if (!cursor) return resolve();
+        const raw = (cursor.value || {}) as any;
+        const normalized = normalizeConversationListRecord(raw);
+        if (normalized !== raw) {
+          changed = true;
+          cursor.update(normalized as any);
+        }
+        cursor.continue();
+      };
+    });
+
+    await txDone(t);
+    if (changed) invalidateConversationListStatsCache();
+    conversationListDerivedKeysBackfilled = true;
+  })()
+    .catch(() => {
+      conversationListDerivedKeysBackfillPromise = null;
+    })
+    .finally(() => {
+      conversationListDerivedKeysBackfillPromise = null;
+    });
+
+  await conversationListDerivedKeysBackfillPromise;
 }
 
 function isSameLocalDayTimestamp(ts: number, now: Date): boolean {
@@ -926,6 +969,12 @@ async function readConversationListPage(input: {
   cursor?: ConversationListCursor | null;
   limit?: number | null;
 }): Promise<ConversationListPage<Conversation>> {
+  try {
+    await ensureConversationListDerivedKeysBackfilled();
+  } catch (_e) {
+    // ignore repair failures; fall back to best-effort reads
+  }
+
   const query = resolveConversationListQuery(input.queryInput, input.limit);
   const cursor = toComparableCursor(input.cursor);
   const statsKey = `${normalizeListKey(query.sourceKey, LIST_SOURCE_KEY_ALL)}::${normalizeConversationListSiteFilterKey(query.siteKey)}`;

--- a/webclipper/src/services/conversations/data/storage-idb.ts
+++ b/webclipper/src/services/conversations/data/storage-idb.ts
@@ -181,9 +181,7 @@ async function ensureConversationListDerivedKeysBackfilled(): Promise<void> {
     if (changed) invalidateConversationListStatsCache();
     conversationListDerivedKeysBackfilled = true;
   })()
-    .catch(() => {
-      conversationListDerivedKeysBackfillPromise = null;
-    })
+    .catch(() => {})
     .finally(() => {
       conversationListDerivedKeysBackfillPromise = null;
     });
@@ -969,11 +967,7 @@ async function readConversationListPage(input: {
   cursor?: ConversationListCursor | null;
   limit?: number | null;
 }): Promise<ConversationListPage<Conversation>> {
-  try {
-    await ensureConversationListDerivedKeysBackfilled();
-  } catch (_e) {
-    // ignore repair failures; fall back to best-effort reads
-  }
+  await ensureConversationListDerivedKeysBackfilled();
 
   const query = resolveConversationListQuery(input.queryInput, input.limit);
   const cursor = toComparableCursor(input.cursor);

--- a/webclipper/src/services/sync/backup/import.ts
+++ b/webclipper/src/services/sync/backup/import.ts
@@ -129,6 +129,41 @@ function normalizeHttpUrl(raw: unknown): string {
   }
 }
 
+function deriveConversationListSourceKey(record: AnyRecord): string {
+  const source = safeString(record?.source).toLowerCase();
+  return source || 'unknown';
+}
+
+function deriveConversationListSiteKey(record: AnyRecord): string {
+  const normalizedUrl = normalizeHttpUrl(record?.url);
+  if (!normalizedUrl) return 'unknown';
+  try {
+    const host = safeString(new URL(normalizedUrl).hostname).toLowerCase();
+    return host ? `domain:${host}` : 'unknown';
+  } catch (_e) {
+    return 'unknown';
+  }
+}
+
+function normalizeListDerivedKeys(record: AnyRecord): AnyRecord {
+  if (!record || typeof record !== 'object') return record;
+  const existingListSourceKey = safeString(record?.listSourceKey);
+  const existingListSiteKey = safeString(record?.listSiteKey);
+
+  const derivedSourceKey = deriveConversationListSourceKey(record);
+  const nextListSourceKey = derivedSourceKey !== 'unknown' ? derivedSourceKey : existingListSourceKey || 'unknown';
+
+  const derivedSiteKey = deriveConversationListSiteKey(record);
+  const nextListSiteKey = derivedSiteKey !== 'unknown' ? derivedSiteKey : existingListSiteKey || 'unknown';
+
+  if (existingListSourceKey === nextListSourceKey && existingListSiteKey === nextListSiteKey) return record;
+  return {
+    ...(record as any),
+    listSourceKey: nextListSourceKey,
+    listSiteKey: nextListSiteKey,
+  };
+}
+
 function commentBaseKey(input: {
   canonicalUrl: string;
   createdAt: number;
@@ -208,7 +243,7 @@ export async function importBackupLegacyJsonMerge(
       }
 
       const existing: AnyRecord = await reqToPromise(idx.get([source, conversationKey]) as any);
-      const merged = mergeConversationRecord(existing, incoming);
+      const merged = normalizeListDerivedKeys(mergeConversationRecord(existing, incoming));
 
       if (existing && existing.id) {
         merged.id = existing.id;
@@ -516,16 +551,17 @@ export async function importBackupZipV2Merge(
       const merged = mergeConversationRecord(existing, incoming);
       merged.source = source;
       merged.conversationKey = conversationKey;
+      const normalizedMerged = normalizeListDerivedKeys(merged);
 
-      const uk = uniqueConversationKey(merged);
+      const uk = uniqueConversationKey(normalizedMerged);
       if (existing && existing.id) {
-        merged.id = existing.id;
+        normalizedMerged.id = existing.id;
 
-        await reqToPromise(s.conversations.put(merged as any));
+        await reqToPromise(s.conversations.put(normalizedMerged as any));
         uniqueToLocalId.set(uk, Number(existing.id));
         stats.conversationsUpdated += 1;
       } else {
-        const id = await reqToPromise(s.conversations.add(merged as any) as any);
+        const id = await reqToPromise(s.conversations.add(normalizedMerged as any) as any);
         uniqueToLocalId.set(uk, Number(id));
         stats.conversationsAdded += 1;
       }


### PR DESCRIPTION
Fixes a regression where imported conversations were counted in summary/facets but omitted from filtered list pagination due to missing list-derived keys.\n\n- Ensure backup import writes / for imported conversations\n- Add one-time runtime backfill of derived keys before list reads to repair existing imported data\n\nVerification:\n- 