### PR TITLE
详情页展示字数统计

### DIFF
--- a/src/services/shared/word-count.ts
+++ b/src/services/shared/word-count.ts
@@ -42,4 +42,3 @@ export function countWordsFromMessages(
   if (!parts.length) return 0;
   return countWords(parts.join('\n'));
 }
-

--- a/src/services/shared/word-count.ts
+++ b/src/services/shared/word-count.ts
@@ -1,0 +1,45 @@
+function normalizeText(text: unknown): string {
+  return String(text || '')
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .trim();
+}
+
+export function countWords(text: string): number {
+  const value = normalizeText(text);
+  if (!value) return 0;
+
+  try {
+    const Segmenter = (Intl as any)?.Segmenter;
+    if (typeof Segmenter === 'function') {
+      const segmenter = new Segmenter(undefined, { granularity: 'word' });
+      let count = 0;
+      for (const token of segmenter.segment(value)) {
+        if (token && token.isWordLike) count += 1;
+      }
+      if (count > 0) return count;
+    }
+  } catch (_e) {
+    // ignore and fallback
+  }
+
+  return value.split(/\s+/).filter(Boolean).length;
+}
+
+export function countWordsFromMessages(
+  messages: Array<{ contentText?: string | null; contentMarkdown?: string | null }>,
+): number {
+  const parts: string[] = [];
+  for (const m of messages || []) {
+    const text = normalizeText(m?.contentText);
+    if (text) {
+      parts.push(text);
+      continue;
+    }
+    const markdown = normalizeText(m?.contentMarkdown);
+    if (markdown) parts.push(markdown);
+  }
+  if (!parts.length) return 0;
+  return countWords(parts.join('\n'));
+}
+

--- a/src/ui/conversations/ConversationDetailPane.tsx
+++ b/src/ui/conversations/ConversationDetailPane.tsx
@@ -12,6 +12,7 @@ import { buttonTintClassName, headerButtonClassName } from '@ui/shared/button-st
 import { tooltipAttrs } from '@ui/shared/AppTooltip';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { storageGet, storageOnChanged } from '@services/shared/storage';
+import { countWordsFromMessages } from '@services/shared/word-count';
 import {
   MARKDOWN_READING_PROFILE_STORAGE_KEY,
   normalizeStoredMarkdownReadingProfile,
@@ -188,6 +189,16 @@ export function ConversationDetailPane({
   const urlInputRef = useRef<HTMLInputElement | null>(null);
   const displayedUrl = String((selected as any)?.url || '').trim();
   const [markdownReadingProfile, setMarkdownReadingProfile] = useState(() => normalizeStoredMarkdownReadingProfile(''));
+  const wordCount = useMemo(() => {
+    if (!selected) return null;
+    if (!Array.isArray(detail?.messages) || !detail.messages.length) return null;
+    return countWordsFromMessages(detail.messages);
+  }, [detail?.messages, selected]);
+  const wordCountLabel = t('detailWordCountLabel');
+  const wordCountText =
+    wordCount != null && Number.isFinite(wordCount)
+      ? `${wordCountLabel} ${Math.max(0, Math.floor(wordCount)).toLocaleString()}`
+      : '';
 
   useEffect(() => {
     setUrlEditing(false);
@@ -400,6 +411,15 @@ export function ConversationDetailPane({
                         >
                           {displayedUrl || t('noLinkAvailable')}
                         </button>
+                        {wordCountText ? (
+                          <span
+                            className="tw-inline-flex tw-items-center tw-rounded-[var(--radius-chip)] tw-border tw-border-[var(--border)] tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-extrabold tw-text-[var(--text-secondary)]"
+                            aria-label={wordCountText}
+                            {...tooltipAttrs(wordCountText)}
+                          >
+                            {wordCountText}
+                          </span>
+                        ) : null}
                       </>
                     )}
                   </div>
@@ -476,6 +496,18 @@ export function ConversationDetailPane({
             hideHeader ? 'tw-pt-3 md:tw-pt-4' : '',
           ].join(' ')}
         >
+          {wordCountText && (hideHeader || urlEditing) ? (
+            <div className="tw-flex tw-justify-end">
+              <span
+                className="tw-inline-flex tw-items-center tw-rounded-[var(--radius-chip)] tw-border tw-border-[var(--border)] tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-extrabold tw-text-[var(--text-secondary)]"
+                aria-label={wordCountText}
+                {...tooltipAttrs(wordCountText)}
+              >
+                {wordCountText}
+              </span>
+            </div>
+          ) : null}
+
           {hideHeader && isChat ? (
             <div
               className="tw-absolute tw-right-3 tw-top-3 tw-z-30 md:tw-right-4 md:tw-top-4"

--- a/src/ui/i18n/locales/en.ts
+++ b/src/ui/i18n/locales/en.ts
@@ -470,6 +470,7 @@ export const en = {
   detailHeaderCacheImagesCacheHits: 'cache hits',
   detailHeaderCacheImagesNoop: 'No images to cache.',
   detailHeaderCacheImagesFailed: 'Cache images failed',
+  detailWordCountLabel: 'Words',
 
   // Conversation sources / sync feedback
   sourceChatgpt: 'ChatGPT',

--- a/src/ui/i18n/locales/zh.ts
+++ b/src/ui/i18n/locales/zh.ts
@@ -465,6 +465,7 @@ export const zh: { [K in TranslationKey]: string } = {
   detailHeaderCacheImagesCacheHits: '命中缓存',
   detailHeaderCacheImagesNoop: '没有可缓存的图片。',
   detailHeaderCacheImagesFailed: '缓存图片失败',
+  detailWordCountLabel: '字数',
 
   // Conversation sources / sync feedback
   sourceChatgpt: 'ChatGPT',

--- a/tests/services/word-count.test.ts
+++ b/tests/services/word-count.test.ts
@@ -33,4 +33,3 @@ describe('word-count', () => {
     expect(countWordsFromMessages([{ contentText: '' }, { contentMarkdown: 'x y' }])).toBe(2);
   });
 });
-

--- a/tests/services/word-count.test.ts
+++ b/tests/services/word-count.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { countWords, countWordsFromMessages } from '@services/shared/word-count';
+
+const originalSegmenter = (Intl as any).Segmenter;
+
+afterEach(() => {
+  (Intl as any).Segmenter = originalSegmenter;
+});
+
+describe('word-count', () => {
+  it('counts words with Intl.Segmenter when available', () => {
+    expect(countWords('Hello world')).toBe(2);
+  });
+
+  it('falls back to whitespace splitting when Segmenter is unavailable', () => {
+    (Intl as any).Segmenter = undefined;
+    expect(countWords('a  b')).toBe(2);
+  });
+
+  it('prefers contentText over contentMarkdown when aggregating messages', () => {
+    expect(
+      countWordsFromMessages([
+        {
+          contentText: 'a b',
+          contentMarkdown: '00:01 a b',
+        },
+      ]),
+    ).toBe(2);
+  });
+
+  it('uses contentMarkdown when contentText is empty', () => {
+    expect(countWordsFromMessages([{ contentText: '' }, { contentMarkdown: 'x y' }])).toBe(2);
+  });
+});
+


### PR DESCRIPTION
## 背景
- DetailView 仅展示消息内容本身，没有任何长度指标，用户无法在进入详情后快速判断文章/对话/字幕的内容体量。
- 字数统计逻辑曾仅出现在文章抓取的内部实现里，缺少可复用的统一入口，导致无法对“对话/字幕”等非文章类型在 DetailView 做一致统计。

## 变更
### 字数统计（Service）
- 改了什么：新增 `countWords()`/`countWordsFromMessages()`，对 `detail.messages[]` 做聚合统计；统计时优先使用 `contentText`，为空才回退 `contentMarkdown`。
- 为什么这样改：旧实现没有可复用的统计能力，且对非文章类型缺乏统一口径；聚合时优先 `contentText` 能避免把字幕时间戳或 markdown 语法误计入。
- 关键实现细节：优先使用 `Intl.Segmenter({ granularity: "word" })` 统计 `isWordLike` token；不可用或异常时回退到按空白切分计数。

### DetailView 展示（UI）
- 改了什么：在 `ConversationDetailPane` 基于 `countWordsFromMessages(detail.messages)` 计算字数，并在标题下方 URL 行右侧展示 badge。
- 为什么这样改：DetailView 过去没有长度提示；把统计绑定到 `detail.messages` 能覆盖文章/对话/字幕等所有 detail 类型（所见即所得）。
- 关键实现细节：
  - 仅在 `detail.messages` 存在且非空时展示。
  - 为避免 URL 编辑态布局拥挤，编辑态不在 header 内插入 badge，而是在正文顶部显示同款 badge；当 `hideHeader` 时同样在正文顶部显示。

### 文案与可测试性
- 改了什么：增加 `detailWordCountLabel`（en/zh），并为统计工具补齐单测（含 Segmenter 不可用时的 fallback 与 messages 聚合规则）。
- 为什么这样改：避免 UI 内硬编码文案；同时确保统计口径在不同运行环境下稳定。

## 测试
- 运行 `rtk npm run compile`，期望 TypeScript 编译检查通过。
- 运行 `rtk npm run test`，期望新增 `word-count` 单测通过，且全量测试通过。
- 运行 `rtk npm run build`，期望产物构建成功。
- 打开任意已保存的文章/对话/字幕条目进入 DetailView，期望 URL 行右侧出现“字数/Words <n>”badge，并随切换条目更新。
- 点击 URL 进入编辑态（出现输入框）并退出编辑态，期望编辑态下 header 不被 badge 挤压，同时正文顶部仍能看到字数 badge。