### PR TITLE
增强 ChatWith 模板与修复微信代码块采集

### DIFF
--- a/src/collectors/web/article-extract/markdown-turndown.ts
+++ b/src/collectors/web/article-extract/markdown-turndown.ts
@@ -64,6 +64,22 @@ function createTurndownService() {
   });
   applyTurndownGfm(turndown);
 
+  function extractPreformattedText(pre: HTMLElement) {
+    const directChildren = Array.from(pre.children || []);
+    const directCodeChildren = directChildren.filter(
+      (child) => String((child as any)?.tagName || '').toLowerCase() === 'code',
+    ) as HTMLElement[];
+
+    // WeChat rich_media "code snippet" renders each line in its own <code> sibling.
+    // Turndown's default "pre" handling (and our previous rule) only captured the first <code>.
+    if (directCodeChildren.length > 1) {
+      return directCodeChildren.map((el) => String(el.textContent || '')).join('\n');
+    }
+
+    const code = pre?.querySelector?.('code');
+    return String(code?.textContent || pre?.textContent || '');
+  }
+
   function isInsideTable(node: Node | null): boolean {
     const el = node && (node as any).nodeType === 1 ? (node as Element) : null;
     if (!el || typeof (el as any).closest !== 'function') return false;
@@ -103,7 +119,8 @@ function createTurndownService() {
       const pre = node as HTMLElement;
       const code = pre?.querySelector?.('code');
       const language = detectCodeLanguage(pre, code);
-      const value = String(code?.textContent || pre?.textContent || '')
+      const value = extractPreformattedText(pre)
+        .replace(/\u00a0/g, ' ')
         .replace(/\r\n/g, '\n')
         .trim();
       if (!value) return '\n';

--- a/src/services/integrations/chatwith/chatwith-settings.ts
+++ b/src/services/integrations/chatwith/chatwith-settings.ts
@@ -2,6 +2,8 @@ import { storageGet, storageSet } from '@platform/storage/local';
 import { formatConversationMarkdown } from '@services/conversations/domain/markdown';
 import { getImageCacheAssetById } from '@services/conversations/data/image-cache-read';
 import type { Conversation, ConversationDetail } from '@services/conversations/domain/models';
+import { buildFeishuDocUrl } from '@services/integrations/openin/feishu-openin';
+import { buildNotionPageUrl } from '@services/integrations/openin/notion-openin';
 import { t } from '@i18n';
 
 export type ChatWithAiPlatform = {
@@ -324,6 +326,8 @@ export async function buildChatWithPayload(
     article_url: getConversationUrl(conversation),
     article_content: articleContent,
     conversation_markdown: conversationMarkdown,
+    notion_url: buildNotionPageUrl(conversation?.notionPageId),
+    feishu_url: buildFeishuDocUrl(conversation?.feishuDocId),
   };
 
   const rendered = renderChatWithTemplate(String(promptTemplate || ''), vars);

--- a/src/ui/i18n/locales/en.ts
+++ b/src/ui/i18n/locales/en.ts
@@ -389,7 +389,7 @@ export const en = {
   chatWithPromptTemplateLabel: 'Prompt template',
   chatWithPromptTemplateAria: 'Prompt template',
   chatWithPromptTemplateHint:
-    'Variables: article_content, article_title, article_url, conversation_markdown. Prefer {{article_content}} style placeholders.',
+    'Variables (prefer {{var}} placeholders): article_title (title), article_url (source URL), article_content (main content), conversation_markdown (full Markdown), notion_url (synced Notion page URL; empty if not synced), feishu_url (synced Feishu doc URL; empty if not synced).',
   chatWithPlatformsLabel: 'Platforms',
   chatWithPlatformsEnabled: 'Enabled',
   chatWithPlatformNameAriaPrefix: 'Platform name',

--- a/src/ui/i18n/locales/en.ts
+++ b/src/ui/i18n/locales/en.ts
@@ -388,8 +388,16 @@ export const en = {
   chatWithSectionSubtitle: 'The generated prompt is copied to your clipboard and the selected AI site is opened in a new tab. Paste it into the chat box to send.',
   chatWithPromptTemplateLabel: 'Prompt template',
   chatWithPromptTemplateAria: 'Prompt template',
-  chatWithPromptTemplateHint:
-    'Variables (prefer {{var}} placeholders): article_title (title), article_url (source URL), article_content (main content), conversation_markdown (full Markdown), notion_url (synced Notion page URL; empty if not synced), feishu_url (synced Feishu doc URL; empty if not synced).',
+  chatWithPromptTemplateHintToggle: 'Variables (click to expand)',
+  chatWithPromptTemplateHint: [
+    'Variables (prefer {{var}} placeholders):',
+    '- {{article_title}}: title',
+    '- {{article_url}}: source URL',
+    '- {{article_content}}: main content (articles: body; chats: Markdown)',
+    '- {{conversation_markdown}}: full Markdown (title, metadata, messages)',
+    '- {{notion_url}}: synced Notion page URL (empty if not synced)',
+    '- {{feishu_url}}: synced Feishu doc URL (empty if not synced)',
+  ].join('\n'),
   chatWithPlatformsLabel: 'Platforms',
   chatWithPlatformsEnabled: 'Enabled',
   chatWithPlatformNameAriaPrefix: 'Platform name',

--- a/src/ui/i18n/locales/zh.ts
+++ b/src/ui/i18n/locales/zh.ts
@@ -383,8 +383,16 @@ export const zh: { [K in TranslationKey]: string } = {
   chatWithSectionSubtitle: '生成的内容会自动复制到剪贴板，并在新标签页打开所选 AI 平台；粘贴到输入框发送即可。',
   chatWithPromptTemplateLabel: 'Prompt 模板',
   chatWithPromptTemplateAria: 'Prompt 模板',
-  chatWithPromptTemplateHint:
-    '可用变量（推荐 {{var}} 写法）：article_title（标题）、article_url（原始网页 URL）、article_content（正文/主要内容）、conversation_markdown（完整 Markdown）、notion_url（同步到 Notion 后的页面 URL；未同步则为空）、feishu_url（同步到飞书后文档 URL；未同步则为空）。',
+  chatWithPromptTemplateHintToggle: '可用变量（点击展开）',
+  chatWithPromptTemplateHint: [
+    '可用变量（推荐 {{var}} 写法）：',
+    '- {{article_title}}：标题',
+    '- {{article_url}}：原始网页 URL',
+    '- {{article_content}}：正文 / 主要内容（文章为正文；对话为 Markdown）',
+    '- {{conversation_markdown}}：完整 Markdown（包含标题、元信息与消息）',
+    '- {{notion_url}}：同步到 Notion 后的页面 URL（未同步则为空）',
+    '- {{feishu_url}}：同步到飞书后文档 URL（未同步则为空）',
+  ].join('\n'),
   chatWithPlatformsLabel: '平台',
   chatWithPlatformsEnabled: '启用',
   chatWithPlatformNameAriaPrefix: '平台名称',

--- a/src/ui/i18n/locales/zh.ts
+++ b/src/ui/i18n/locales/zh.ts
@@ -384,7 +384,7 @@ export const zh: { [K in TranslationKey]: string } = {
   chatWithPromptTemplateLabel: 'Prompt 模板',
   chatWithPromptTemplateAria: 'Prompt 模板',
   chatWithPromptTemplateHint:
-    '可用变量：article_content、article_title、article_url、conversation_markdown。推荐使用 {{article_content}} 这类占位符。',
+    '可用变量（推荐 {{var}} 写法）：article_title（标题）、article_url（原始网页 URL）、article_content（正文/主要内容）、conversation_markdown（完整 Markdown）、notion_url（同步到 Notion 后的页面 URL；未同步则为空）、feishu_url（同步到飞书后文档 URL；未同步则为空）。',
   chatWithPlatformsLabel: '平台',
   chatWithPlatformsEnabled: '启用',
   chatWithPlatformNameAriaPrefix: '平台名称',

--- a/src/ui/settings/sections/ChatWithAiSection.tsx
+++ b/src/ui/settings/sections/ChatWithAiSection.tsx
@@ -87,9 +87,10 @@ export function ChatWithAiSection(props: {
               onChange={(e) => onChangePromptTemplate(e.target.value)}
               aria-label={t('chatWithPromptTemplateAria')}
             />
-            <div className="tw-text-xs tw-font-semibold tw-text-[var(--text-secondary)] tw-opacity-90">
-              {t('chatWithPromptTemplateHint')}
-            </div>
+            <details className="tw-text-xs tw-font-semibold tw-text-[var(--text-secondary)] tw-opacity-90">
+              <summary className="tw-cursor-pointer tw-select-none">{t('chatWithPromptTemplateHintToggle')}</summary>
+              <div className="tw-mt-1 tw-whitespace-pre-wrap">{t('chatWithPromptTemplateHint')}</div>
+            </details>
           </div>
         </SettingsFormRow>
 

--- a/src/ui/shared/ChatMessageBubble.tsx
+++ b/src/ui/shared/ChatMessageBubble.tsx
@@ -244,8 +244,8 @@ export function ChatMessageBubble({
     '[&_code]:tw-px-[5px] [&_code]:tw-py-[1px] [&_code]:tw-rounded-[var(--radius-inline)] [&_code]:tw-bg-[color-mix(in_srgb,currentColor_12%,transparent)] [&_code]:tw-font-mono',
     '[&_kbd]:tw-inline-flex [&_kbd]:tw-items-center [&_kbd]:tw-rounded-[var(--radius-inline)] [&_kbd]:tw-border [&_kbd]:tw-border-[var(--border)] [&_kbd]:tw-bg-[color-mix(in_srgb,var(--bg-sunken)_55%,var(--bg-card))] [&_kbd]:tw-px-[6px] [&_kbd]:tw-py-[1px] [&_kbd]:tw-font-mono',
 
-    // Code blocks: keep contrast high in both light/dark bubbles.
-    '[&_pre]:tw-mt-0 [&_pre]:tw-mb-2 [&_pre]:tw-px-[10px] [&_pre]:tw-py-[8px] [&_pre]:tw-rounded-[var(--radius-inline)] [&_pre]:tw-border [&_pre]:tw-border-[var(--border)] [&_pre]:tw-bg-[color-mix(in_srgb,var(--bg-sunken)_55%,var(--bg-card))] [&_pre]:tw-overflow-auto',
+    // Code blocks: keep contrast high in both light/dark bubbles (light mode uses white surfaces).
+    '[&_pre]:tw-mt-0 [&_pre]:tw-mb-2 [&_pre]:tw-px-[10px] [&_pre]:tw-py-[8px] [&_pre]:tw-rounded-[var(--radius-inline)] [&_pre]:tw-border [&_pre]:tw-border-[var(--border)] [&_pre]:tw-bg-[color-mix(in_srgb,var(--bg-primary)_80%,var(--border))] [&_pre]:tw-overflow-auto',
     '[&_pre>code]:tw-block [&_pre>code]:tw-p-0 [&_pre>code]:tw-bg-transparent [&_pre>code]:tw-rounded-none',
 
     // Tables can be wider than the viewport; let the table itself scroll instead of the whole bubble.

--- a/tests/collectors/article-extract-markdown.test.ts
+++ b/tests/collectors/article-extract-markdown.test.ts
@@ -70,6 +70,22 @@ describe('article-extract markdown', () => {
     expect(md).not.toContain('data:image/gif');
   });
 
+  it('captures full wechat rich_media code-snippet blocks with multiple <code> siblings', () => {
+    const html = `
+      <section><section class="code-snippet__fix code-snippet__js"><ul class="code-snippet__line-index code-snippet__js"><li></li><li></li><li></li><li></li><li></li></ul><pre class="code-snippet__js" data-lang="markdown"><code><span leaf=""><span class="code-snippet__section"># 寓言写作 Prompt</span></span></code><code><span leaf=""><span class="code-snippet__section">围绕&nbsp;</span><span class="code-snippet__section"><span class="code-snippet__strong">**{concept}**</span></span><span class="code-snippet__section">&nbsp;这个概念，写一则寓言来完整地解释它。要像真正的寓言那样间接讲，不要直接点破。</span></span></code><code><span leaf="">---</span></code><code><span leaf=""><span class="code-snippet__section">## 一、寓言体感</span></span></code><code><span leaf=""><span class="code-snippet__bullet">-</span>&nbsp;<span class="code-snippet__strong">**篇幅**</span>：1000字以内。真正的寓言是精炼的，靠一个核心场景、一两次转折把意思撑起来，不需要铺陈。</span></code></pre></section></section>
+    `;
+
+    const dom = new JSDOM(`<body>${html}</body>`, { url: 'https://mp.weixin.qq.com/s/abc123' });
+    setupDom(dom);
+
+    const md = htmlToMarkdownTurndown(html, 'https://mp.weixin.qq.com/s/abc123');
+    expect(md).toContain('```markdown');
+    expect(md).toContain('# 寓言写作 Prompt');
+    expect(md).toContain('围绕 **{concept}** 这个概念');
+    expect(md).toContain('## 一、寓言体感');
+    expect(md).toContain('- **篇幅**：1000字以内');
+  });
+
   it('converts GitHub-style README table HTML into markdown table with alignment', () => {
     const html = `
       <article class="markdown-body entry-content">

--- a/tests/unit/chat-message-bubble.test.ts
+++ b/tests/unit/chat-message-bubble.test.ts
@@ -65,6 +65,7 @@ describe('ChatMessageBubble', () => {
     const cls = extractMarkdownClass(html);
     expect(cls).toContain('[overflow-wrap:anywhere]');
     expect(cls).toContain('[&_pre]:tw-overflow-auto');
+    expect(cls).toContain('[&_pre]:tw-bg-[color-mix(in_srgb,var(--bg-primary)_80%,var(--border))]');
     expect(cls).toContain('[&_table]:tw-overflow-x-auto');
     expect(cls).toContain('[&_.syncnos-md-image-link]');
     expect(cls).toContain('[&_blockquote]:tw-relative');

--- a/tests/unit/chatwith-payload.test.ts
+++ b/tests/unit/chatwith-payload.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildChatWithPayload } from '../../src/services/integrations/chatwith/chatwith-settings';
+
+describe('buildChatWithPayload', () => {
+  it('renders notion_url and feishu_url when ids exist', async () => {
+    const payload = await buildChatWithPayload(
+      {
+        id: 1,
+        sourceType: 'article',
+        source: 'test',
+        conversationKey: 'article:https://example.com/x',
+        title: 'T',
+        url: 'https://example.com/x',
+        notionPageId: '01234567-89ab-cdef-0123-456789abcdef',
+        feishuDocId: 'docxToken',
+      },
+      {
+        conversationId: 1,
+        messages: [
+          {
+            id: 1,
+            conversationId: 1,
+            messageKey: 'm1',
+            role: 'system',
+            contentText: 'Hello',
+          },
+        ],
+      },
+      'Notion={{notion_url}}\nFeishu={{feishu_url}}\nURL={{article_url}}',
+    );
+
+    expect(payload).toContain('Notion=https://www.notion.so/0123456789abcdef0123456789abcdef');
+    expect(payload).toContain('Feishu=https://www.feishu.cn/docx/docxToken');
+    expect(payload).toContain('URL=https://example.com/x');
+    expect(payload.endsWith('\n')).toBe(true);
+  });
+
+  it('renders empty notion_url/feishu_url when ids are missing', async () => {
+    const payload = await buildChatWithPayload(
+      {
+        id: 1,
+        sourceType: 'article',
+        source: 'test',
+        conversationKey: 'article:https://example.com/x',
+        title: 'T',
+        url: 'https://example.com/x',
+      },
+      {
+        conversationId: 1,
+        messages: [
+          {
+            id: 1,
+            conversationId: 1,
+            messageKey: 'm1',
+            role: 'system',
+            contentText: 'Hello',
+          },
+        ],
+      },
+      'Notion={{notion_url}}\nFeishu={{feishu_url}}',
+    );
+
+    expect(payload).toContain('Notion=');
+    expect(payload).toContain('Feishu=');
+    expect(payload.endsWith('\n')).toBe(true);
+  });
+});
+

--- a/tests/unit/chatwith-payload.test.ts
+++ b/tests/unit/chatwith-payload.test.ts
@@ -66,4 +66,3 @@ describe('buildChatWithPayload', () => {
     expect(payload.endsWith('\n')).toBe(true);
   });
 });
-


### PR DESCRIPTION
## 背景

- **微信富媒体代码块提取只取到第一行**：微信公众号的「代码片段」把每一行渲染为独立的 `<code>` 兄弟节点，而旧规则只用 `querySelector("code")` 取第一个子元素，导致多行代码块采集后只剩首行，后面的内容全部丢失。
- **ChatWith 模板无法引用已同步页面的链接**：会话已同步至 Notion / 飞书时，`notionPageId` / `feishuDocId` 已存储在 conversation 记录中，但 Prompt 模板没有对应变量，用户只能手动拼接 URL。
- **Prompt 变量说明在设置页占据过多空间**：变量列表随功能迭代变长，固定显示一行的 hint 文案已不清晰，且无法折叠。
- **聊天消息代码块在浅色模式下与背景融为一体**：`pre` 元素背景直接使用 `--bg-sunken` 混合色，在浅色主题（白色表面）上对比度不足，代码块边界模糊。

## 变更

### 1. 微信富媒体多 `<code>` 兄弟节点代码块采集

**改了什么**：新增 `extractPreformattedText(pre)` 函数；当 `<pre>` 下存在多个直接 `<code>` 子元素时，按 DOM 顺序提取每个 `<code>` 的 `textContent` 并以 `\n` 拼接，再将结果中的 `\u00a0`（`&nbsp;`）统一替换为普通空格。

**为什么这样改**：旧逻辑 `pre.querySelector("code")` 仅命中第一个 `<code>`，微信富媒体代码片段的多行结构（每行一个 `<code>` 兄弟）无法被覆盖；`\u00a0` 在 Markdown 中不会被当作空白折叠，会导致段落粘连。

**关键实现**：遍历 `pre.children`，按 `tagName === "code"` 筛选直接子节点；仅在 `directCodeChildren.length > 1` 时走新逻辑，否则保持原有 `querySelector("code")` fallback，确保非微信站点行为不变。替换 `\u00a0` 操作作用于整个提取结果，独立于多行分支。

相关测试：`tests/collectors/article-extract-markdown.test.ts`

### 2. ChatWith 模板新增 `notion_url` / `feishu_url` 变量

**改了什么**：在 `buildChatWithPayload` 的模板变量对象中追加 `notion_url` 和 `feishu_url`，值分别由 `buildNotionPageUrl(conversation?.notionPageId)` 和 `buildFeishuDocUrl(conversation?.feishuDocId)` 生成；当对应 ID 不存在时返回空字符串。

**为什么这样改**：用户在 Prompt 中引用同步后页面链接时需要手动拼 URL，易出错且无法跨 Notion / 飞书切换。新变量让模板直接输出对应链接，未同步时安全降级为空串，不影响原有模板行为。

**关键实现**：复用已有的 `buildNotionPageUrl` 和 `buildFeishuDocUrl` 工具函数（来自 `openin` 模块），避免重复 URL 拼接逻辑。i18n hint 同步更新，补充所有可用变量及语义说明。

相关测试：`tests/unit/chatwith-payload.test.ts`

### 3. Prompt 变量说明改为可折叠 `<details>` 显示

**改了什么**：`ChatWithAiSection` 中变量 hint 从固定 `<div>` 改为 `<details>` + `<summary>`，新增 `chatWithPromptTemplateHintToggle` 国际化 key；hint 文案扩展为多行，列出全部变量及用途。

**为什么这样改**：变量数量增加后，固定展示的单行 hint 文案变得冗长且信息密度低，折叠后可按需查看，避免干扰主要操作流。

**关键实现**：`<details>` 元素保持原有 `tw-text-xs` 字号和 secondary 文字色；`<div>` 内容使用 `tw-whitespace-pre-wrap` 保留换行格式。

### 4. 聊天消息代码块背景色适配浅色模式

**改了什么**：`ChatMessageBubble` 中 `pre` 元素的背景色从 `color-mix(in_srgb,var(--bg-sunken)_55%,var(--bg-card))` 改为 `color-mix(in_srgb,var(--bg-primary)_80%,var(--border))`。

**为什么这样改**：浅色模式下 `--bg-sunken` 和 `--bg-card` 均接近白色，混合后对比度不足，代码块边界不可见；新配色引入 `--border` 色调，在保持色系统一的同时提供可感知的背景区分。

**关键实现**：使用 `color-mix` 将 `--bg-primary`（80%）与 `--border`（20%）混合，dark mode 下因 `--bg-primary` 本身较深，结果依然保持合理对比，无需单独处理暗色模式。

相关测试：`tests/unit/chat-message-bubble.test.ts`

## 测试

- 打开任意微信公众号文章，采集包含「代码片段」的多行代码块，期望 Markdown 输出包含全部行，首行后内容不丢失
- 采集含 `\u00a0` 的微信代码片段，期望 Markdown 中无 `\u00a0` 字符，空格正常显示
- 在 ChatWith 模板中使用 `{{notion_url}}` / `{{feishu_url}}`，会话已同步时，期望输出完整 Notion / 飞书页面 URL
- 会话未同步时，期望 `{{notion_url}}` / `{{feishu_url}}` 输出为空字符串，模板其余部分正常渲染
- 打开 ChatWith 设置，期望 Prompt 模板下方显示可折叠「Variables」区域，默认收起，展开后显示全部变量及说明
- 在浅色模式下打开含代码块的聊天消息，期望代码块背景与消息背景有清晰区分