### PR TITLE
fix(webclipper): exclude Obsidian API key from backups

### DIFF
--- a/webclipper/src/services/sync/backup/backup-utils.ts
+++ b/webclipper/src/services/sync/backup/backup-utils.ts
@@ -15,6 +15,8 @@ const STORAGE_BACKUP_DENYLIST_EXACT = new Set<string>([
   'notion_oauth_token_v1',
   // Not used by default (ensureDefaultNotionOAuthClientId removes it), but keep it out of backups.
   'notion_oauth_client_secret',
+  // Obsidian Local REST API key is a secret even though base URL is safe to export.
+  'obsidian_api_key',
 ]);
 
 function shouldIncludeStorageKeyInBackup(key: string): boolean {

--- a/webclipper/tests/domains/backup-utils.test.ts
+++ b/webclipper/tests/domains/backup-utils.test.ts
@@ -17,7 +17,7 @@ describe('backup backup-utils', () => {
     expect(uniqueConversationKey({ source: '', conversationKey: 'c1' })).toBe('');
   });
 
-  it('filterStorageForBackup keeps all non-sensitive settings', () => {
+  it('filterStorageForBackup keeps non-sensitive settings and removes secrets', () => {
     const filtered = filterStorageForBackup({
       notion_oauth_client_id: 'abc',
       notion_oauth_client_secret: 'secret',
@@ -44,7 +44,6 @@ describe('backup backup-utils', () => {
       chat_with_prompt_template_v1: 'talk',
       chat_with_ai_platforms_v1: [{ id: 'chatgpt', name: 'ChatGPT', url: 'https://chatgpt.com/', enabled: true }],
       obsidian_api_base_url: 'http://127.0.0.1:27123',
-      obsidian_api_key: 'obsidian-key',
     });
   });
 

--- a/webclipper/tests/smoke/backup-utils.test.ts
+++ b/webclipper/tests/smoke/backup-utils.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import * as backupUtils from '@services/sync/backup/backup-utils.ts';
 
 describe('backup-utils', () => {
-  it('filterStorageForBackup keeps all non-sensitive settings', () => {
+  it('filterStorageForBackup keeps non-sensitive settings and removes secrets', () => {
     const filtered = backupUtils.filterStorageForBackup({
       notion_oauth_client_id: 'abc',
       notion_oauth_client_secret: 'secret',
@@ -14,6 +14,7 @@ describe('backup-utils', () => {
       notion_ai_preferred_model_index: 3,
       last_backup_export_at: 1700000000000,
       notion_oauth_token_v1: { accessToken: 'secret' },
+      obsidian_api_base_url: 'http://127.0.0.1:27123',
       obsidian_api_key: 'obsidian-key',
     });
     expect(filtered).toEqual({
@@ -25,7 +26,7 @@ describe('backup-utils', () => {
       popup_source_filter_key: 'all',
       notion_ai_preferred_model_index: 3,
       last_backup_export_at: 1700000000000,
-      obsidian_api_key: 'obsidian-key',
+      obsidian_api_base_url: 'http://127.0.0.1:27123',
     });
   });
 


### PR DESCRIPTION
## Summary
- exclude `obsidian_api_key` from `chrome.storage.local` backup exports
- keep non-sensitive Obsidian settings such as `obsidian_api_base_url` in backups
- update smoke/domain backup utility tests to cover the secret exclusion

## Testing
- Not run locally; changes are covered by existing Vitest backup utility tests updated in this PR.