### PR TITLE
fix(webclipper): preserve chat title in ChatGPT Projects

### DIFF
--- a/webclipper/eslint.config.cjs
+++ b/webclipper/eslint.config.cjs
@@ -7,7 +7,15 @@ const eslintConfigPrettier = require('eslint-config-prettier');
 /** @type {import("eslint").Linter.FlatConfig[]} */
 module.exports = [
   {
-    ignores: ['.output/**', '.wxt/**', 'node_modules/**', 'cloudflare-workers/**', 'public/src/vendor/**'],
+    ignores: [
+      '.output/**',
+      '.wxt/**',
+      'dist/**',
+      'dist-firefox/**',
+      'node_modules/**',
+      'cloudflare-workers/**',
+      'public/src/vendor/**',
+    ],
   },
 
   js.configs.recommended,

--- a/webclipper/src/collectors/chatgpt/chatgpt-collector.ts
+++ b/webclipper/src/collectors/chatgpt/chatgpt-collector.ts
@@ -191,12 +191,16 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
 
     if (conversationId) {
       const activeLinks = Array.from(env.document.querySelectorAll("a[aria-current='page'][href]")) as any[];
-      const active = activeLinks.find((a: any) => String(a?.getAttribute?.('href') || '').includes(`/c/${conversationId}`));
+      const active = activeLinks.find((a: any) =>
+        String(a?.getAttribute?.('href') || '').includes(`/c/${conversationId}`),
+      );
       const activeText = active && active.textContent ? String(active.textContent).trim() : '';
       if (activeText) return activeText;
 
       const hrefLinks = Array.from(env.document.querySelectorAll('a[href]')) as any[];
-      const byHref = hrefLinks.find((a: any) => String(a?.getAttribute?.('href') || '').includes(`/c/${conversationId}`));
+      const byHref = hrefLinks.find((a: any) =>
+        String(a?.getAttribute?.('href') || '').includes(`/c/${conversationId}`),
+      );
       const hrefText = byHref && byHref.textContent ? String(byHref.textContent).trim() : '';
       if (hrefText) return hrefText;
     }

--- a/webclipper/src/collectors/chatgpt/chatgpt-collector.ts
+++ b/webclipper/src/collectors/chatgpt/chatgpt-collector.ts
@@ -187,6 +187,20 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
   }
 
   function findTitle(): any {
+    const conversationId = findConversationIdFromUrl();
+
+    if (conversationId) {
+      const activeLinks = Array.from(env.document.querySelectorAll("a[aria-current='page'][href]")) as any[];
+      const active = activeLinks.find((a: any) => String(a?.getAttribute?.('href') || '').includes(`/c/${conversationId}`));
+      const activeText = active && active.textContent ? String(active.textContent).trim() : '';
+      if (activeText) return activeText;
+
+      const hrefLinks = Array.from(env.document.querySelectorAll('a[href]')) as any[];
+      const byHref = hrefLinks.find((a: any) => String(a?.getAttribute?.('href') || '').includes(`/c/${conversationId}`));
+      const hrefText = byHref && byHref.textContent ? String(byHref.textContent).trim() : '';
+      if (hrefText) return hrefText;
+    }
+
     const h = env.document.querySelector('h1');
     const t = h && h.textContent ? h.textContent.trim() : '';
     return t || env.document.title || 'ChatGPT';

--- a/webclipper/tests/collectors/chatgpt-collector.test.ts
+++ b/webclipper/tests/collectors/chatgpt-collector.test.ts
@@ -10,6 +10,31 @@ function setupChatgptDom(html: string, url: string) {
 }
 
 describe('chatgpt-collector', () => {
+  it('uses active conversation title in ChatGPT Projects pages (instead of project name h1)', async () => {
+    const html = `
+      <h1>Research</h1>
+      <nav>
+        <a href="/g/p_1/c/conv_project_1" aria-current="page"><span>GPR signal preprocessing</span></a>
+      </nav>
+      <div data-message-author-role="user"><div class="whitespace-pre-wrap">Q</div></div>
+      <div data-message-author-role="assistant" data-message-id="m_ai_1">
+        <div class="markdown prose"><p>A</p></div>
+      </div>
+    `;
+
+    const dom = setupChatgptDom(html, 'https://chatgpt.com/g/p_1/c/conv_project_1');
+    const env = createCollectorEnv({
+      window: dom.window as any,
+      document: dom.window.document as any,
+      location: dom.window.location as any,
+      normalize: normalizeApi,
+    });
+
+    const snap = (await Promise.resolve(createChatgptCollectorDef(env).collector.capture({ manual: true }))) as any;
+    expect(snap).toBeTruthy();
+    expect(snap.conversation.title).toBe('GPR signal preprocessing');
+  });
+
   it('extracts assistant contentMarkdown from semantic markdown DOM', async () => {
     const html = `
       <article data-testid="conversation-turn-1">


### PR DESCRIPTION
Fixes #408.

## What
- Prefer the active conversation link text (Projects sidebar) as the conversation title.
- Fall back to `h1` / `document.title` when the sidebar link is unavailable.

## Tests
- `npm --prefix webclipper run compile`
- `npm --prefix webclipper run test`
