### PR TITLE
会话变更自动同步

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ web-ext.config.ts
 
 .codegraph/
 metadata/
+_temp/

--- a/docs/api.md
+++ b/docs/api.md
@@ -50,6 +50,17 @@
 | `getNotionSyncJobStatus` | 无 | `{ provider: 'notion', job, instanceId }` | 查询后台同步 job 状态（running / done / error 等以 job store 为准） |
 | `clearNotionSyncJobStatus` | 无 | `{ provider: 'notion', job: null, instanceId }` | 清空同步状态，便于 UI 重置提示 |
 
+## 自动同步（Auto Sync）
+
+自动同步是 background 内部能力（不通过 router 暴露新的消息类型）：当会话写入或 comments 变更发生时，会以 debounce 方式自动触发“同步当前会话”。
+
+- **开关**：按 provider 分开存储，默认关闭：
+  - `notion_auto_sync_enabled_v1`
+  - `obsidian_auto_sync_enabled_v1`
+  - `feishu_auto_sync_enabled_v1`
+- **调度与队列**：队列与 alarm 名称集中定义在 `src/services/sync/auto-sync/auto-sync-keys.ts`，并通过 MV3 `alarms` 做一次性唤醒 flush（非定期任务）。
+- **同步范围**：仅同步被影响的 `conversationId`。
+
 ## ITEM_MENTION（$ mention）关键消息
 
 | 消息类型 | 入参关键字段 | 返回 | 说明 |

--- a/docs/modules/webclipper.md
+++ b/docs/modules/webclipper.md
@@ -169,3 +169,15 @@
 - **改 Notion / Obsidian 行为**：先看各 orchestrator，再看 `conversation-kinds.ts` 和 settings store。
 - **改 article 抓取**：先看 `article-fetch.ts`（background 侧注入/重试策略）+ `article-extract/engine.ts`（抽取顺序）+ `article-extract/markdown-turndown.ts`（统一转换），再确认保存后的 `sourceType` 和 message 结构没有变。
 - **改视频字幕采集**：先看 `modules/videos.md`、`video-transcript-interceptor.content.ts`、`video-transcript-bridge.content.ts`、`video-transcript-extract.ts`、`video-transcript-capture.ts`、`clipper-context-menu.ts`，再确认 `sourceType='video'`、`SyncNos-Videos` 以及空字幕提示都没有回退。
+
+## 自动同步（Auto Sync）
+
+自动同步是 **事件驱动** 的：当会话内容写入（包括增量 auto-save）或 article comments 发生变更时，background 会在一个 debounce 窗口后，自动触发对应 provider 的“同步当前会话”。
+
+- **设置位置**：Settings → Notion / Obsidian / Feishu 的同步区域内。
+- **显示规则**：只有当「同步到 XXX」被开启时，才会显示「自动同步」开关。
+- **默认值**：所有 provider 的自动同步都默认关闭。
+- **触发源**：会话 upsert / 写入消息 / 图片回填（backfill）/ comments add-delete-migrate。
+- **同步范围**：仅同步发生变更的 `conversationId`（不会自动全量同步全部会话）。
+- **调度策略**：debounce（当前实现为 60s），并使用 MV3 `alarms` 做一次性唤醒调度（不是定时任务；实际触发时间可能有延迟）。
+- **反馈方式**：复用现有 sync job store，最终在会话列表页的 `ConversationSyncFeedbackNotice` 展示 running / failed / success。

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -14,6 +14,7 @@ module.exports = [
       'dist/**',
       'dist-firefox/**',
       'node_modules/**',
+      '_temp/**',
       'cloudflare-workers/**',
       'public/src/vendor/**',
     ],

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -109,5 +109,15 @@ export default defineBackground(() => {
     // ignore
   }
 
+  // Best-effort flush for any overdue auto-sync queue items. This complements
+  // alarms-based wakeups and helps after extension reload / background restart.
+  try {
+    void services.autoSync.notionScheduler.flush();
+    void services.autoSync.obsidianScheduler.flush();
+    void services.autoSync.feishuScheduler.flush();
+  } catch (_e) {
+    // ignore
+  }
+
   router.start();
 });

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -35,7 +35,7 @@ async function openAboutSectionAfterInstall(): Promise<void> {
 }
 
 export default defineBackground(() => {
-  const services = createBackgroundServices();
+  const services = createBackgroundServices({ getInstanceId: getBackgroundInstanceId });
 
   const router = createBackgroundRouter({
     fallback: (msg) => ({

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -45,10 +45,14 @@ export default defineBackground(() => {
     }),
   });
 
-  registerConversationHandlers(router);
+  registerConversationHandlers(router, {
+    onConversationChanged: (conversationId, reason) => services.autoSync.onConversationChanged(conversationId, reason),
+  });
   registerItemMentionHandlers(router);
   registerChatWithBackgroundHandlers(router);
-  registerArticleCommentsHandlers(router);
+  registerArticleCommentsHandlers(router, {
+    onConversationChanged: (conversationId, reason) => services.autoSync.onConversationChanged(conversationId, reason),
+  });
   registerWebArticleHandlers(router);
   registerChatgptDeepResearchHandlers(router);
   registerNotionSettingsHandlers(router, {

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -22,6 +22,7 @@ import { registerFeishuSettingsHandlers } from '@services/sync/feishu/settings-b
 import { onInstalled } from '@platform/runtime/runtime';
 import { openOrFocusExtensionAppTab } from '@platform/webext/extension-app';
 import { registerClipperContextMenu } from '@platform/context-menus/clipper-context-menu';
+import { onAlarm } from '@platform/alarms/alarms';
 
 let backgroundInstanceId: string | null = null;
 function getBackgroundInstanceId(): string {
@@ -92,6 +93,14 @@ export default defineBackground(() => {
     services?.notionSyncJobStore?.abortRunningJobIfFromOtherInstance?.(id)?.catch?.(() => {});
     obsidianSyncJobStore.abortRunningJobIfFromOtherInstance(id).catch(() => {});
     feishuSyncJobStore.abortRunningJobIfFromOtherInstance(id).catch(() => {});
+  } catch (_e) {
+    // ignore
+  }
+
+  try {
+    onAlarm((alarm) => {
+      void services.autoSync.handleAlarm(String(alarm?.name || ''));
+    });
   } catch (_e) {
     // ignore
   }

--- a/src/platform/alarms/alarms.ts
+++ b/src/platform/alarms/alarms.ts
@@ -67,4 +67,3 @@ export function onAlarm(listener: (alarm: Alarm) => void): () => void {
     }
   };
 }
-

--- a/src/platform/alarms/alarms.ts
+++ b/src/platform/alarms/alarms.ts
@@ -1,0 +1,70 @@
+export type AlarmCreateInfo = {
+  when?: number;
+  delayInMinutes?: number;
+};
+
+export type Alarm = {
+  name: string;
+  scheduledTime?: number;
+};
+
+function getAlarmsApi(): any | null {
+  const anyGlobal = globalThis as any;
+  return anyGlobal.browser?.alarms ?? anyGlobal.chrome?.alarms ?? null;
+}
+
+export function isAlarmsAvailable(): boolean {
+  const api = getAlarmsApi();
+  return !!api?.create && !!api?.onAlarm?.addListener;
+}
+
+export function create(name: string, info: AlarmCreateInfo): boolean {
+  const api = getAlarmsApi();
+  if (!api?.create) return false;
+  try {
+    api.create(name, info);
+    return true;
+  } catch (_e) {
+    return false;
+  }
+}
+
+export async function clear(name: string): Promise<boolean> {
+  const api = getAlarmsApi();
+  if (!api?.clear) return false;
+
+  try {
+    const result = api.clear(name);
+    if (result && typeof result.then === 'function') {
+      return !!(await result);
+    }
+  } catch (_e) {
+    // ignore and fallback to callback style
+  }
+
+  return await new Promise<boolean>((resolve) => {
+    try {
+      api.clear(name, (wasCleared: boolean) => resolve(!!wasCleared));
+    } catch (_e) {
+      resolve(false);
+    }
+  });
+}
+
+export function onAlarm(listener: (alarm: Alarm) => void): () => void {
+  const api = getAlarmsApi();
+  if (!api?.onAlarm?.addListener || !api?.onAlarm?.removeListener) return () => {};
+  try {
+    api.onAlarm.addListener(listener);
+  } catch (_e) {
+    return () => {};
+  }
+  return () => {
+    try {
+      api.onAlarm.removeListener(listener);
+    } catch (_e) {
+      // ignore
+    }
+  };
+}
+

--- a/src/services/bootstrap/background-services.ts
+++ b/src/services/bootstrap/background-services.ts
@@ -23,6 +23,8 @@ import {
 } from '@services/sync/feishu/feishu-sync-orchestrator.ts';
 
 import { conversationKinds } from '@services/protocols/conversation-kinds.ts';
+import { createNotionAutoSyncScheduler, type NotionAutoSyncScheduler } from '@services/sync/auto-sync/notion-auto-sync-scheduler';
+import { NOTION_AUTO_SYNC_DEBOUNCE_ALARM_NAME } from '@services/sync/auto-sync/auto-sync-keys';
 
 export type NotionSyncOrchestrator = {
   syncConversations: (input: { conversationIds?: unknown[]; instanceId: string }) => Promise<unknown>;
@@ -55,11 +57,13 @@ export type BackgroundServices = {
   obsidianSyncOrchestrator: ObsidianSyncOrchestrator;
   feishuSyncOrchestrator: FeishuSyncOrchestrator;
   autoSync: {
+    notionScheduler: NotionAutoSyncScheduler;
+    onConversationChanged: (conversationId: number, reason: string) => Promise<void>;
     handleAlarm: (name: string) => Promise<void>;
   };
 };
 
-export function createBackgroundServices(): BackgroundServices {
+export function createBackgroundServices(deps: { getInstanceId: () => string }): BackgroundServices {
   const notionSyncOrchestrator = createNotionSyncOrchestrator({
     tokenStore: { getToken: getNotionOAuthToken },
     storage: notionBackgroundStorage,
@@ -71,13 +75,25 @@ export function createBackgroundServices(): BackgroundServices {
     jobStore: notionSyncJobStore,
   });
 
+  const notionScheduler = createNotionAutoSyncScheduler({
+    getInstanceId: deps.getInstanceId,
+    notionSyncOrchestrator,
+  });
+
   return {
     articleFetchService,
     conversationKinds,
     notionSyncJobStore,
     notionSyncOrchestrator,
     autoSync: {
-      handleAlarm: async (_name: string) => {},
+      notionScheduler,
+      onConversationChanged: async (conversationId: number, reason: string) => {
+        await notionScheduler.enqueue(conversationId, reason);
+      },
+      handleAlarm: async (name: string) => {
+        if (String(name || '').trim() !== NOTION_AUTO_SYNC_DEBOUNCE_ALARM_NAME) return;
+        await notionScheduler.flush();
+      },
     },
     obsidianSyncOrchestrator: {
       syncConversations: obsidianSyncConversations,

--- a/src/services/bootstrap/background-services.ts
+++ b/src/services/bootstrap/background-services.ts
@@ -23,9 +23,18 @@ import {
 } from '@services/sync/feishu/feishu-sync-orchestrator.ts';
 
 import { conversationKinds } from '@services/protocols/conversation-kinds.ts';
-import { createNotionAutoSyncScheduler, type NotionAutoSyncScheduler } from '@services/sync/auto-sync/notion-auto-sync-scheduler';
-import { createObsidianAutoSyncScheduler, type ObsidianAutoSyncScheduler } from '@services/sync/auto-sync/obsidian-auto-sync-scheduler';
-import { createFeishuAutoSyncScheduler, type FeishuAutoSyncScheduler } from '@services/sync/auto-sync/feishu-auto-sync-scheduler';
+import {
+  createNotionAutoSyncScheduler,
+  type NotionAutoSyncScheduler,
+} from '@services/sync/auto-sync/notion-auto-sync-scheduler';
+import {
+  createObsidianAutoSyncScheduler,
+  type ObsidianAutoSyncScheduler,
+} from '@services/sync/auto-sync/obsidian-auto-sync-scheduler';
+import {
+  createFeishuAutoSyncScheduler,
+  type FeishuAutoSyncScheduler,
+} from '@services/sync/auto-sync/feishu-auto-sync-scheduler';
 import {
   FEISHU_AUTO_SYNC_DEBOUNCE_ALARM_NAME,
   NOTION_AUTO_SYNC_DEBOUNCE_ALARM_NAME,

--- a/src/services/bootstrap/background-services.ts
+++ b/src/services/bootstrap/background-services.ts
@@ -54,6 +54,9 @@ export type BackgroundServices = {
   notionSyncOrchestrator: NotionSyncOrchestrator;
   obsidianSyncOrchestrator: ObsidianSyncOrchestrator;
   feishuSyncOrchestrator: FeishuSyncOrchestrator;
+  autoSync: {
+    handleAlarm: (name: string) => Promise<void>;
+  };
 };
 
 export function createBackgroundServices(): BackgroundServices {
@@ -73,6 +76,9 @@ export function createBackgroundServices(): BackgroundServices {
     conversationKinds,
     notionSyncJobStore,
     notionSyncOrchestrator,
+    autoSync: {
+      handleAlarm: async (_name: string) => {},
+    },
     obsidianSyncOrchestrator: {
       syncConversations: obsidianSyncConversations,
       getSyncStatus: async (input: { instanceId: string }) => getObsidianSyncStatus(input as any),

--- a/src/services/bootstrap/background-services.ts
+++ b/src/services/bootstrap/background-services.ts
@@ -24,7 +24,8 @@ import {
 
 import { conversationKinds } from '@services/protocols/conversation-kinds.ts';
 import { createNotionAutoSyncScheduler, type NotionAutoSyncScheduler } from '@services/sync/auto-sync/notion-auto-sync-scheduler';
-import { NOTION_AUTO_SYNC_DEBOUNCE_ALARM_NAME } from '@services/sync/auto-sync/auto-sync-keys';
+import { createObsidianAutoSyncScheduler, type ObsidianAutoSyncScheduler } from '@services/sync/auto-sync/obsidian-auto-sync-scheduler';
+import { NOTION_AUTO_SYNC_DEBOUNCE_ALARM_NAME, OBSIDIAN_AUTO_SYNC_DEBOUNCE_ALARM_NAME } from '@services/sync/auto-sync/auto-sync-keys';
 
 export type NotionSyncOrchestrator = {
   syncConversations: (input: { conversationIds?: unknown[]; instanceId: string }) => Promise<unknown>;
@@ -58,6 +59,7 @@ export type BackgroundServices = {
   feishuSyncOrchestrator: FeishuSyncOrchestrator;
   autoSync: {
     notionScheduler: NotionAutoSyncScheduler;
+    obsidianScheduler: ObsidianAutoSyncScheduler;
     onConversationChanged: (conversationId: number, reason: string) => Promise<void>;
     handleAlarm: (name: string) => Promise<void>;
   };
@@ -79,6 +81,15 @@ export function createBackgroundServices(deps: { getInstanceId: () => string }):
     getInstanceId: deps.getInstanceId,
     notionSyncOrchestrator,
   });
+  const obsidianScheduler = createObsidianAutoSyncScheduler({
+    getInstanceId: deps.getInstanceId,
+    obsidianSyncOrchestrator: {
+      syncConversations: obsidianSyncConversations,
+      getSyncStatus: async (input: { instanceId: string }) => getObsidianSyncStatus(input as any),
+      clearSyncStatus: async (input: { instanceId: string }) => clearObsidianSyncStatus(input as any),
+      testConnection: testObsidianConnection,
+    },
+  });
 
   return {
     articleFetchService,
@@ -87,12 +98,20 @@ export function createBackgroundServices(deps: { getInstanceId: () => string }):
     notionSyncOrchestrator,
     autoSync: {
       notionScheduler,
+      obsidianScheduler,
       onConversationChanged: async (conversationId: number, reason: string) => {
         await notionScheduler.enqueue(conversationId, reason);
+        await obsidianScheduler.enqueue(conversationId, reason);
       },
       handleAlarm: async (name: string) => {
-        if (String(name || '').trim() !== NOTION_AUTO_SYNC_DEBOUNCE_ALARM_NAME) return;
-        await notionScheduler.flush();
+        const alarmName = String(name || '').trim();
+        if (alarmName === NOTION_AUTO_SYNC_DEBOUNCE_ALARM_NAME) {
+          await notionScheduler.flush();
+          return;
+        }
+        if (alarmName === OBSIDIAN_AUTO_SYNC_DEBOUNCE_ALARM_NAME) {
+          await obsidianScheduler.flush();
+        }
       },
     },
     obsidianSyncOrchestrator: {

--- a/src/services/bootstrap/background-services.ts
+++ b/src/services/bootstrap/background-services.ts
@@ -25,7 +25,12 @@ import {
 import { conversationKinds } from '@services/protocols/conversation-kinds.ts';
 import { createNotionAutoSyncScheduler, type NotionAutoSyncScheduler } from '@services/sync/auto-sync/notion-auto-sync-scheduler';
 import { createObsidianAutoSyncScheduler, type ObsidianAutoSyncScheduler } from '@services/sync/auto-sync/obsidian-auto-sync-scheduler';
-import { NOTION_AUTO_SYNC_DEBOUNCE_ALARM_NAME, OBSIDIAN_AUTO_SYNC_DEBOUNCE_ALARM_NAME } from '@services/sync/auto-sync/auto-sync-keys';
+import { createFeishuAutoSyncScheduler, type FeishuAutoSyncScheduler } from '@services/sync/auto-sync/feishu-auto-sync-scheduler';
+import {
+  FEISHU_AUTO_SYNC_DEBOUNCE_ALARM_NAME,
+  NOTION_AUTO_SYNC_DEBOUNCE_ALARM_NAME,
+  OBSIDIAN_AUTO_SYNC_DEBOUNCE_ALARM_NAME,
+} from '@services/sync/auto-sync/auto-sync-keys';
 
 export type NotionSyncOrchestrator = {
   syncConversations: (input: { conversationIds?: unknown[]; instanceId: string }) => Promise<unknown>;
@@ -60,6 +65,7 @@ export type BackgroundServices = {
   autoSync: {
     notionScheduler: NotionAutoSyncScheduler;
     obsidianScheduler: ObsidianAutoSyncScheduler;
+    feishuScheduler: FeishuAutoSyncScheduler;
     onConversationChanged: (conversationId: number, reason: string) => Promise<void>;
     handleAlarm: (name: string) => Promise<void>;
   };
@@ -90,6 +96,14 @@ export function createBackgroundServices(deps: { getInstanceId: () => string }):
       testConnection: testObsidianConnection,
     },
   });
+  const feishuScheduler = createFeishuAutoSyncScheduler({
+    getInstanceId: deps.getInstanceId,
+    feishuSyncOrchestrator: {
+      syncConversations: feishuSyncConversations,
+      getSyncStatus: async (input: { instanceId: string }) => getFeishuSyncStatus(input as any),
+      clearSyncStatus: async (input: { instanceId: string }) => clearFeishuSyncStatus(input as any),
+    },
+  });
 
   return {
     articleFetchService,
@@ -99,9 +113,11 @@ export function createBackgroundServices(deps: { getInstanceId: () => string }):
     autoSync: {
       notionScheduler,
       obsidianScheduler,
+      feishuScheduler,
       onConversationChanged: async (conversationId: number, reason: string) => {
         await notionScheduler.enqueue(conversationId, reason);
         await obsidianScheduler.enqueue(conversationId, reason);
+        await feishuScheduler.enqueue(conversationId, reason);
       },
       handleAlarm: async (name: string) => {
         const alarmName = String(name || '').trim();
@@ -111,6 +127,10 @@ export function createBackgroundServices(deps: { getInstanceId: () => string }):
         }
         if (alarmName === OBSIDIAN_AUTO_SYNC_DEBOUNCE_ALARM_NAME) {
           await obsidianScheduler.flush();
+          return;
+        }
+        if (alarmName === FEISHU_AUTO_SYNC_DEBOUNCE_ALARM_NAME) {
+          await feishuScheduler.flush();
         }
       },
     },

--- a/src/services/bootstrap/background-services.ts
+++ b/src/services/bootstrap/background-services.ts
@@ -42,6 +42,7 @@ import {
   NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY,
   OBSIDIAN_AUTO_SYNC_DEBOUNCE_ALARM_NAME,
   OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY,
+  type AutoSyncConversationChangedReason,
 } from '@services/sync/auto-sync/auto-sync-keys';
 import { storageGet } from '@services/shared/storage';
 
@@ -79,7 +80,7 @@ export type BackgroundServices = {
     notionScheduler: NotionAutoSyncScheduler;
     obsidianScheduler: ObsidianAutoSyncScheduler;
     feishuScheduler: FeishuAutoSyncScheduler;
-    onConversationChanged: (conversationId: number, reason: string) => Promise<void>;
+    onConversationChanged: (conversationId: number, reason: AutoSyncConversationChangedReason) => Promise<void>;
     handleAlarm: (name: string) => Promise<void>;
   };
 };
@@ -127,7 +128,7 @@ export function createBackgroundServices(deps: { getInstanceId: () => string }):
       notionScheduler,
       obsidianScheduler,
       feishuScheduler,
-      onConversationChanged: async (conversationId: number, reason: string) => {
+      onConversationChanged: async (conversationId: number, reason: AutoSyncConversationChangedReason) => {
         const local = await storageGet([
           NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY,
           OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY,

--- a/src/services/bootstrap/background-services.ts
+++ b/src/services/bootstrap/background-services.ts
@@ -36,10 +36,14 @@ import {
   type FeishuAutoSyncScheduler,
 } from '@services/sync/auto-sync/feishu-auto-sync-scheduler';
 import {
+  FEISHU_AUTO_SYNC_ENABLED_STORAGE_KEY,
   FEISHU_AUTO_SYNC_DEBOUNCE_ALARM_NAME,
   NOTION_AUTO_SYNC_DEBOUNCE_ALARM_NAME,
+  NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY,
   OBSIDIAN_AUTO_SYNC_DEBOUNCE_ALARM_NAME,
+  OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY,
 } from '@services/sync/auto-sync/auto-sync-keys';
+import { storageGet } from '@services/shared/storage';
 
 export type NotionSyncOrchestrator = {
   syncConversations: (input: { conversationIds?: unknown[]; instanceId: string }) => Promise<unknown>;
@@ -124,9 +128,20 @@ export function createBackgroundServices(deps: { getInstanceId: () => string }):
       obsidianScheduler,
       feishuScheduler,
       onConversationChanged: async (conversationId: number, reason: string) => {
-        await notionScheduler.enqueue(conversationId, reason);
-        await obsidianScheduler.enqueue(conversationId, reason);
-        await feishuScheduler.enqueue(conversationId, reason);
+        const local = await storageGet([
+          NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY,
+          OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY,
+          FEISHU_AUTO_SYNC_ENABLED_STORAGE_KEY,
+        ]).catch(() => ({}));
+        if ((local as any)?.[NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY] === true) {
+          void notionScheduler.enqueue(conversationId, reason);
+        }
+        if ((local as any)?.[OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY] === true) {
+          void obsidianScheduler.enqueue(conversationId, reason);
+        }
+        if ((local as any)?.[FEISHU_AUTO_SYNC_ENABLED_STORAGE_KEY] === true) {
+          void feishuScheduler.enqueue(conversationId, reason);
+        }
       },
       handleAlarm: async (name: string) => {
         const alarmName = String(name || '').trim();

--- a/src/services/comments/background/handlers.ts
+++ b/src/services/comments/background/handlers.ts
@@ -14,6 +14,10 @@ import {
   DEFAULT_ABOUT_YOU_USER_NAME,
   normalizeUserName,
 } from '@services/shared/user-profile';
+import {
+  AUTO_SYNC_CONVERSATION_CHANGED_REASONS,
+  type AutoSyncConversationChangedReason,
+} from '@services/sync/auto-sync/auto-sync-keys';
 import { canonicalizeArticleUrl } from '@services/url-cleaning/http-url';
 
 type AnyRouter = {
@@ -24,7 +28,7 @@ type AnyRouter = {
 };
 
 type ArticleCommentsHandlersDeps = {
-  onConversationChanged: (conversationId: number, reason: string) => void | Promise<void>;
+  onConversationChanged: (conversationId: number, reason: AutoSyncConversationChangedReason) => void | Promise<void>;
 };
 
 function fireAndForget(task: void | Promise<void>) {
@@ -73,7 +77,9 @@ export function registerArticleCommentsHandlers(router: AnyRouter, deps: Article
         reason: 'articleCommentAdded',
         conversationId: comment.conversationId,
       });
-      fireAndForget(deps.onConversationChanged(Number(comment.conversationId), 'articleCommentChanged'));
+      fireAndForget(
+        deps.onConversationChanged(Number(comment.conversationId), AUTO_SYNC_CONVERSATION_CHANGED_REASONS.articleCommentChanged),
+      );
     }
 
     return router.ok(comment);
@@ -91,7 +97,7 @@ export function registerArticleCommentsHandlers(router: AnyRouter, deps: Article
           reason: 'articleCommentDeleted',
           conversationId,
         });
-        fireAndForget(deps.onConversationChanged(conversationId, 'articleCommentChanged'));
+        fireAndForget(deps.onConversationChanged(conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.articleCommentChanged));
       } else {
         router.eventsHub?.broadcast(UI_EVENT_TYPES.CONVERSATIONS_CHANGED, {
           reason: 'articleCommentDeleted',
@@ -111,7 +117,7 @@ export function registerArticleCommentsHandlers(router: AnyRouter, deps: Article
       reason: 'articleCommentAttached',
       conversationId,
     });
-    fireAndForget(deps.onConversationChanged(conversationId, 'articleCommentChanged'));
+    fireAndForget(deps.onConversationChanged(conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.articleCommentChanged));
     return router.ok(res);
   });
 
@@ -130,7 +136,7 @@ export function registerArticleCommentsHandlers(router: AnyRouter, deps: Article
         fromCanonicalUrl,
         toCanonicalUrl,
       });
-      fireAndForget(deps.onConversationChanged(conversationId, 'articleCommentChanged'));
+      fireAndForget(deps.onConversationChanged(conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.articleCommentChanged));
     } else {
       router.eventsHub?.broadcast(UI_EVENT_TYPES.CONVERSATIONS_CHANGED, {
         reason: 'articleCommentsMigrated',

--- a/src/services/comments/background/handlers.ts
+++ b/src/services/comments/background/handlers.ts
@@ -78,7 +78,10 @@ export function registerArticleCommentsHandlers(router: AnyRouter, deps: Article
         conversationId: comment.conversationId,
       });
       fireAndForget(
-        deps.onConversationChanged(Number(comment.conversationId), AUTO_SYNC_CONVERSATION_CHANGED_REASONS.articleCommentChanged),
+        deps.onConversationChanged(
+          Number(comment.conversationId),
+          AUTO_SYNC_CONVERSATION_CHANGED_REASONS.articleCommentChanged,
+        ),
       );
     }
 
@@ -97,7 +100,9 @@ export function registerArticleCommentsHandlers(router: AnyRouter, deps: Article
           reason: 'articleCommentDeleted',
           conversationId,
         });
-        fireAndForget(deps.onConversationChanged(conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.articleCommentChanged));
+        fireAndForget(
+          deps.onConversationChanged(conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.articleCommentChanged),
+        );
       } else {
         router.eventsHub?.broadcast(UI_EVENT_TYPES.CONVERSATIONS_CHANGED, {
           reason: 'articleCommentDeleted',
@@ -117,7 +122,9 @@ export function registerArticleCommentsHandlers(router: AnyRouter, deps: Article
       reason: 'articleCommentAttached',
       conversationId,
     });
-    fireAndForget(deps.onConversationChanged(conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.articleCommentChanged));
+    fireAndForget(
+      deps.onConversationChanged(conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.articleCommentChanged),
+    );
     return router.ok(res);
   });
 
@@ -136,7 +143,9 @@ export function registerArticleCommentsHandlers(router: AnyRouter, deps: Article
         fromCanonicalUrl,
         toCanonicalUrl,
       });
-      fireAndForget(deps.onConversationChanged(conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.articleCommentChanged));
+      fireAndForget(
+        deps.onConversationChanged(conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.articleCommentChanged),
+      );
     } else {
       router.eventsHub?.broadcast(UI_EVENT_TYPES.CONVERSATIONS_CHANGED, {
         reason: 'articleCommentsMigrated',

--- a/src/services/comments/background/handlers.ts
+++ b/src/services/comments/background/handlers.ts
@@ -23,7 +23,11 @@ type AnyRouter = {
   eventsHub?: { broadcast: (type: string, payload: unknown) => void };
 };
 
-export function registerArticleCommentsHandlers(router: AnyRouter) {
+type ArticleCommentsHandlersDeps = {
+  onConversationChanged: (conversationId: number, reason: string) => void | Promise<void>;
+};
+
+export function registerArticleCommentsHandlers(router: AnyRouter, deps: ArticleCommentsHandlersDeps) {
   router.register(COMMENTS_MESSAGE_TYPES.LIST_ARTICLE_COMMENTS, async (msg) => {
     const canonicalUrl = canonicalizeArticleUrl(msg?.canonicalUrl);
     const conversationId = Number(msg?.conversationId);
@@ -65,6 +69,7 @@ export function registerArticleCommentsHandlers(router: AnyRouter) {
         reason: 'articleCommentAdded',
         conversationId: comment.conversationId,
       });
+      await deps.onConversationChanged(Number(comment.conversationId), 'articleCommentChanged');
     }
 
     return router.ok(comment);
@@ -82,6 +87,7 @@ export function registerArticleCommentsHandlers(router: AnyRouter) {
           reason: 'articleCommentDeleted',
           conversationId,
         });
+        await deps.onConversationChanged(conversationId, 'articleCommentChanged');
       } else {
         router.eventsHub?.broadcast(UI_EVENT_TYPES.CONVERSATIONS_CHANGED, {
           reason: 'articleCommentDeleted',
@@ -101,6 +107,7 @@ export function registerArticleCommentsHandlers(router: AnyRouter) {
       reason: 'articleCommentAttached',
       conversationId,
     });
+    await deps.onConversationChanged(conversationId, 'articleCommentChanged');
     return router.ok(res);
   });
 
@@ -119,6 +126,7 @@ export function registerArticleCommentsHandlers(router: AnyRouter) {
         fromCanonicalUrl,
         toCanonicalUrl,
       });
+      await deps.onConversationChanged(conversationId, 'articleCommentChanged');
     } else {
       router.eventsHub?.broadcast(UI_EVENT_TYPES.CONVERSATIONS_CHANGED, {
         reason: 'articleCommentsMigrated',

--- a/src/services/comments/background/handlers.ts
+++ b/src/services/comments/background/handlers.ts
@@ -27,6 +27,10 @@ type ArticleCommentsHandlersDeps = {
   onConversationChanged: (conversationId: number, reason: string) => void | Promise<void>;
 };
 
+function fireAndForget(task: void | Promise<void>) {
+  Promise.resolve(task).catch(() => {});
+}
+
 export function registerArticleCommentsHandlers(router: AnyRouter, deps: ArticleCommentsHandlersDeps) {
   router.register(COMMENTS_MESSAGE_TYPES.LIST_ARTICLE_COMMENTS, async (msg) => {
     const canonicalUrl = canonicalizeArticleUrl(msg?.canonicalUrl);
@@ -69,7 +73,7 @@ export function registerArticleCommentsHandlers(router: AnyRouter, deps: Article
         reason: 'articleCommentAdded',
         conversationId: comment.conversationId,
       });
-      await deps.onConversationChanged(Number(comment.conversationId), 'articleCommentChanged');
+      fireAndForget(deps.onConversationChanged(Number(comment.conversationId), 'articleCommentChanged'));
     }
 
     return router.ok(comment);
@@ -87,7 +91,7 @@ export function registerArticleCommentsHandlers(router: AnyRouter, deps: Article
           reason: 'articleCommentDeleted',
           conversationId,
         });
-        await deps.onConversationChanged(conversationId, 'articleCommentChanged');
+        fireAndForget(deps.onConversationChanged(conversationId, 'articleCommentChanged'));
       } else {
         router.eventsHub?.broadcast(UI_EVENT_TYPES.CONVERSATIONS_CHANGED, {
           reason: 'articleCommentDeleted',
@@ -107,7 +111,7 @@ export function registerArticleCommentsHandlers(router: AnyRouter, deps: Article
       reason: 'articleCommentAttached',
       conversationId,
     });
-    await deps.onConversationChanged(conversationId, 'articleCommentChanged');
+    fireAndForget(deps.onConversationChanged(conversationId, 'articleCommentChanged'));
     return router.ok(res);
   });
 
@@ -126,7 +130,7 @@ export function registerArticleCommentsHandlers(router: AnyRouter, deps: Article
         fromCanonicalUrl,
         toCanonicalUrl,
       });
-      await deps.onConversationChanged(conversationId, 'articleCommentChanged');
+      fireAndForget(deps.onConversationChanged(conversationId, 'articleCommentChanged'));
     } else {
       router.eventsHub?.broadcast(UI_EVENT_TYPES.CONVERSATIONS_CHANGED, {
         reason: 'articleCommentsMigrated',

--- a/src/services/conversations/background/handlers.ts
+++ b/src/services/conversations/background/handlers.ts
@@ -31,6 +31,10 @@ type ConversationHandlersDeps = {
   onConversationChanged: (conversationId: number, reason: string) => void | Promise<void>;
 };
 
+function fireAndForget(task: void | Promise<void>) {
+  Promise.resolve(task).catch(() => {});
+}
+
 type ListQueryPayload = {
   sourceKey: string;
   siteKey: string;
@@ -181,7 +185,7 @@ export function registerConversationHandlers(router: AnyRouter, deps: Conversati
         reason: existed ? 'upsertConversation' : 'createConversation',
         conversationId,
       });
-      await deps.onConversationChanged(conversationId, existed ? 'upsertConversation' : 'createConversation');
+      fireAndForget(deps.onConversationChanged(conversationId, existed ? 'upsertConversation' : 'createConversation'));
     }
     return router.ok({ ...(convo as any), __isNew: !existed });
   });
@@ -295,7 +299,7 @@ export function registerConversationHandlers(router: AnyRouter, deps: Conversati
       reason: 'upsert',
       conversationId,
     });
-    await deps.onConversationChanged(conversationId, 'syncConversationMessages');
+    fireAndForget(deps.onConversationChanged(conversationId, 'syncConversationMessages'));
     return router.ok(res);
   });
 
@@ -316,14 +320,14 @@ export function registerConversationHandlers(router: AnyRouter, deps: Conversati
         });
         if (progressEnqueued) return;
         progressEnqueued = true;
-        await deps.onConversationChanged(conversationId, 'backfillImages');
+        fireAndForget(deps.onConversationChanged(conversationId, 'backfillImages'));
       },
     });
     router.eventsHub?.broadcast(UI_EVENT_TYPES.CONVERSATIONS_CHANGED, {
       reason: 'upsert',
       conversationId,
     });
-    await deps.onConversationChanged(conversationId, 'backfillImages');
+    fireAndForget(deps.onConversationChanged(conversationId, 'backfillImages'));
     return router.ok(res);
   });
 

--- a/src/services/conversations/background/handlers.ts
+++ b/src/services/conversations/background/handlers.ts
@@ -19,6 +19,10 @@ import {
   DEFAULT_ABOUT_YOU_USER_NAME,
   normalizeUserName,
 } from '@services/shared/user-profile';
+import {
+  AUTO_SYNC_CONVERSATION_CHANGED_REASONS,
+  type AutoSyncConversationChangedReason,
+} from '@services/sync/auto-sync/auto-sync-keys';
 
 type AnyRouter = {
   ok: (data: unknown) => any;
@@ -28,7 +32,7 @@ type AnyRouter = {
 };
 
 type ConversationHandlersDeps = {
-  onConversationChanged: (conversationId: number, reason: string) => void | Promise<void>;
+  onConversationChanged: (conversationId: number, reason: AutoSyncConversationChangedReason) => void | Promise<void>;
 };
 
 function fireAndForget(task: void | Promise<void>) {
@@ -185,7 +189,14 @@ export function registerConversationHandlers(router: AnyRouter, deps: Conversati
         reason: existed ? 'upsertConversation' : 'createConversation',
         conversationId,
       });
-      fireAndForget(deps.onConversationChanged(conversationId, existed ? 'upsertConversation' : 'createConversation'));
+      fireAndForget(
+        deps.onConversationChanged(
+          conversationId,
+          existed
+            ? AUTO_SYNC_CONVERSATION_CHANGED_REASONS.upsertConversation
+            : AUTO_SYNC_CONVERSATION_CHANGED_REASONS.createConversation,
+        ),
+      );
     }
     return router.ok({ ...(convo as any), __isNew: !existed });
   });
@@ -299,7 +310,7 @@ export function registerConversationHandlers(router: AnyRouter, deps: Conversati
       reason: 'upsert',
       conversationId,
     });
-    fireAndForget(deps.onConversationChanged(conversationId, 'syncConversationMessages'));
+    fireAndForget(deps.onConversationChanged(conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.syncConversationMessages));
     return router.ok(res);
   });
 
@@ -320,14 +331,14 @@ export function registerConversationHandlers(router: AnyRouter, deps: Conversati
         });
         if (progressEnqueued) return;
         progressEnqueued = true;
-        fireAndForget(deps.onConversationChanged(conversationId, 'backfillImages'));
+        fireAndForget(deps.onConversationChanged(conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.backfillImages));
       },
     });
     router.eventsHub?.broadcast(UI_EVENT_TYPES.CONVERSATIONS_CHANGED, {
       reason: 'upsert',
       conversationId,
     });
-    fireAndForget(deps.onConversationChanged(conversationId, 'backfillImages'));
+    fireAndForget(deps.onConversationChanged(conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.backfillImages));
     return router.ok(res);
   });
 

--- a/src/services/conversations/background/handlers.ts
+++ b/src/services/conversations/background/handlers.ts
@@ -310,7 +310,9 @@ export function registerConversationHandlers(router: AnyRouter, deps: Conversati
       reason: 'upsert',
       conversationId,
     });
-    fireAndForget(deps.onConversationChanged(conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.syncConversationMessages));
+    fireAndForget(
+      deps.onConversationChanged(conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.syncConversationMessages),
+    );
     return router.ok(res);
   });
 
@@ -331,7 +333,9 @@ export function registerConversationHandlers(router: AnyRouter, deps: Conversati
         });
         if (progressEnqueued) return;
         progressEnqueued = true;
-        fireAndForget(deps.onConversationChanged(conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.backfillImages));
+        fireAndForget(
+          deps.onConversationChanged(conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.backfillImages),
+        );
       },
     });
     router.eventsHub?.broadcast(UI_EVENT_TYPES.CONVERSATIONS_CHANGED, {

--- a/src/services/conversations/background/handlers.ts
+++ b/src/services/conversations/background/handlers.ts
@@ -27,6 +27,10 @@ type AnyRouter = {
   eventsHub?: { broadcast: (type: string, payload: unknown) => void };
 };
 
+type ConversationHandlersDeps = {
+  onConversationChanged: (conversationId: number, reason: string) => void | Promise<void>;
+};
+
 type ListQueryPayload = {
   sourceKey: string;
   siteKey: string;
@@ -90,7 +94,7 @@ function parseListCursorPayload(value: unknown): ListCursorPayload | null {
   return { lastCapturedAt, id };
 }
 
-export function registerConversationHandlers(router: AnyRouter) {
+export function registerConversationHandlers(router: AnyRouter, deps: ConversationHandlersDeps) {
   const invalidArgument = (field: string, message: string, received: unknown) => {
     return router.err(message, {
       code: 'INVALID_ARGUMENT',
@@ -177,6 +181,7 @@ export function registerConversationHandlers(router: AnyRouter) {
         reason: existed ? 'upsertConversation' : 'createConversation',
         conversationId,
       });
+      await deps.onConversationChanged(conversationId, existed ? 'upsertConversation' : 'createConversation');
     }
     return router.ok({ ...(convo as any), __isNew: !existed });
   });
@@ -290,6 +295,7 @@ export function registerConversationHandlers(router: AnyRouter) {
       reason: 'upsert',
       conversationId,
     });
+    await deps.onConversationChanged(conversationId, 'syncConversationMessages');
     return router.ok(res);
   });
 
@@ -297,6 +303,7 @@ export function registerConversationHandlers(router: AnyRouter) {
     const conversationId = Number(msg.conversationId);
     if (!Number.isFinite(conversationId) || conversationId <= 0) return router.err('invalid conversationId');
     const conversationUrl = String(msg?.conversationUrl || '').trim();
+    let progressEnqueued = false;
     const res = await backfillConversationImages({
       conversationId,
       conversationUrl,
@@ -307,12 +314,16 @@ export function registerConversationHandlers(router: AnyRouter) {
           reason: 'upsert',
           conversationId,
         });
+        if (progressEnqueued) return;
+        progressEnqueued = true;
+        await deps.onConversationChanged(conversationId, 'backfillImages');
       },
     });
     router.eventsHub?.broadcast(UI_EVENT_TYPES.CONVERSATIONS_CHANGED, {
       reason: 'upsert',
       conversationId,
     });
+    await deps.onConversationChanged(conversationId, 'backfillImages');
     return router.ok(res);
   });
 

--- a/src/services/sync/auto-sync/auto-sync-keys.ts
+++ b/src/services/sync/auto-sync/auto-sync-keys.ts
@@ -17,3 +17,6 @@ export function autoSyncEnabledStorageKey(provider: AutoSyncProviderId) {
 
 export const NOTION_AUTO_SYNC_DEBOUNCE_ALARM_NAME = 'auto_sync_notion_debounce_v1' as const;
 
+export const NOTION_AUTO_SYNC_QUEUE_STORAGE_KEY = 'notion_auto_sync_queue_v1' as const;
+export const NOTION_AUTO_SYNC_DEBOUNCE_MS = 60_000;
+export const NOTION_AUTO_SYNC_QUEUE_MAX_ITEMS = 200;

--- a/src/services/sync/auto-sync/auto-sync-keys.ts
+++ b/src/services/sync/auto-sync/auto-sync-keys.ts
@@ -1,0 +1,19 @@
+export type AutoSyncProviderId = 'notion' | 'obsidian' | 'feishu';
+
+export const NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY = 'notion_auto_sync_enabled_v1' as const;
+export const OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY = 'obsidian_auto_sync_enabled_v1' as const;
+export const FEISHU_AUTO_SYNC_ENABLED_STORAGE_KEY = 'feishu_auto_sync_enabled_v1' as const;
+
+export function autoSyncEnabledStorageKey(provider: AutoSyncProviderId) {
+  switch (provider) {
+    case 'notion':
+      return NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY;
+    case 'obsidian':
+      return OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY;
+    case 'feishu':
+      return FEISHU_AUTO_SYNC_ENABLED_STORAGE_KEY;
+  }
+}
+
+export const NOTION_AUTO_SYNC_DEBOUNCE_ALARM_NAME = 'auto_sync_notion_debounce_v1' as const;
+

--- a/src/services/sync/auto-sync/auto-sync-keys.ts
+++ b/src/services/sync/auto-sync/auto-sync-keys.ts
@@ -30,3 +30,14 @@ export const OBSIDIAN_AUTO_SYNC_QUEUE_MAX_ITEMS = 200;
 export const FEISHU_AUTO_SYNC_QUEUE_STORAGE_KEY = 'feishu_auto_sync_queue_v1' as const;
 export const FEISHU_AUTO_SYNC_DEBOUNCE_MS = 60_000;
 export const FEISHU_AUTO_SYNC_QUEUE_MAX_ITEMS = 200;
+
+export const AUTO_SYNC_CONVERSATION_CHANGED_REASONS = {
+  createConversation: 'createConversation',
+  upsertConversation: 'upsertConversation',
+  syncConversationMessages: 'syncConversationMessages',
+  backfillImages: 'backfillImages',
+  articleCommentChanged: 'articleCommentChanged',
+} as const;
+
+export type AutoSyncConversationChangedReason =
+  (typeof AUTO_SYNC_CONVERSATION_CHANGED_REASONS)[keyof typeof AUTO_SYNC_CONVERSATION_CHANGED_REASONS];

--- a/src/services/sync/auto-sync/auto-sync-keys.ts
+++ b/src/services/sync/auto-sync/auto-sync-keys.ts
@@ -16,7 +16,17 @@ export function autoSyncEnabledStorageKey(provider: AutoSyncProviderId) {
 }
 
 export const NOTION_AUTO_SYNC_DEBOUNCE_ALARM_NAME = 'auto_sync_notion_debounce_v1' as const;
+export const OBSIDIAN_AUTO_SYNC_DEBOUNCE_ALARM_NAME = 'auto_sync_obsidian_debounce_v1' as const;
+export const FEISHU_AUTO_SYNC_DEBOUNCE_ALARM_NAME = 'auto_sync_feishu_debounce_v1' as const;
 
 export const NOTION_AUTO_SYNC_QUEUE_STORAGE_KEY = 'notion_auto_sync_queue_v1' as const;
 export const NOTION_AUTO_SYNC_DEBOUNCE_MS = 60_000;
 export const NOTION_AUTO_SYNC_QUEUE_MAX_ITEMS = 200;
+
+export const OBSIDIAN_AUTO_SYNC_QUEUE_STORAGE_KEY = 'obsidian_auto_sync_queue_v1' as const;
+export const OBSIDIAN_AUTO_SYNC_DEBOUNCE_MS = 60_000;
+export const OBSIDIAN_AUTO_SYNC_QUEUE_MAX_ITEMS = 200;
+
+export const FEISHU_AUTO_SYNC_QUEUE_STORAGE_KEY = 'feishu_auto_sync_queue_v1' as const;
+export const FEISHU_AUTO_SYNC_DEBOUNCE_MS = 60_000;
+export const FEISHU_AUTO_SYNC_QUEUE_MAX_ITEMS = 200;

--- a/src/services/sync/auto-sync/auto-sync-scheduler-core.ts
+++ b/src/services/sync/auto-sync/auto-sync-scheduler-core.ts
@@ -54,7 +54,12 @@ function pickEarliestDueAt(queue: QueueMap): number | null {
 
 function normalizeIds(ids: string[]) {
   return Array.from(
-    new Set(ids.map((x) => Number(x)).filter((x) => Number.isFinite(x) && x > 0).map((x) => Math.floor(x))),
+    new Set(
+      ids
+        .map((x) => Number(x))
+        .filter((x) => Number.isFinite(x) && x > 0)
+        .map((x) => Math.floor(x)),
+    ),
   );
 }
 
@@ -91,7 +96,7 @@ export function createAutoSyncSchedulerCore(config: {
   } = config;
 
   const readQueue = async (): Promise<QueueMap> => {
-    const res = await infra.storage.get([queueStorageKey]).catch(() => ({} as any));
+    const res = await infra.storage.get([queueStorageKey]).catch(() => ({}) as any);
     return normalizeQueue((res as any)?.[queueStorageKey]);
   };
 
@@ -113,7 +118,7 @@ export function createAutoSyncSchedulerCore(config: {
     const id = Number(conversationId);
     if (!Number.isFinite(id) || id <= 0) return;
 
-    const local = await infra.storage.get([enabledStorageKey]).catch(() => ({} as any));
+    const local = await infra.storage.get([enabledStorageKey]).catch(() => ({}) as any);
     const autoSyncEnabled = (local as any)?.[enabledStorageKey] === true;
     if (!autoSyncEnabled) return;
 
@@ -148,7 +153,7 @@ export function createAutoSyncSchedulerCore(config: {
       return;
     }
 
-    const local = await infra.storage.get([enabledStorageKey]).catch(() => ({} as any));
+    const local = await infra.storage.get([enabledStorageKey]).catch(() => ({}) as any);
     const autoSyncEnabled = (local as any)?.[enabledStorageKey] === true;
     const providerEnabled = await isProviderEnabled().catch(() => false);
 
@@ -192,4 +197,3 @@ export function createAutoSyncSchedulerCore(config: {
 
   return { enqueue, flush };
 }
-

--- a/src/services/sync/auto-sync/auto-sync-scheduler-core.ts
+++ b/src/services/sync/auto-sync/auto-sync-scheduler-core.ts
@@ -139,6 +139,13 @@ export function createAutoSyncSchedulerCore(config: {
     const nextQueue = trimQueue({ ...queue, [key]: nextDueAt }, maxItems);
     await writeQueue(nextQueue);
     await scheduleNextAlarm(nextQueue);
+
+    // Best-effort fallback when `alarms` API is unavailable: we cannot wake the
+    // background to flush at `dueAt`, so we opportunistically flush any due
+    // items whenever we have an activity signal (enqueue).
+    if (!infra.alarms.isAvailable()) {
+      await flush();
+    }
   };
 
   const flush = async () => {

--- a/src/services/sync/auto-sync/auto-sync-scheduler-core.ts
+++ b/src/services/sync/auto-sync/auto-sync-scheduler-core.ts
@@ -1,0 +1,195 @@
+export type AutoSyncSchedulerInfra = {
+  now: () => number;
+  storage: {
+    get: (keys: string[]) => Promise<Record<string, unknown>>;
+    set: (patch: Record<string, unknown>) => Promise<void>;
+  };
+  alarms: {
+    isAvailable: () => boolean;
+    create: (name: string, info: { when: number }) => boolean;
+    clear: (name: string) => Promise<boolean>;
+  };
+};
+
+export type AutoSyncScheduler = {
+  enqueue: (conversationId: number, reason: string) => Promise<void>;
+  flush: () => Promise<void>;
+};
+
+type QueueMap = Record<string, number>;
+
+function normalizeQueue(value: unknown): QueueMap {
+  if (!value || typeof value !== 'object') return {};
+  const out: QueueMap = {};
+  for (const [key, rawDueAt] of Object.entries(value as Record<string, unknown>)) {
+    const conversationId = Number(key);
+    if (!Number.isFinite(conversationId) || conversationId <= 0) continue;
+    const dueAt = Number(rawDueAt);
+    if (!Number.isFinite(dueAt) || dueAt <= 0) continue;
+    out[String(conversationId)] = Math.floor(dueAt);
+  }
+  return out;
+}
+
+function trimQueue(queue: QueueMap, maxItems: number): QueueMap {
+  const entries = Object.entries(queue);
+  const max = Number.isFinite(Number(maxItems)) ? Math.max(1, Math.floor(Number(maxItems))) : 200;
+  if (entries.length <= max) return queue;
+  entries.sort((a, b) => a[1] - b[1]);
+  const kept = entries.slice(0, max);
+  const out: QueueMap = {};
+  for (const [id, dueAt] of kept) out[id] = dueAt;
+  return out;
+}
+
+function pickEarliestDueAt(queue: QueueMap): number | null {
+  let earliest: number | null = null;
+  for (const dueAt of Object.values(queue)) {
+    const value = Number(dueAt);
+    if (!Number.isFinite(value) || value <= 0) continue;
+    if (earliest == null || value < earliest) earliest = value;
+  }
+  return earliest;
+}
+
+function normalizeIds(ids: string[]) {
+  return Array.from(
+    new Set(ids.map((x) => Number(x)).filter((x) => Number.isFinite(x) && x > 0).map((x) => Math.floor(x))),
+  );
+}
+
+function isAlreadyRunningError(error: unknown): boolean {
+  const code = String((error as any)?.code || '').trim();
+  if (code === 'sync_already_running') return true;
+  const message = error instanceof Error ? error.message : String(error || '').trim();
+  return message.toLowerCase().includes('sync already in progress');
+}
+
+export function createAutoSyncSchedulerCore(config: {
+  queueStorageKey: string;
+  enabledStorageKey: string;
+  alarmName: string;
+  debounceMs: number;
+  maxItems: number;
+  infra: AutoSyncSchedulerInfra;
+  getInstanceId: () => string;
+  isProviderEnabled: () => Promise<boolean>;
+  syncConversations: (conversationIds: number[], instanceId: string) => Promise<void>;
+  onPreflightFailed?: (args: { conversationIds: number[]; instanceId: string; error: string }) => Promise<void>;
+}): AutoSyncScheduler {
+  const {
+    queueStorageKey,
+    enabledStorageKey,
+    alarmName,
+    debounceMs,
+    maxItems,
+    infra,
+    getInstanceId,
+    isProviderEnabled,
+    syncConversations,
+    onPreflightFailed,
+  } = config;
+
+  const readQueue = async (): Promise<QueueMap> => {
+    const res = await infra.storage.get([queueStorageKey]).catch(() => ({} as any));
+    return normalizeQueue((res as any)?.[queueStorageKey]);
+  };
+
+  const writeQueue = async (queue: QueueMap): Promise<void> => {
+    await infra.storage.set({ [queueStorageKey]: queue }).catch(() => {});
+  };
+
+  const scheduleNextAlarm = async (queue: QueueMap): Promise<void> => {
+    const earliestDueAt = pickEarliestDueAt(queue);
+    if (earliestDueAt == null) {
+      if (infra.alarms.isAvailable()) await infra.alarms.clear(alarmName);
+      return;
+    }
+    if (!infra.alarms.isAvailable()) return;
+    infra.alarms.create(alarmName, { when: earliestDueAt });
+  };
+
+  const enqueue = async (conversationId: number, _reason: string) => {
+    const id = Number(conversationId);
+    if (!Number.isFinite(id) || id <= 0) return;
+
+    const local = await infra.storage.get([enabledStorageKey]).catch(() => ({} as any));
+    const autoSyncEnabled = (local as any)?.[enabledStorageKey] === true;
+    if (!autoSyncEnabled) return;
+
+    const providerEnabled = await isProviderEnabled().catch(() => false);
+    if (!providerEnabled) return;
+
+    const now = infra.now();
+    const nextDueAt = now + debounceMs;
+
+    const queue = await readQueue();
+    const key = String(Math.floor(id));
+    const prevDueAt = Number(queue[key]);
+    if (Number.isFinite(prevDueAt) && prevDueAt >= nextDueAt) {
+      await scheduleNextAlarm(queue);
+      return;
+    }
+
+    const nextQueue = trimQueue({ ...queue, [key]: nextDueAt }, maxItems);
+    await writeQueue(nextQueue);
+    await scheduleNextAlarm(nextQueue);
+  };
+
+  const flush = async () => {
+    const now = infra.now();
+    const instanceId = getInstanceId();
+    const queue = await readQueue();
+
+    const dueKeys = Object.keys(queue).filter((key) => Number(queue[key]) <= now);
+    const dueConversationIds = normalizeIds(dueKeys);
+    if (!dueConversationIds.length) {
+      await scheduleNextAlarm(queue);
+      return;
+    }
+
+    const local = await infra.storage.get([enabledStorageKey]).catch(() => ({} as any));
+    const autoSyncEnabled = (local as any)?.[enabledStorageKey] === true;
+    const providerEnabled = await isProviderEnabled().catch(() => false);
+
+    const restQueue: QueueMap = { ...queue };
+    for (const key of dueKeys) delete restQueue[key];
+
+    if (!providerEnabled || !autoSyncEnabled) {
+      await writeQueue(restQueue);
+      await scheduleNextAlarm(restQueue);
+      return;
+    }
+
+    try {
+      await syncConversations(dueConversationIds, instanceId);
+      await writeQueue(restQueue);
+      await scheduleNextAlarm(restQueue);
+    } catch (error) {
+      if (isAlreadyRunningError(error)) {
+        const delayedQueue: QueueMap = { ...queue };
+        const delayedDueAt = now + debounceMs;
+        for (const conversationId of dueConversationIds) delayedQueue[String(conversationId)] = delayedDueAt;
+        const trimmed = trimQueue(delayedQueue, maxItems);
+        await writeQueue(trimmed);
+        await scheduleNextAlarm(trimmed);
+        return;
+      }
+
+      if (onPreflightFailed) {
+        const text = error instanceof Error ? error.message : String(error || '').trim();
+        await onPreflightFailed({
+          conversationIds: dueConversationIds,
+          instanceId,
+          error: text || 'sync failed',
+        }).catch(() => {});
+      }
+
+      await writeQueue(restQueue);
+      await scheduleNextAlarm(restQueue);
+    }
+  };
+
+  return { enqueue, flush };
+}
+

--- a/src/services/sync/auto-sync/feishu-auto-sync-scheduler.ts
+++ b/src/services/sync/auto-sync/feishu-auto-sync-scheduler.ts
@@ -10,157 +10,43 @@ import {
   FEISHU_AUTO_SYNC_QUEUE_MAX_ITEMS,
   FEISHU_AUTO_SYNC_QUEUE_STORAGE_KEY,
 } from '@services/sync/auto-sync/auto-sync-keys';
+import {
+  createAutoSyncSchedulerCore,
+  type AutoSyncScheduler,
+  type AutoSyncSchedulerInfra,
+} from '@services/sync/auto-sync/auto-sync-scheduler-core';
 
-type QueueMap = Record<string, number>;
+export type FeishuAutoSyncScheduler = AutoSyncScheduler;
 
-function normalizeQueue(value: unknown): QueueMap {
-  if (!value || typeof value !== 'object') return {};
-  const out: QueueMap = {};
-  for (const [key, rawDueAt] of Object.entries(value as Record<string, unknown>)) {
-    const conversationId = Number(key);
-    if (!Number.isFinite(conversationId) || conversationId <= 0) continue;
-    const dueAt = Number(rawDueAt);
-    if (!Number.isFinite(dueAt) || dueAt <= 0) continue;
-    out[String(conversationId)] = Math.floor(dueAt);
-  }
-  return out;
-}
-
-function trimQueue(queue: QueueMap, maxItems: number): QueueMap {
-  const entries = Object.entries(queue);
-  const max = Number.isFinite(Number(maxItems)) ? Math.max(1, Math.floor(Number(maxItems))) : 200;
-  if (entries.length <= max) return queue;
-  entries.sort((a, b) => a[1] - b[1]);
-  const kept = entries.slice(0, max);
-  const out: QueueMap = {};
-  for (const [id, dueAt] of kept) out[id] = dueAt;
-  return out;
-}
-
-function pickEarliestDueAt(queue: QueueMap): number | null {
-  let earliest: number | null = null;
-  for (const dueAt of Object.values(queue)) {
-    const value = Number(dueAt);
-    if (!Number.isFinite(value) || value <= 0) continue;
-    if (earliest == null || value < earliest) earliest = value;
-  }
-  return earliest;
-}
-
-function normalizeIds(ids: string[]) {
-  return Array.from(
-    new Set(ids.map((x) => Number(x)).filter((x) => Number.isFinite(x) && x > 0).map((x) => Math.floor(x))),
-  );
-}
-
-function isAlreadyRunningError(error: unknown): boolean {
-  const code = String((error as any)?.code || '').trim();
-  if (code === 'sync_already_running') return true;
-  const message = error instanceof Error ? error.message : String(error || '').trim();
-  return message.toLowerCase().includes('sync already in progress');
-}
-
-async function readQueue(): Promise<QueueMap> {
-  const res = await storageGet([FEISHU_AUTO_SYNC_QUEUE_STORAGE_KEY]).catch(() => ({}));
-  return normalizeQueue((res as any)?.[FEISHU_AUTO_SYNC_QUEUE_STORAGE_KEY]);
-}
-
-async function writeQueue(queue: QueueMap): Promise<void> {
-  await storageSet({ [FEISHU_AUTO_SYNC_QUEUE_STORAGE_KEY]: queue }).catch(() => {});
-}
-
-async function scheduleNextAlarm(queue: QueueMap): Promise<void> {
-  const earliestDueAt = pickEarliestDueAt(queue);
-  if (earliestDueAt == null) {
-    if (isAlarmsAvailable()) await clear(FEISHU_AUTO_SYNC_DEBOUNCE_ALARM_NAME);
-    return;
-  }
-  if (!isAlarmsAvailable()) return;
-  create(FEISHU_AUTO_SYNC_DEBOUNCE_ALARM_NAME, { when: earliestDueAt });
-}
-
-export type FeishuAutoSyncScheduler = {
-  enqueue: (conversationId: number, reason: string) => Promise<void>;
-  flush: () => Promise<void>;
-};
-
-export function createFeishuAutoSyncScheduler(deps: {
-  getInstanceId: () => string;
-  feishuSyncOrchestrator: FeishuSyncOrchestrator;
-}): FeishuAutoSyncScheduler {
-  const { getInstanceId, feishuSyncOrchestrator } = deps;
-
-  const enqueue = async (conversationId: number, _reason: string) => {
-    const id = Number(conversationId);
-    if (!Number.isFinite(id) || id <= 0) return;
-
-    const local = await storageGet([FEISHU_AUTO_SYNC_ENABLED_STORAGE_KEY]).catch(() => ({}));
-    const autoSyncEnabled = (local as any)?.[FEISHU_AUTO_SYNC_ENABLED_STORAGE_KEY] === true;
-    if (!autoSyncEnabled) return;
-    const providerEnabled = await isSyncProviderEnabled('feishu').catch(() => false);
-    if (!providerEnabled) return;
-
-    const now = Date.now();
-    const nextDueAt = now + FEISHU_AUTO_SYNC_DEBOUNCE_MS;
-
-    const queue = await readQueue();
-    const key = String(Math.floor(id));
-    const prevDueAt = Number(queue[key]);
-    if (Number.isFinite(prevDueAt) && prevDueAt >= nextDueAt) {
-      await scheduleNextAlarm(queue);
-      return;
-    }
-
-    const nextQueue = trimQueue({ ...queue, [key]: nextDueAt }, FEISHU_AUTO_SYNC_QUEUE_MAX_ITEMS);
-    await writeQueue(nextQueue);
-    await scheduleNextAlarm(nextQueue);
+export function createFeishuAutoSyncScheduler(
+  deps: {
+    getInstanceId: () => string;
+    feishuSyncOrchestrator: FeishuSyncOrchestrator;
+  },
+  infraOverrides?: Partial<AutoSyncSchedulerInfra>,
+): FeishuAutoSyncScheduler {
+  const infra: AutoSyncSchedulerInfra = {
+    now: () => Date.now(),
+    storage: { get: storageGet as any, set: storageSet as any },
+    alarms: {
+      isAvailable: () => isAlarmsAvailable(),
+      create: (name, info) => create(name, info),
+      clear: (name) => clear(name),
+    },
+    ...infraOverrides,
   };
 
-  const flush = async () => {
-    const now = Date.now();
-    const instanceId = getInstanceId();
-    const queue = await readQueue();
-
-    const dueKeys = Object.keys(queue).filter((key) => Number(queue[key]) <= now);
-    const dueConversationIds = normalizeIds(dueKeys);
-    if (!dueConversationIds.length) {
-      await scheduleNextAlarm(queue);
-      return;
-    }
-
-    const local = await storageGet([FEISHU_AUTO_SYNC_ENABLED_STORAGE_KEY]).catch(() => ({}));
-    const autoSyncEnabled = (local as any)?.[FEISHU_AUTO_SYNC_ENABLED_STORAGE_KEY] === true;
-    const providerEnabled = await isSyncProviderEnabled('feishu').catch(() => false);
-
-    const restQueue: QueueMap = { ...queue };
-    for (const key of dueKeys) delete restQueue[key];
-
-    if (!providerEnabled || !autoSyncEnabled) {
-      await writeQueue(restQueue);
-      await scheduleNextAlarm(restQueue);
-      return;
-    }
-
-    try {
-      await feishuSyncOrchestrator.syncConversations({ conversationIds: dueConversationIds, instanceId });
-      await writeQueue(restQueue);
-      await scheduleNextAlarm(restQueue);
-    } catch (error) {
-      if (isAlreadyRunningError(error)) {
-        const delayedQueue: QueueMap = { ...queue };
-        const delayedDueAt = now + FEISHU_AUTO_SYNC_DEBOUNCE_MS;
-        for (const conversationId of dueConversationIds) delayedQueue[String(conversationId)] = delayedDueAt;
-        const trimmed = trimQueue(delayedQueue, FEISHU_AUTO_SYNC_QUEUE_MAX_ITEMS);
-        await writeQueue(trimmed);
-        await scheduleNextAlarm(trimmed);
-        return;
-      }
-
-      await writeQueue(restQueue);
-      await scheduleNextAlarm(restQueue);
-    }
-  };
-
-  return { enqueue, flush };
+  return createAutoSyncSchedulerCore({
+    queueStorageKey: FEISHU_AUTO_SYNC_QUEUE_STORAGE_KEY,
+    enabledStorageKey: FEISHU_AUTO_SYNC_ENABLED_STORAGE_KEY,
+    alarmName: FEISHU_AUTO_SYNC_DEBOUNCE_ALARM_NAME,
+    debounceMs: FEISHU_AUTO_SYNC_DEBOUNCE_MS,
+    maxItems: FEISHU_AUTO_SYNC_QUEUE_MAX_ITEMS,
+    infra,
+    getInstanceId: deps.getInstanceId,
+    isProviderEnabled: () => isSyncProviderEnabled('feishu'),
+    syncConversations: (conversationIds, instanceId) =>
+      deps.feishuSyncOrchestrator.syncConversations({ conversationIds, instanceId } as any) as any,
+  });
 }
 

--- a/src/services/sync/auto-sync/feishu-auto-sync-scheduler.ts
+++ b/src/services/sync/auto-sync/feishu-auto-sync-scheduler.ts
@@ -1,0 +1,166 @@
+import { create, clear, isAlarmsAvailable } from '@platform/alarms/alarms';
+import { storageGet, storageSet } from '@services/shared/storage';
+import { isSyncProviderEnabled } from '@services/sync/sync-provider-gate';
+
+import type { FeishuSyncOrchestrator } from '@services/bootstrap/background-services';
+import {
+  FEISHU_AUTO_SYNC_DEBOUNCE_ALARM_NAME,
+  FEISHU_AUTO_SYNC_DEBOUNCE_MS,
+  FEISHU_AUTO_SYNC_ENABLED_STORAGE_KEY,
+  FEISHU_AUTO_SYNC_QUEUE_MAX_ITEMS,
+  FEISHU_AUTO_SYNC_QUEUE_STORAGE_KEY,
+} from '@services/sync/auto-sync/auto-sync-keys';
+
+type QueueMap = Record<string, number>;
+
+function normalizeQueue(value: unknown): QueueMap {
+  if (!value || typeof value !== 'object') return {};
+  const out: QueueMap = {};
+  for (const [key, rawDueAt] of Object.entries(value as Record<string, unknown>)) {
+    const conversationId = Number(key);
+    if (!Number.isFinite(conversationId) || conversationId <= 0) continue;
+    const dueAt = Number(rawDueAt);
+    if (!Number.isFinite(dueAt) || dueAt <= 0) continue;
+    out[String(conversationId)] = Math.floor(dueAt);
+  }
+  return out;
+}
+
+function trimQueue(queue: QueueMap, maxItems: number): QueueMap {
+  const entries = Object.entries(queue);
+  const max = Number.isFinite(Number(maxItems)) ? Math.max(1, Math.floor(Number(maxItems))) : 200;
+  if (entries.length <= max) return queue;
+  entries.sort((a, b) => a[1] - b[1]);
+  const kept = entries.slice(0, max);
+  const out: QueueMap = {};
+  for (const [id, dueAt] of kept) out[id] = dueAt;
+  return out;
+}
+
+function pickEarliestDueAt(queue: QueueMap): number | null {
+  let earliest: number | null = null;
+  for (const dueAt of Object.values(queue)) {
+    const value = Number(dueAt);
+    if (!Number.isFinite(value) || value <= 0) continue;
+    if (earliest == null || value < earliest) earliest = value;
+  }
+  return earliest;
+}
+
+function normalizeIds(ids: string[]) {
+  return Array.from(
+    new Set(ids.map((x) => Number(x)).filter((x) => Number.isFinite(x) && x > 0).map((x) => Math.floor(x))),
+  );
+}
+
+function isAlreadyRunningError(error: unknown): boolean {
+  const code = String((error as any)?.code || '').trim();
+  if (code === 'sync_already_running') return true;
+  const message = error instanceof Error ? error.message : String(error || '').trim();
+  return message.toLowerCase().includes('sync already in progress');
+}
+
+async function readQueue(): Promise<QueueMap> {
+  const res = await storageGet([FEISHU_AUTO_SYNC_QUEUE_STORAGE_KEY]).catch(() => ({}));
+  return normalizeQueue((res as any)?.[FEISHU_AUTO_SYNC_QUEUE_STORAGE_KEY]);
+}
+
+async function writeQueue(queue: QueueMap): Promise<void> {
+  await storageSet({ [FEISHU_AUTO_SYNC_QUEUE_STORAGE_KEY]: queue }).catch(() => {});
+}
+
+async function scheduleNextAlarm(queue: QueueMap): Promise<void> {
+  const earliestDueAt = pickEarliestDueAt(queue);
+  if (earliestDueAt == null) {
+    if (isAlarmsAvailable()) await clear(FEISHU_AUTO_SYNC_DEBOUNCE_ALARM_NAME);
+    return;
+  }
+  if (!isAlarmsAvailable()) return;
+  create(FEISHU_AUTO_SYNC_DEBOUNCE_ALARM_NAME, { when: earliestDueAt });
+}
+
+export type FeishuAutoSyncScheduler = {
+  enqueue: (conversationId: number, reason: string) => Promise<void>;
+  flush: () => Promise<void>;
+};
+
+export function createFeishuAutoSyncScheduler(deps: {
+  getInstanceId: () => string;
+  feishuSyncOrchestrator: FeishuSyncOrchestrator;
+}): FeishuAutoSyncScheduler {
+  const { getInstanceId, feishuSyncOrchestrator } = deps;
+
+  const enqueue = async (conversationId: number, _reason: string) => {
+    const id = Number(conversationId);
+    if (!Number.isFinite(id) || id <= 0) return;
+
+    const local = await storageGet([FEISHU_AUTO_SYNC_ENABLED_STORAGE_KEY]).catch(() => ({}));
+    const autoSyncEnabled = (local as any)?.[FEISHU_AUTO_SYNC_ENABLED_STORAGE_KEY] === true;
+    if (!autoSyncEnabled) return;
+    const providerEnabled = await isSyncProviderEnabled('feishu').catch(() => false);
+    if (!providerEnabled) return;
+
+    const now = Date.now();
+    const nextDueAt = now + FEISHU_AUTO_SYNC_DEBOUNCE_MS;
+
+    const queue = await readQueue();
+    const key = String(Math.floor(id));
+    const prevDueAt = Number(queue[key]);
+    if (Number.isFinite(prevDueAt) && prevDueAt >= nextDueAt) {
+      await scheduleNextAlarm(queue);
+      return;
+    }
+
+    const nextQueue = trimQueue({ ...queue, [key]: nextDueAt }, FEISHU_AUTO_SYNC_QUEUE_MAX_ITEMS);
+    await writeQueue(nextQueue);
+    await scheduleNextAlarm(nextQueue);
+  };
+
+  const flush = async () => {
+    const now = Date.now();
+    const instanceId = getInstanceId();
+    const queue = await readQueue();
+
+    const dueKeys = Object.keys(queue).filter((key) => Number(queue[key]) <= now);
+    const dueConversationIds = normalizeIds(dueKeys);
+    if (!dueConversationIds.length) {
+      await scheduleNextAlarm(queue);
+      return;
+    }
+
+    const local = await storageGet([FEISHU_AUTO_SYNC_ENABLED_STORAGE_KEY]).catch(() => ({}));
+    const autoSyncEnabled = (local as any)?.[FEISHU_AUTO_SYNC_ENABLED_STORAGE_KEY] === true;
+    const providerEnabled = await isSyncProviderEnabled('feishu').catch(() => false);
+
+    const restQueue: QueueMap = { ...queue };
+    for (const key of dueKeys) delete restQueue[key];
+
+    if (!providerEnabled || !autoSyncEnabled) {
+      await writeQueue(restQueue);
+      await scheduleNextAlarm(restQueue);
+      return;
+    }
+
+    try {
+      await feishuSyncOrchestrator.syncConversations({ conversationIds: dueConversationIds, instanceId });
+      await writeQueue(restQueue);
+      await scheduleNextAlarm(restQueue);
+    } catch (error) {
+      if (isAlreadyRunningError(error)) {
+        const delayedQueue: QueueMap = { ...queue };
+        const delayedDueAt = now + FEISHU_AUTO_SYNC_DEBOUNCE_MS;
+        for (const conversationId of dueConversationIds) delayedQueue[String(conversationId)] = delayedDueAt;
+        const trimmed = trimQueue(delayedQueue, FEISHU_AUTO_SYNC_QUEUE_MAX_ITEMS);
+        await writeQueue(trimmed);
+        await scheduleNextAlarm(trimmed);
+        return;
+      }
+
+      await writeQueue(restQueue);
+      await scheduleNextAlarm(restQueue);
+    }
+  };
+
+  return { enqueue, flush };
+}
+

--- a/src/services/sync/auto-sync/feishu-auto-sync-scheduler.ts
+++ b/src/services/sync/auto-sync/feishu-auto-sync-scheduler.ts
@@ -49,4 +49,3 @@ export function createFeishuAutoSyncScheduler(
       deps.feishuSyncOrchestrator.syncConversations({ conversationIds, instanceId } as any) as any,
   });
 }
-

--- a/src/services/sync/auto-sync/notion-auto-sync-scheduler.ts
+++ b/src/services/sync/auto-sync/notion-auto-sync-scheduler.ts
@@ -1,0 +1,210 @@
+import { create, clear, isAlarmsAvailable } from '@platform/alarms/alarms';
+import { storageGet, storageSet } from '@services/shared/storage';
+import { isSyncProviderEnabled } from '@services/sync/sync-provider-gate';
+import { getNotionOAuthToken } from '@services/sync/notion/auth/token-store';
+import notionSyncJobStore from '@services/sync/notion/notion-sync-job-store';
+
+import type { NotionSyncOrchestrator } from '@services/bootstrap/background-services';
+import {
+  NOTION_AUTO_SYNC_DEBOUNCE_ALARM_NAME,
+  NOTION_AUTO_SYNC_DEBOUNCE_MS,
+  NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY,
+  NOTION_AUTO_SYNC_QUEUE_MAX_ITEMS,
+  NOTION_AUTO_SYNC_QUEUE_STORAGE_KEY,
+} from '@services/sync/auto-sync/auto-sync-keys';
+
+type QueueMap = Record<string, number>;
+
+function normalizeQueue(value: unknown): QueueMap {
+  if (!value || typeof value !== 'object') return {};
+  const out: QueueMap = {};
+  for (const [key, rawDueAt] of Object.entries(value as Record<string, unknown>)) {
+    const conversationId = Number(key);
+    if (!Number.isFinite(conversationId) || conversationId <= 0) continue;
+    const dueAt = Number(rawDueAt);
+    if (!Number.isFinite(dueAt) || dueAt <= 0) continue;
+    out[String(conversationId)] = Math.floor(dueAt);
+  }
+  return out;
+}
+
+function trimQueue(queue: QueueMap, maxItems: number): QueueMap {
+  const entries = Object.entries(queue);
+  const max = Number.isFinite(Number(maxItems)) ? Math.max(1, Math.floor(Number(maxItems))) : 200;
+  if (entries.length <= max) return queue;
+  entries.sort((a, b) => a[1] - b[1]);
+  const kept = entries.slice(0, max);
+  const out: QueueMap = {};
+  for (const [id, dueAt] of kept) out[id] = dueAt;
+  return out;
+}
+
+function pickEarliestDueAt(queue: QueueMap): number | null {
+  let earliest: number | null = null;
+  for (const dueAt of Object.values(queue)) {
+    const value = Number(dueAt);
+    if (!Number.isFinite(value) || value <= 0) continue;
+    if (earliest == null || value < earliest) earliest = value;
+  }
+  return earliest;
+}
+
+function normalizeIds(ids: string[]) {
+  return Array.from(
+    new Set(ids.map((x) => Number(x)).filter((x) => Number.isFinite(x) && x > 0).map((x) => Math.floor(x))),
+  );
+}
+
+function isAlreadyRunningError(error: unknown): boolean {
+  const code = String((error as any)?.code || '').trim();
+  if (code === 'sync_already_running') return true;
+  const message = error instanceof Error ? error.message : String(error || '').trim();
+  return message.toLowerCase().includes('sync already in progress');
+}
+
+async function readQueue(): Promise<QueueMap> {
+  const res = await storageGet([NOTION_AUTO_SYNC_QUEUE_STORAGE_KEY]).catch(() => ({}));
+  return normalizeQueue((res as any)?.[NOTION_AUTO_SYNC_QUEUE_STORAGE_KEY]);
+}
+
+async function writeQueue(queue: QueueMap): Promise<void> {
+  await storageSet({ [NOTION_AUTO_SYNC_QUEUE_STORAGE_KEY]: queue }).catch(() => {});
+}
+
+async function scheduleNextAlarm(queue: QueueMap): Promise<void> {
+  const earliestDueAt = pickEarliestDueAt(queue);
+  if (earliestDueAt == null) {
+    if (isAlarmsAvailable()) await clear(NOTION_AUTO_SYNC_DEBOUNCE_ALARM_NAME);
+    return;
+  }
+  if (!isAlarmsAvailable()) return;
+  create(NOTION_AUTO_SYNC_DEBOUNCE_ALARM_NAME, { when: earliestDueAt });
+}
+
+async function writePreflightFailureJob(conversationIds: number[], instanceId: string, error: string) {
+  const now = Date.now();
+  await notionSyncJobStore
+    .setJob({
+      id: `${now}_autosync_preflight`,
+      provider: 'notion',
+      instanceId,
+      status: 'done',
+      startedAt: now,
+      updatedAt: now,
+      finishedAt: now,
+      conversationIds,
+      currentConversationId: conversationIds[0] || undefined,
+      currentStage: 'preparing_sync',
+      okCount: 0,
+      failCount: conversationIds.length,
+      perConversation: conversationIds.map((conversationId) => ({
+        conversationId,
+        conversationTitle: '',
+        ok: false,
+        mode: 'failed',
+        appended: 0,
+        error,
+        warnings: [],
+        at: now,
+      })),
+    })
+    .catch(() => {});
+}
+
+export type NotionAutoSyncScheduler = {
+  enqueue: (conversationId: number, reason: string) => Promise<void>;
+  flush: () => Promise<void>;
+};
+
+export function createNotionAutoSyncScheduler(deps: {
+  getInstanceId: () => string;
+  notionSyncOrchestrator: NotionSyncOrchestrator;
+}): NotionAutoSyncScheduler {
+  const { getInstanceId, notionSyncOrchestrator } = deps;
+
+  const enqueue = async (conversationId: number, _reason: string) => {
+    const id = Number(conversationId);
+    if (!Number.isFinite(id) || id <= 0) return;
+
+    const local = await storageGet([NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY]).catch(() => ({}));
+    const autoSyncEnabled = (local as any)?.[NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY] === true;
+    if (!autoSyncEnabled) return;
+    const providerEnabled = await isSyncProviderEnabled('notion').catch(() => false);
+    if (!providerEnabled) return;
+
+    const now = Date.now();
+    const nextDueAt = now + NOTION_AUTO_SYNC_DEBOUNCE_MS;
+
+    const queue = await readQueue();
+    const key = String(Math.floor(id));
+    const prevDueAt = Number(queue[key]);
+    if (Number.isFinite(prevDueAt) && prevDueAt >= nextDueAt) {
+      await scheduleNextAlarm(queue);
+      return;
+    }
+
+    const nextQueue = trimQueue({ ...queue, [key]: nextDueAt }, NOTION_AUTO_SYNC_QUEUE_MAX_ITEMS);
+    await writeQueue(nextQueue);
+    await scheduleNextAlarm(nextQueue);
+  };
+
+  const flush = async () => {
+    const now = Date.now();
+    const instanceId = getInstanceId();
+    const queue = await readQueue();
+
+    const dueKeys = Object.keys(queue).filter((key) => Number(queue[key]) <= now);
+    const dueConversationIds = normalizeIds(dueKeys);
+    if (!dueConversationIds.length) {
+      await scheduleNextAlarm(queue);
+      return;
+    }
+
+    const local = await storageGet([NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY, 'notion_parent_page_id']).catch(() => ({}));
+    const autoSyncEnabled = (local as any)?.[NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY] === true;
+    const providerEnabled = await isSyncProviderEnabled('notion').catch(() => false);
+    const token = await getNotionOAuthToken().catch(() => null);
+    const parentPageId = String((local as any)?.notion_parent_page_id || '').trim();
+
+    const preflightError = !providerEnabled
+      ? 'sync provider disabled'
+      : !autoSyncEnabled
+        ? 'notion auto sync disabled'
+        : !token || !token.accessToken
+          ? 'notion not connected'
+          : !parentPageId
+            ? 'missing parentPageId'
+            : '';
+
+    const restQueue: QueueMap = { ...queue };
+    for (const key of dueKeys) delete restQueue[key];
+
+    if (preflightError) {
+      await writePreflightFailureJob(dueConversationIds, instanceId, preflightError);
+      await writeQueue(restQueue);
+      await scheduleNextAlarm(restQueue);
+      return;
+    }
+
+    try {
+      await notionSyncOrchestrator.syncConversations({ conversationIds: dueConversationIds, instanceId });
+      await writeQueue(restQueue);
+      await scheduleNextAlarm(restQueue);
+    } catch (error) {
+      if (isAlreadyRunningError(error)) {
+        const delayedQueue: QueueMap = { ...queue };
+        const delayedDueAt = now + NOTION_AUTO_SYNC_DEBOUNCE_MS;
+        for (const conversationId of dueConversationIds) delayedQueue[String(conversationId)] = delayedDueAt;
+        const trimmed = trimQueue(delayedQueue, NOTION_AUTO_SYNC_QUEUE_MAX_ITEMS);
+        await writeQueue(trimmed);
+        await scheduleNextAlarm(trimmed);
+        return;
+      }
+
+      await writeQueue(restQueue);
+      await scheduleNextAlarm(restQueue);
+    }
+  };
+
+  return { enqueue, flush };
+}

--- a/src/services/sync/auto-sync/notion-auto-sync-scheduler.ts
+++ b/src/services/sync/auto-sync/notion-auto-sync-scheduler.ts
@@ -12,77 +12,13 @@ import {
   NOTION_AUTO_SYNC_QUEUE_MAX_ITEMS,
   NOTION_AUTO_SYNC_QUEUE_STORAGE_KEY,
 } from '@services/sync/auto-sync/auto-sync-keys';
+import {
+  createAutoSyncSchedulerCore,
+  type AutoSyncScheduler,
+  type AutoSyncSchedulerInfra,
+} from '@services/sync/auto-sync/auto-sync-scheduler-core';
 
-type QueueMap = Record<string, number>;
-
-function normalizeQueue(value: unknown): QueueMap {
-  if (!value || typeof value !== 'object') return {};
-  const out: QueueMap = {};
-  for (const [key, rawDueAt] of Object.entries(value as Record<string, unknown>)) {
-    const conversationId = Number(key);
-    if (!Number.isFinite(conversationId) || conversationId <= 0) continue;
-    const dueAt = Number(rawDueAt);
-    if (!Number.isFinite(dueAt) || dueAt <= 0) continue;
-    out[String(conversationId)] = Math.floor(dueAt);
-  }
-  return out;
-}
-
-function trimQueue(queue: QueueMap, maxItems: number): QueueMap {
-  const entries = Object.entries(queue);
-  const max = Number.isFinite(Number(maxItems)) ? Math.max(1, Math.floor(Number(maxItems))) : 200;
-  if (entries.length <= max) return queue;
-  entries.sort((a, b) => a[1] - b[1]);
-  const kept = entries.slice(0, max);
-  const out: QueueMap = {};
-  for (const [id, dueAt] of kept) out[id] = dueAt;
-  return out;
-}
-
-function pickEarliestDueAt(queue: QueueMap): number | null {
-  let earliest: number | null = null;
-  for (const dueAt of Object.values(queue)) {
-    const value = Number(dueAt);
-    if (!Number.isFinite(value) || value <= 0) continue;
-    if (earliest == null || value < earliest) earliest = value;
-  }
-  return earliest;
-}
-
-function normalizeIds(ids: string[]) {
-  return Array.from(
-    new Set(ids.map((x) => Number(x)).filter((x) => Number.isFinite(x) && x > 0).map((x) => Math.floor(x))),
-  );
-}
-
-function isAlreadyRunningError(error: unknown): boolean {
-  const code = String((error as any)?.code || '').trim();
-  if (code === 'sync_already_running') return true;
-  const message = error instanceof Error ? error.message : String(error || '').trim();
-  return message.toLowerCase().includes('sync already in progress');
-}
-
-async function readQueue(): Promise<QueueMap> {
-  const res = await storageGet([NOTION_AUTO_SYNC_QUEUE_STORAGE_KEY]).catch(() => ({}));
-  return normalizeQueue((res as any)?.[NOTION_AUTO_SYNC_QUEUE_STORAGE_KEY]);
-}
-
-async function writeQueue(queue: QueueMap): Promise<void> {
-  await storageSet({ [NOTION_AUTO_SYNC_QUEUE_STORAGE_KEY]: queue }).catch(() => {});
-}
-
-async function scheduleNextAlarm(queue: QueueMap): Promise<void> {
-  const earliestDueAt = pickEarliestDueAt(queue);
-  if (earliestDueAt == null) {
-    if (isAlarmsAvailable()) await clear(NOTION_AUTO_SYNC_DEBOUNCE_ALARM_NAME);
-    return;
-  }
-  if (!isAlarmsAvailable()) return;
-  create(NOTION_AUTO_SYNC_DEBOUNCE_ALARM_NAME, { when: earliestDueAt });
-}
-
-async function writePreflightFailureJob(conversationIds: number[], instanceId: string, error: string) {
-  const now = Date.now();
+async function writePreflightFailureJob(conversationIds: number[], instanceId: string, error: string, now: number) {
   await notionSyncJobStore
     .setJob({
       id: `${now}_autosync_preflight`,
@@ -111,100 +47,46 @@ async function writePreflightFailureJob(conversationIds: number[], instanceId: s
     .catch(() => {});
 }
 
-export type NotionAutoSyncScheduler = {
-  enqueue: (conversationId: number, reason: string) => Promise<void>;
-  flush: () => Promise<void>;
-};
+export type NotionAutoSyncScheduler = AutoSyncScheduler;
 
-export function createNotionAutoSyncScheduler(deps: {
-  getInstanceId: () => string;
-  notionSyncOrchestrator: NotionSyncOrchestrator;
-}): NotionAutoSyncScheduler {
-  const { getInstanceId, notionSyncOrchestrator } = deps;
-
-  const enqueue = async (conversationId: number, _reason: string) => {
-    const id = Number(conversationId);
-    if (!Number.isFinite(id) || id <= 0) return;
-
-    const local = await storageGet([NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY]).catch(() => ({}));
-    const autoSyncEnabled = (local as any)?.[NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY] === true;
-    if (!autoSyncEnabled) return;
-    const providerEnabled = await isSyncProviderEnabled('notion').catch(() => false);
-    if (!providerEnabled) return;
-
-    const now = Date.now();
-    const nextDueAt = now + NOTION_AUTO_SYNC_DEBOUNCE_MS;
-
-    const queue = await readQueue();
-    const key = String(Math.floor(id));
-    const prevDueAt = Number(queue[key]);
-    if (Number.isFinite(prevDueAt) && prevDueAt >= nextDueAt) {
-      await scheduleNextAlarm(queue);
-      return;
-    }
-
-    const nextQueue = trimQueue({ ...queue, [key]: nextDueAt }, NOTION_AUTO_SYNC_QUEUE_MAX_ITEMS);
-    await writeQueue(nextQueue);
-    await scheduleNextAlarm(nextQueue);
+export function createNotionAutoSyncScheduler(
+  deps: {
+    getInstanceId: () => string;
+    notionSyncOrchestrator: NotionSyncOrchestrator;
+  },
+  infraOverrides?: Partial<AutoSyncSchedulerInfra>,
+): NotionAutoSyncScheduler {
+  const infra: AutoSyncSchedulerInfra = {
+    now: () => Date.now(),
+    storage: { get: storageGet as any, set: storageSet as any },
+    alarms: {
+      isAvailable: () => isAlarmsAvailable(),
+      create: (name, info) => create(name, info),
+      clear: (name) => clear(name),
+    },
+    ...infraOverrides,
   };
 
-  const flush = async () => {
-    const now = Date.now();
-    const instanceId = getInstanceId();
-    const queue = await readQueue();
-
-    const dueKeys = Object.keys(queue).filter((key) => Number(queue[key]) <= now);
-    const dueConversationIds = normalizeIds(dueKeys);
-    if (!dueConversationIds.length) {
-      await scheduleNextAlarm(queue);
-      return;
-    }
-
-    const local = await storageGet([NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY, 'notion_parent_page_id']).catch(() => ({}));
-    const autoSyncEnabled = (local as any)?.[NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY] === true;
-    const providerEnabled = await isSyncProviderEnabled('notion').catch(() => false);
-    const token = await getNotionOAuthToken().catch(() => null);
-    const parentPageId = String((local as any)?.notion_parent_page_id || '').trim();
-
-    const preflightError = !providerEnabled
-      ? 'sync provider disabled'
-      : !autoSyncEnabled
-        ? 'notion auto sync disabled'
-        : !token || !token.accessToken
-          ? 'notion not connected'
-          : !parentPageId
-            ? 'missing parentPageId'
-            : '';
-
-    const restQueue: QueueMap = { ...queue };
-    for (const key of dueKeys) delete restQueue[key];
-
-    if (preflightError) {
-      await writePreflightFailureJob(dueConversationIds, instanceId, preflightError);
-      await writeQueue(restQueue);
-      await scheduleNextAlarm(restQueue);
-      return;
-    }
-
-    try {
-      await notionSyncOrchestrator.syncConversations({ conversationIds: dueConversationIds, instanceId });
-      await writeQueue(restQueue);
-      await scheduleNextAlarm(restQueue);
-    } catch (error) {
-      if (isAlreadyRunningError(error)) {
-        const delayedQueue: QueueMap = { ...queue };
-        const delayedDueAt = now + NOTION_AUTO_SYNC_DEBOUNCE_MS;
-        for (const conversationId of dueConversationIds) delayedQueue[String(conversationId)] = delayedDueAt;
-        const trimmed = trimQueue(delayedQueue, NOTION_AUTO_SYNC_QUEUE_MAX_ITEMS);
-        await writeQueue(trimmed);
-        await scheduleNextAlarm(trimmed);
-        return;
-      }
-
-      await writeQueue(restQueue);
-      await scheduleNextAlarm(restQueue);
-    }
-  };
-
-  return { enqueue, flush };
+  return createAutoSyncSchedulerCore({
+    queueStorageKey: NOTION_AUTO_SYNC_QUEUE_STORAGE_KEY,
+    enabledStorageKey: NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY,
+    alarmName: NOTION_AUTO_SYNC_DEBOUNCE_ALARM_NAME,
+    debounceMs: NOTION_AUTO_SYNC_DEBOUNCE_MS,
+    maxItems: NOTION_AUTO_SYNC_QUEUE_MAX_ITEMS,
+    infra,
+    getInstanceId: deps.getInstanceId,
+    isProviderEnabled: () => isSyncProviderEnabled('notion'),
+    syncConversations: async (conversationIds, instanceId) => {
+      const local = await infra.storage.get(['notion_parent_page_id']).catch(() => ({} as any));
+      const token = await getNotionOAuthToken().catch(() => null);
+      const parentPageId = String((local as any)?.notion_parent_page_id || '').trim();
+      if (!token || !(token as any).accessToken) throw new Error('notion not connected');
+      if (!parentPageId) throw new Error('missing parentPageId');
+      await deps.notionSyncOrchestrator.syncConversations({ conversationIds, instanceId } as any);
+    },
+    onPreflightFailed: async ({ conversationIds, instanceId, error }) => {
+      await writePreflightFailureJob(conversationIds, instanceId, error, infra.now());
+    },
+  });
 }
+

--- a/src/services/sync/auto-sync/notion-auto-sync-scheduler.ts
+++ b/src/services/sync/auto-sync/notion-auto-sync-scheduler.ts
@@ -77,7 +77,7 @@ export function createNotionAutoSyncScheduler(
     getInstanceId: deps.getInstanceId,
     isProviderEnabled: () => isSyncProviderEnabled('notion'),
     syncConversations: async (conversationIds, instanceId) => {
-      const local = await infra.storage.get(['notion_parent_page_id']).catch(() => ({} as any));
+      const local = await infra.storage.get(['notion_parent_page_id']).catch(() => ({}) as any);
       const token = await getNotionOAuthToken().catch(() => null);
       const parentPageId = String((local as any)?.notion_parent_page_id || '').trim();
       if (!token || !(token as any).accessToken) throw new Error('notion not connected');
@@ -89,4 +89,3 @@ export function createNotionAutoSyncScheduler(
     },
   });
 }
-

--- a/src/services/sync/auto-sync/obsidian-auto-sync-scheduler.ts
+++ b/src/services/sync/auto-sync/obsidian-auto-sync-scheduler.ts
@@ -1,0 +1,166 @@
+import { create, clear, isAlarmsAvailable } from '@platform/alarms/alarms';
+import { storageGet, storageSet } from '@services/shared/storage';
+import { isSyncProviderEnabled } from '@services/sync/sync-provider-gate';
+
+import type { ObsidianSyncOrchestrator } from '@services/bootstrap/background-services';
+import {
+  OBSIDIAN_AUTO_SYNC_DEBOUNCE_ALARM_NAME,
+  OBSIDIAN_AUTO_SYNC_DEBOUNCE_MS,
+  OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY,
+  OBSIDIAN_AUTO_SYNC_QUEUE_MAX_ITEMS,
+  OBSIDIAN_AUTO_SYNC_QUEUE_STORAGE_KEY,
+} from '@services/sync/auto-sync/auto-sync-keys';
+
+type QueueMap = Record<string, number>;
+
+function normalizeQueue(value: unknown): QueueMap {
+  if (!value || typeof value !== 'object') return {};
+  const out: QueueMap = {};
+  for (const [key, rawDueAt] of Object.entries(value as Record<string, unknown>)) {
+    const conversationId = Number(key);
+    if (!Number.isFinite(conversationId) || conversationId <= 0) continue;
+    const dueAt = Number(rawDueAt);
+    if (!Number.isFinite(dueAt) || dueAt <= 0) continue;
+    out[String(conversationId)] = Math.floor(dueAt);
+  }
+  return out;
+}
+
+function trimQueue(queue: QueueMap, maxItems: number): QueueMap {
+  const entries = Object.entries(queue);
+  const max = Number.isFinite(Number(maxItems)) ? Math.max(1, Math.floor(Number(maxItems))) : 200;
+  if (entries.length <= max) return queue;
+  entries.sort((a, b) => a[1] - b[1]);
+  const kept = entries.slice(0, max);
+  const out: QueueMap = {};
+  for (const [id, dueAt] of kept) out[id] = dueAt;
+  return out;
+}
+
+function pickEarliestDueAt(queue: QueueMap): number | null {
+  let earliest: number | null = null;
+  for (const dueAt of Object.values(queue)) {
+    const value = Number(dueAt);
+    if (!Number.isFinite(value) || value <= 0) continue;
+    if (earliest == null || value < earliest) earliest = value;
+  }
+  return earliest;
+}
+
+function normalizeIds(ids: string[]) {
+  return Array.from(
+    new Set(ids.map((x) => Number(x)).filter((x) => Number.isFinite(x) && x > 0).map((x) => Math.floor(x))),
+  );
+}
+
+function isAlreadyRunningError(error: unknown): boolean {
+  const code = String((error as any)?.code || '').trim();
+  if (code === 'sync_already_running') return true;
+  const message = error instanceof Error ? error.message : String(error || '').trim();
+  return message.toLowerCase().includes('sync already in progress');
+}
+
+async function readQueue(): Promise<QueueMap> {
+  const res = await storageGet([OBSIDIAN_AUTO_SYNC_QUEUE_STORAGE_KEY]).catch(() => ({}));
+  return normalizeQueue((res as any)?.[OBSIDIAN_AUTO_SYNC_QUEUE_STORAGE_KEY]);
+}
+
+async function writeQueue(queue: QueueMap): Promise<void> {
+  await storageSet({ [OBSIDIAN_AUTO_SYNC_QUEUE_STORAGE_KEY]: queue }).catch(() => {});
+}
+
+async function scheduleNextAlarm(queue: QueueMap): Promise<void> {
+  const earliestDueAt = pickEarliestDueAt(queue);
+  if (earliestDueAt == null) {
+    if (isAlarmsAvailable()) await clear(OBSIDIAN_AUTO_SYNC_DEBOUNCE_ALARM_NAME);
+    return;
+  }
+  if (!isAlarmsAvailable()) return;
+  create(OBSIDIAN_AUTO_SYNC_DEBOUNCE_ALARM_NAME, { when: earliestDueAt });
+}
+
+export type ObsidianAutoSyncScheduler = {
+  enqueue: (conversationId: number, reason: string) => Promise<void>;
+  flush: () => Promise<void>;
+};
+
+export function createObsidianAutoSyncScheduler(deps: {
+  getInstanceId: () => string;
+  obsidianSyncOrchestrator: ObsidianSyncOrchestrator;
+}): ObsidianAutoSyncScheduler {
+  const { getInstanceId, obsidianSyncOrchestrator } = deps;
+
+  const enqueue = async (conversationId: number, _reason: string) => {
+    const id = Number(conversationId);
+    if (!Number.isFinite(id) || id <= 0) return;
+
+    const local = await storageGet([OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY]).catch(() => ({}));
+    const autoSyncEnabled = (local as any)?.[OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY] === true;
+    if (!autoSyncEnabled) return;
+    const providerEnabled = await isSyncProviderEnabled('obsidian').catch(() => false);
+    if (!providerEnabled) return;
+
+    const now = Date.now();
+    const nextDueAt = now + OBSIDIAN_AUTO_SYNC_DEBOUNCE_MS;
+
+    const queue = await readQueue();
+    const key = String(Math.floor(id));
+    const prevDueAt = Number(queue[key]);
+    if (Number.isFinite(prevDueAt) && prevDueAt >= nextDueAt) {
+      await scheduleNextAlarm(queue);
+      return;
+    }
+
+    const nextQueue = trimQueue({ ...queue, [key]: nextDueAt }, OBSIDIAN_AUTO_SYNC_QUEUE_MAX_ITEMS);
+    await writeQueue(nextQueue);
+    await scheduleNextAlarm(nextQueue);
+  };
+
+  const flush = async () => {
+    const now = Date.now();
+    const instanceId = getInstanceId();
+    const queue = await readQueue();
+
+    const dueKeys = Object.keys(queue).filter((key) => Number(queue[key]) <= now);
+    const dueConversationIds = normalizeIds(dueKeys);
+    if (!dueConversationIds.length) {
+      await scheduleNextAlarm(queue);
+      return;
+    }
+
+    const local = await storageGet([OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY]).catch(() => ({}));
+    const autoSyncEnabled = (local as any)?.[OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY] === true;
+    const providerEnabled = await isSyncProviderEnabled('obsidian').catch(() => false);
+
+    const restQueue: QueueMap = { ...queue };
+    for (const key of dueKeys) delete restQueue[key];
+
+    if (!providerEnabled || !autoSyncEnabled) {
+      await writeQueue(restQueue);
+      await scheduleNextAlarm(restQueue);
+      return;
+    }
+
+    try {
+      await obsidianSyncOrchestrator.syncConversations({ conversationIds: dueConversationIds, instanceId });
+      await writeQueue(restQueue);
+      await scheduleNextAlarm(restQueue);
+    } catch (error) {
+      if (isAlreadyRunningError(error)) {
+        const delayedQueue: QueueMap = { ...queue };
+        const delayedDueAt = now + OBSIDIAN_AUTO_SYNC_DEBOUNCE_MS;
+        for (const conversationId of dueConversationIds) delayedQueue[String(conversationId)] = delayedDueAt;
+        const trimmed = trimQueue(delayedQueue, OBSIDIAN_AUTO_SYNC_QUEUE_MAX_ITEMS);
+        await writeQueue(trimmed);
+        await scheduleNextAlarm(trimmed);
+        return;
+      }
+
+      await writeQueue(restQueue);
+      await scheduleNextAlarm(restQueue);
+    }
+  };
+
+  return { enqueue, flush };
+}
+

--- a/src/services/sync/auto-sync/obsidian-auto-sync-scheduler.ts
+++ b/src/services/sync/auto-sync/obsidian-auto-sync-scheduler.ts
@@ -49,4 +49,3 @@ export function createObsidianAutoSyncScheduler(
       deps.obsidianSyncOrchestrator.syncConversations({ conversationIds, instanceId } as any) as any,
   });
 }
-

--- a/src/services/sync/auto-sync/obsidian-auto-sync-scheduler.ts
+++ b/src/services/sync/auto-sync/obsidian-auto-sync-scheduler.ts
@@ -10,157 +10,43 @@ import {
   OBSIDIAN_AUTO_SYNC_QUEUE_MAX_ITEMS,
   OBSIDIAN_AUTO_SYNC_QUEUE_STORAGE_KEY,
 } from '@services/sync/auto-sync/auto-sync-keys';
+import {
+  createAutoSyncSchedulerCore,
+  type AutoSyncScheduler,
+  type AutoSyncSchedulerInfra,
+} from '@services/sync/auto-sync/auto-sync-scheduler-core';
 
-type QueueMap = Record<string, number>;
+export type ObsidianAutoSyncScheduler = AutoSyncScheduler;
 
-function normalizeQueue(value: unknown): QueueMap {
-  if (!value || typeof value !== 'object') return {};
-  const out: QueueMap = {};
-  for (const [key, rawDueAt] of Object.entries(value as Record<string, unknown>)) {
-    const conversationId = Number(key);
-    if (!Number.isFinite(conversationId) || conversationId <= 0) continue;
-    const dueAt = Number(rawDueAt);
-    if (!Number.isFinite(dueAt) || dueAt <= 0) continue;
-    out[String(conversationId)] = Math.floor(dueAt);
-  }
-  return out;
-}
-
-function trimQueue(queue: QueueMap, maxItems: number): QueueMap {
-  const entries = Object.entries(queue);
-  const max = Number.isFinite(Number(maxItems)) ? Math.max(1, Math.floor(Number(maxItems))) : 200;
-  if (entries.length <= max) return queue;
-  entries.sort((a, b) => a[1] - b[1]);
-  const kept = entries.slice(0, max);
-  const out: QueueMap = {};
-  for (const [id, dueAt] of kept) out[id] = dueAt;
-  return out;
-}
-
-function pickEarliestDueAt(queue: QueueMap): number | null {
-  let earliest: number | null = null;
-  for (const dueAt of Object.values(queue)) {
-    const value = Number(dueAt);
-    if (!Number.isFinite(value) || value <= 0) continue;
-    if (earliest == null || value < earliest) earliest = value;
-  }
-  return earliest;
-}
-
-function normalizeIds(ids: string[]) {
-  return Array.from(
-    new Set(ids.map((x) => Number(x)).filter((x) => Number.isFinite(x) && x > 0).map((x) => Math.floor(x))),
-  );
-}
-
-function isAlreadyRunningError(error: unknown): boolean {
-  const code = String((error as any)?.code || '').trim();
-  if (code === 'sync_already_running') return true;
-  const message = error instanceof Error ? error.message : String(error || '').trim();
-  return message.toLowerCase().includes('sync already in progress');
-}
-
-async function readQueue(): Promise<QueueMap> {
-  const res = await storageGet([OBSIDIAN_AUTO_SYNC_QUEUE_STORAGE_KEY]).catch(() => ({}));
-  return normalizeQueue((res as any)?.[OBSIDIAN_AUTO_SYNC_QUEUE_STORAGE_KEY]);
-}
-
-async function writeQueue(queue: QueueMap): Promise<void> {
-  await storageSet({ [OBSIDIAN_AUTO_SYNC_QUEUE_STORAGE_KEY]: queue }).catch(() => {});
-}
-
-async function scheduleNextAlarm(queue: QueueMap): Promise<void> {
-  const earliestDueAt = pickEarliestDueAt(queue);
-  if (earliestDueAt == null) {
-    if (isAlarmsAvailable()) await clear(OBSIDIAN_AUTO_SYNC_DEBOUNCE_ALARM_NAME);
-    return;
-  }
-  if (!isAlarmsAvailable()) return;
-  create(OBSIDIAN_AUTO_SYNC_DEBOUNCE_ALARM_NAME, { when: earliestDueAt });
-}
-
-export type ObsidianAutoSyncScheduler = {
-  enqueue: (conversationId: number, reason: string) => Promise<void>;
-  flush: () => Promise<void>;
-};
-
-export function createObsidianAutoSyncScheduler(deps: {
-  getInstanceId: () => string;
-  obsidianSyncOrchestrator: ObsidianSyncOrchestrator;
-}): ObsidianAutoSyncScheduler {
-  const { getInstanceId, obsidianSyncOrchestrator } = deps;
-
-  const enqueue = async (conversationId: number, _reason: string) => {
-    const id = Number(conversationId);
-    if (!Number.isFinite(id) || id <= 0) return;
-
-    const local = await storageGet([OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY]).catch(() => ({}));
-    const autoSyncEnabled = (local as any)?.[OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY] === true;
-    if (!autoSyncEnabled) return;
-    const providerEnabled = await isSyncProviderEnabled('obsidian').catch(() => false);
-    if (!providerEnabled) return;
-
-    const now = Date.now();
-    const nextDueAt = now + OBSIDIAN_AUTO_SYNC_DEBOUNCE_MS;
-
-    const queue = await readQueue();
-    const key = String(Math.floor(id));
-    const prevDueAt = Number(queue[key]);
-    if (Number.isFinite(prevDueAt) && prevDueAt >= nextDueAt) {
-      await scheduleNextAlarm(queue);
-      return;
-    }
-
-    const nextQueue = trimQueue({ ...queue, [key]: nextDueAt }, OBSIDIAN_AUTO_SYNC_QUEUE_MAX_ITEMS);
-    await writeQueue(nextQueue);
-    await scheduleNextAlarm(nextQueue);
+export function createObsidianAutoSyncScheduler(
+  deps: {
+    getInstanceId: () => string;
+    obsidianSyncOrchestrator: ObsidianSyncOrchestrator;
+  },
+  infraOverrides?: Partial<AutoSyncSchedulerInfra>,
+): ObsidianAutoSyncScheduler {
+  const infra: AutoSyncSchedulerInfra = {
+    now: () => Date.now(),
+    storage: { get: storageGet as any, set: storageSet as any },
+    alarms: {
+      isAvailable: () => isAlarmsAvailable(),
+      create: (name, info) => create(name, info),
+      clear: (name) => clear(name),
+    },
+    ...infraOverrides,
   };
 
-  const flush = async () => {
-    const now = Date.now();
-    const instanceId = getInstanceId();
-    const queue = await readQueue();
-
-    const dueKeys = Object.keys(queue).filter((key) => Number(queue[key]) <= now);
-    const dueConversationIds = normalizeIds(dueKeys);
-    if (!dueConversationIds.length) {
-      await scheduleNextAlarm(queue);
-      return;
-    }
-
-    const local = await storageGet([OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY]).catch(() => ({}));
-    const autoSyncEnabled = (local as any)?.[OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY] === true;
-    const providerEnabled = await isSyncProviderEnabled('obsidian').catch(() => false);
-
-    const restQueue: QueueMap = { ...queue };
-    for (const key of dueKeys) delete restQueue[key];
-
-    if (!providerEnabled || !autoSyncEnabled) {
-      await writeQueue(restQueue);
-      await scheduleNextAlarm(restQueue);
-      return;
-    }
-
-    try {
-      await obsidianSyncOrchestrator.syncConversations({ conversationIds: dueConversationIds, instanceId });
-      await writeQueue(restQueue);
-      await scheduleNextAlarm(restQueue);
-    } catch (error) {
-      if (isAlreadyRunningError(error)) {
-        const delayedQueue: QueueMap = { ...queue };
-        const delayedDueAt = now + OBSIDIAN_AUTO_SYNC_DEBOUNCE_MS;
-        for (const conversationId of dueConversationIds) delayedQueue[String(conversationId)] = delayedDueAt;
-        const trimmed = trimQueue(delayedQueue, OBSIDIAN_AUTO_SYNC_QUEUE_MAX_ITEMS);
-        await writeQueue(trimmed);
-        await scheduleNextAlarm(trimmed);
-        return;
-      }
-
-      await writeQueue(restQueue);
-      await scheduleNextAlarm(restQueue);
-    }
-  };
-
-  return { enqueue, flush };
+  return createAutoSyncSchedulerCore({
+    queueStorageKey: OBSIDIAN_AUTO_SYNC_QUEUE_STORAGE_KEY,
+    enabledStorageKey: OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY,
+    alarmName: OBSIDIAN_AUTO_SYNC_DEBOUNCE_ALARM_NAME,
+    debounceMs: OBSIDIAN_AUTO_SYNC_DEBOUNCE_MS,
+    maxItems: OBSIDIAN_AUTO_SYNC_QUEUE_MAX_ITEMS,
+    infra,
+    getInstanceId: deps.getInstanceId,
+    isProviderEnabled: () => isSyncProviderEnabled('obsidian'),
+    syncConversations: (conversationIds, instanceId) =>
+      deps.obsidianSyncOrchestrator.syncConversations({ conversationIds, instanceId } as any) as any,
+  });
 }
 

--- a/src/ui/i18n/locales/en.ts
+++ b/src/ui/i18n/locales/en.ts
@@ -498,6 +498,7 @@ export const en = {
   providerFeishu: 'Feishu',
   notionSyncEnabledLabel: 'Sync to Notion',
   notionSyncEnabledHint: 'Notion sync is disabled. You can re-enable it anytime in Settings.',
+  notionAutoSyncEnabledLabel: 'Auto sync',
   obsidianSyncEnabledLabel: 'Sync to Obsidian',
   obsidianSyncEnabledHint: 'Obsidian sync is disabled. You can re-enable it anytime in Settings.',
   feishuOAuth: 'Feishu OAuth',

--- a/src/ui/i18n/locales/en.ts
+++ b/src/ui/i18n/locales/en.ts
@@ -501,6 +501,7 @@ export const en = {
   notionAutoSyncEnabledLabel: 'Auto sync',
   obsidianSyncEnabledLabel: 'Sync to Obsidian',
   obsidianSyncEnabledHint: 'Obsidian sync is disabled. You can re-enable it anytime in Settings.',
+  obsidianAutoSyncEnabledLabel: 'Auto sync',
   feishuOAuth: 'Feishu OAuth',
   feishuSyncEnabledLabel: 'Sync to Feishu',
   feishuSyncEnabledHint: 'Feishu sync is disabled. You can re-enable it anytime in Settings.',

--- a/src/ui/i18n/locales/en.ts
+++ b/src/ui/i18n/locales/en.ts
@@ -505,6 +505,7 @@ export const en = {
   feishuOAuth: 'Feishu OAuth',
   feishuSyncEnabledLabel: 'Sync to Feishu',
   feishuSyncEnabledHint: 'Feishu sync is disabled. You can re-enable it anytime in Settings.',
+  feishuAutoSyncEnabledLabel: 'Auto sync',
   feishuPaths: 'Feishu Paths',
   feishuPathsNote: 'Drive-root-relative folder paths. Nested folders supported. Empty uses defaults.',
   feishuOAuthClientIdLabel: 'App ID (Client ID)',

--- a/src/ui/i18n/locales/zh.ts
+++ b/src/ui/i18n/locales/zh.ts
@@ -500,6 +500,7 @@ export const zh: { [K in TranslationKey]: string } = {
   feishuOAuth: '飞书 OAuth',
   feishuSyncEnabledLabel: '同步到飞书',
   feishuSyncEnabledHint: '已关闭飞书同步，您可以随时在设置中重新开启。',
+  feishuAutoSyncEnabledLabel: '自动同步',
   feishuPaths: '飞书路径',
   feishuPathsNote: '相对于云盘根目录的文件夹路径。支持嵌套文件夹，留空则使用默认路径。',
   feishuOAuthClientIdLabel: 'App ID（Client ID）',

--- a/src/ui/i18n/locales/zh.ts
+++ b/src/ui/i18n/locales/zh.ts
@@ -493,6 +493,7 @@ export const zh: { [K in TranslationKey]: string } = {
   providerFeishu: '飞书',
   notionSyncEnabledLabel: '同步到 Notion',
   notionSyncEnabledHint: '已关闭 Notion 同步，您可以随时在设置中重新开启。',
+  notionAutoSyncEnabledLabel: '自动同步',
   obsidianSyncEnabledLabel: '同步到 Obsidian',
   obsidianSyncEnabledHint: '已关闭 Obsidian 同步，您可以随时在设置中重新开启。',
   feishuOAuth: '飞书 OAuth',

--- a/src/ui/i18n/locales/zh.ts
+++ b/src/ui/i18n/locales/zh.ts
@@ -496,6 +496,7 @@ export const zh: { [K in TranslationKey]: string } = {
   notionAutoSyncEnabledLabel: '自动同步',
   obsidianSyncEnabledLabel: '同步到 Obsidian',
   obsidianSyncEnabledHint: '已关闭 Obsidian 同步，您可以随时在设置中重新开启。',
+  obsidianAutoSyncEnabledLabel: '自动同步',
   feishuOAuth: '飞书 OAuth',
   feishuSyncEnabledLabel: '同步到飞书',
   feishuSyncEnabledHint: '已关闭飞书同步，您可以随时在设置中重新开启。',

--- a/src/ui/settings/SettingsScene.tsx
+++ b/src/ui/settings/SettingsScene.tsx
@@ -77,6 +77,8 @@ export function SettingsScene(props: SettingsSceneProps) {
 
     feishuSyncEnabled,
     onToggleFeishuSyncEnabled,
+    feishuAutoSyncEnabled,
+    onToggleFeishuAutoSyncEnabled,
 
     feishuConnected,
     pollingFeishu,
@@ -270,6 +272,7 @@ export function SettingsScene(props: SettingsSceneProps) {
         <FeishuOAuthSection
           busy={busy}
           syncEnabled={feishuSyncEnabled}
+          autoSyncEnabled={feishuAutoSyncEnabled}
           feishuStatusText={feishuStatusText}
           feishuConnected={!!feishuConnected}
           pollingFeishu={pollingFeishu}
@@ -284,6 +287,9 @@ export function SettingsScene(props: SettingsSceneProps) {
           setupGuideUrl={feishuSetupGuideUrl}
           onToggleSyncEnabled={(enabled) => {
             void onToggleFeishuSyncEnabled(enabled);
+          }}
+          onToggleAutoSyncEnabled={(enabled) => {
+            void onToggleFeishuAutoSyncEnabled(enabled);
           }}
           onChangeClientId={setFeishuClientId}
           onChangeClientSecret={setFeishuClientSecret}

--- a/src/ui/settings/SettingsScene.tsx
+++ b/src/ui/settings/SettingsScene.tsx
@@ -110,6 +110,8 @@ export function SettingsScene(props: SettingsSceneProps) {
 
     obsidianSyncEnabled,
     onToggleObsidianSyncEnabled,
+    obsidianAutoSyncEnabled,
+    onToggleObsidianAutoSyncEnabled,
 
     obsidianApiBaseUrl,
     setObsidianApiBaseUrl,
@@ -322,6 +324,7 @@ export function SettingsScene(props: SettingsSceneProps) {
         <ObsidianSettingsSection
           busy={busy}
           syncEnabled={obsidianSyncEnabled}
+          autoSyncEnabled={obsidianAutoSyncEnabled}
           apiBaseUrl={obsidianApiBaseUrl}
           authHeaderName={obsidianAuthHeaderName}
           apiKeyDraft={obsidianApiKeyDraft}
@@ -340,6 +343,9 @@ export function SettingsScene(props: SettingsSceneProps) {
           onChangeVideoFolder={setObsidianVideoFolder}
           onToggleSyncEnabled={(enabled) => {
             void onToggleObsidianSyncEnabled(enabled);
+          }}
+          onToggleAutoSyncEnabled={(enabled) => {
+            void onToggleObsidianAutoSyncEnabled(enabled);
           }}
           onSave={() => {
             void onSaveObsidianSettings();

--- a/src/ui/settings/SettingsScene.tsx
+++ b/src/ui/settings/SettingsScene.tsx
@@ -44,6 +44,8 @@ export function SettingsScene(props: SettingsSceneProps) {
 
     notionSyncEnabled,
     onToggleNotionSyncEnabled,
+    notionAutoSyncEnabled,
+    onToggleNotionAutoSyncEnabled,
 
     notionConnected,
     pollingNotion,
@@ -202,6 +204,7 @@ export function SettingsScene(props: SettingsSceneProps) {
           <NotionOAuthSection
             busy={busy}
             syncEnabled={notionSyncEnabled}
+            autoSyncEnabled={notionAutoSyncEnabled}
             notionStatusText={notionStatusText}
             notionConnected={!!notionConnected}
             pollingNotion={pollingNotion}
@@ -218,6 +221,9 @@ export function SettingsScene(props: SettingsSceneProps) {
             notionLogoUrl={getURL('icons/notion.svg' as any)}
             onToggleSyncEnabled={(enabled) => {
               void onToggleNotionSyncEnabled(enabled);
+            }}
+            onToggleAutoSyncEnabled={(enabled) => {
+              void onToggleNotionAutoSyncEnabled(enabled);
             }}
             onToggleAdvancedOpen={() => {
               onToggleNotionAdvancedOpen();

--- a/src/ui/settings/sections/FeishuOAuthSection.tsx
+++ b/src/ui/settings/sections/FeishuOAuthSection.tsx
@@ -6,6 +6,7 @@ import { SettingsFormRow } from '@ui/settings/sections/SettingsFormRow';
 export function FeishuOAuthSection(props: {
   busy: boolean;
   syncEnabled: boolean;
+  autoSyncEnabled: boolean;
   feishuStatusText: string;
   feishuConnected: boolean;
   pollingFeishu: boolean;
@@ -19,6 +20,7 @@ export function FeishuOAuthSection(props: {
   feishuVideoFolder: string;
   setupGuideUrl: string;
   onToggleSyncEnabled: (enabled: boolean) => void;
+  onToggleAutoSyncEnabled: (enabled: boolean) => void;
   onConnectOrDisconnect: () => void;
   onChangeClientId: (value: string) => void;
   onChangeClientSecret: (value: string) => void;
@@ -33,6 +35,7 @@ export function FeishuOAuthSection(props: {
   const {
     busy,
     syncEnabled,
+    autoSyncEnabled,
     feishuStatusText,
     feishuConnected,
     pollingFeishu,
@@ -46,6 +49,7 @@ export function FeishuOAuthSection(props: {
     feishuVideoFolder,
     setupGuideUrl,
     onToggleSyncEnabled,
+    onToggleAutoSyncEnabled,
     onConnectOrDisconnect,
     onChangeClientId,
     onChangeClientSecret,
@@ -118,6 +122,22 @@ export function FeishuOAuthSection(props: {
             </div>
           ) : null}
         </div>
+
+        {syncEnabled ? (
+          <div className="tw-mt-3" aria-label={t('feishuAutoSyncEnabledLabel')}>
+            <SettingsFormRow label={t('feishuAutoSyncEnabledLabel')}>
+              <input
+                id="feishuAutoSyncEnabledToggle"
+                type="checkbox"
+                className={checkboxClassName}
+                checked={autoSyncEnabled}
+                disabled={busy}
+                aria-label={t('feishuAutoSyncEnabledLabel')}
+                onChange={(e) => onToggleAutoSyncEnabled(e.target.checked)}
+              />
+            </SettingsFormRow>
+          </div>
+        ) : null}
 
         <div id="feishu-advanced-settings" className="tw-mt-3 tw-grid tw-gap-2">
           <SettingsFormRow label={t('feishuOAuthClientIdLabel')}>

--- a/src/ui/settings/sections/NotionOAuthSection.tsx
+++ b/src/ui/settings/sections/NotionOAuthSection.tsx
@@ -8,6 +8,7 @@ import { SelectMenu } from '@ui/shared/SelectMenu';
 export function NotionOAuthSection(props: {
   busy: boolean;
   syncEnabled: boolean;
+  autoSyncEnabled: boolean;
   notionStatusText: string;
   notionConnected: boolean;
   pollingNotion: boolean;
@@ -23,6 +24,7 @@ export function NotionOAuthSection(props: {
   notionPageOptions: NotionPageOption[];
   notionLogoUrl: string;
   onToggleSyncEnabled: (enabled: boolean) => void;
+  onToggleAutoSyncEnabled: (enabled: boolean) => void;
   onToggleAdvancedOpen: () => void;
   onConnectOrDisconnect: () => void;
   onSaveNotionParentPage: (id: string) => void;
@@ -36,6 +38,7 @@ export function NotionOAuthSection(props: {
   const {
     busy,
     syncEnabled,
+    autoSyncEnabled,
     notionStatusText,
     notionConnected,
     pollingNotion,
@@ -51,6 +54,7 @@ export function NotionOAuthSection(props: {
     notionPageOptions,
     notionLogoUrl,
     onToggleSyncEnabled,
+    onToggleAutoSyncEnabled,
     onToggleAdvancedOpen,
     onConnectOrDisconnect,
     onSaveNotionParentPage,
@@ -106,6 +110,22 @@ export function NotionOAuthSection(props: {
           </div>
         ) : null}
       </div>
+
+      {syncEnabled ? (
+        <div className="tw-mt-3" aria-label={t('notionAutoSyncEnabledLabel')}>
+          <SettingsFormRow label={t('notionAutoSyncEnabledLabel')}>
+            <input
+              id="notionAutoSyncEnabledToggle"
+              type="checkbox"
+              className={checkboxClassName}
+              checked={autoSyncEnabled}
+              disabled={busy}
+              aria-label={t('notionAutoSyncEnabledLabel')}
+              onChange={(e) => onToggleAutoSyncEnabled(e.target.checked)}
+            />
+          </SettingsFormRow>
+        </div>
+      ) : null}
 
       <div className="tw-mt-3" aria-label={t('parentPage')}>
         <SettingsFormRow label={t('parentPage')}>

--- a/src/ui/settings/sections/ObsidianSettingsSection.tsx
+++ b/src/ui/settings/sections/ObsidianSettingsSection.tsx
@@ -7,6 +7,7 @@ import { SettingsFormRow } from '@ui/settings/sections/SettingsFormRow';
 export function ObsidianSettingsSection(props: {
   busy: boolean;
   syncEnabled: boolean;
+  autoSyncEnabled: boolean;
   apiBaseUrl: string;
   authHeaderName: string;
   apiKeyDraft: string;
@@ -24,6 +25,7 @@ export function ObsidianSettingsSection(props: {
   onChangeArticleFolder: (v: string) => void;
   onChangeVideoFolder: (v: string) => void;
   onToggleSyncEnabled: (enabled: boolean) => void;
+  onToggleAutoSyncEnabled: (enabled: boolean) => void;
   onSave: () => void;
   onSaveApiKey: () => void;
   onTest: () => void;
@@ -32,6 +34,7 @@ export function ObsidianSettingsSection(props: {
   const {
     busy,
     syncEnabled,
+    autoSyncEnabled,
     apiBaseUrl,
     authHeaderName,
     apiKeyDraft,
@@ -49,6 +52,7 @@ export function ObsidianSettingsSection(props: {
     onChangeArticleFolder,
     onChangeVideoFolder,
     onToggleSyncEnabled,
+    onToggleAutoSyncEnabled,
     onSave,
     onSaveApiKey,
     onTest,
@@ -94,6 +98,20 @@ export function ObsidianSettingsSection(props: {
               <div className="tw-text-xs tw-font-semibold tw-text-[var(--text-secondary)]">
                 {t('obsidianSyncEnabledHint')}
               </div>
+            </SettingsFormRow>
+          ) : null}
+
+          {syncEnabled ? (
+            <SettingsFormRow label={t('obsidianAutoSyncEnabledLabel')}>
+              <input
+                id="obsidianAutoSyncEnabledToggle"
+                type="checkbox"
+                className={checkboxClassName}
+                checked={autoSyncEnabled}
+                disabled={busy}
+                aria-label={t('obsidianAutoSyncEnabledLabel')}
+                onChange={(e) => onToggleAutoSyncEnabled(e.target.checked)}
+              />
             </SettingsFormRow>
           ) : null}
 

--- a/src/viewmodels/settings/useSettingsSceneController.ts
+++ b/src/viewmodels/settings/useSettingsSceneController.ts
@@ -37,6 +37,7 @@ import { send } from '@services/shared/runtime';
 import { storageGet, storageOnChanged, storageRemove, storageSet } from '@services/shared/storage';
 import { openOrFocusExtensionAppTab } from '@services/shared/webext';
 import { setSyncProviderEnabled, syncProviderEnabledStorageKey } from '@services/sync/sync-provider-gate';
+import { NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY } from '@services/sync/auto-sync/auto-sync-keys';
 import {
   DEFAULT_CHAT_WITH_PLATFORMS,
   DEFAULT_CHAT_WITH_PROMPT_TEMPLATE,
@@ -211,6 +212,7 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
   const [pollingNotion, setPollingNotion] = useState(false);
   const notionPagesAutoLoadRef = useRef(false);
   const [notionSyncEnabled, setNotionSyncEnabled] = useState(true);
+  const [notionAutoSyncEnabled, setNotionAutoSyncEnabled] = useState(false);
 
   // Feishu
   const [feishuConnected, setFeishuConnected] = useState<boolean | null>(null);
@@ -342,6 +344,7 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
         NOTION_SYNC_PROVIDER_ENABLED_KEY,
         FEISHU_SYNC_PROVIDER_ENABLED_KEY,
         OBSIDIAN_SYNC_PROVIDER_ENABLED_KEY,
+        NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY,
         'inpage_display_mode',
         'inpage_supported_only',
         'ai_chat_auto_save_enabled',
@@ -377,6 +380,7 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
     setNotionArticleDatabaseId(String(local?.[articleDbSpec.storageKey] || ''));
     setNotionVideoDatabaseId(String(local?.[videoDbSpec.storageKey] || ''));
     setNotionSyncEnabled(local?.[NOTION_SYNC_PROVIDER_ENABLED_KEY] !== false);
+    setNotionAutoSyncEnabled(local?.[NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY] === true);
     setFeishuSyncEnabled(local?.[FEISHU_SYNC_PROVIDER_ENABLED_KEY] !== false);
     setObsidianSyncEnabled(local?.[OBSIDIAN_SYNC_PROVIDER_ENABLED_KEY] !== false);
 
@@ -445,6 +449,10 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
       if (Object.prototype.hasOwnProperty.call(changes, NOTION_SYNC_PROVIDER_ENABLED_KEY)) {
         const nextValue = changes[NOTION_SYNC_PROVIDER_ENABLED_KEY]?.newValue;
         setNotionSyncEnabled(nextValue !== false);
+      }
+      if (Object.prototype.hasOwnProperty.call(changes, NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY)) {
+        const nextValue = changes[NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY]?.newValue;
+        setNotionAutoSyncEnabled(nextValue === true);
       }
       if (Object.prototype.hasOwnProperty.call(changes, OBSIDIAN_SYNC_PROVIDER_ENABLED_KEY)) {
         const nextValue = changes[OBSIDIAN_SYNC_PROVIDER_ENABLED_KEY]?.newValue;
@@ -638,6 +646,19 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
           setNotionSyncEnabled(enabled);
         },
         { fallbackMessage: 'save notion sync enabled failed' },
+      );
+    },
+    [runTask],
+  );
+
+  const onToggleNotionAutoSyncEnabled = useCallback(
+    async (enabled: boolean) => {
+      await runTask(
+        async () => {
+          await storageSet({ [NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY]: enabled });
+          setNotionAutoSyncEnabled(enabled);
+        },
+        { fallbackMessage: 'save notion auto sync enabled failed' },
       );
     },
     [runTask],
@@ -1360,6 +1381,8 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
 
     notionSyncEnabled,
     onToggleNotionSyncEnabled,
+    notionAutoSyncEnabled,
+    onToggleNotionAutoSyncEnabled,
 
     notionConnected,
     pollingNotion,

--- a/src/viewmodels/settings/useSettingsSceneController.ts
+++ b/src/viewmodels/settings/useSettingsSceneController.ts
@@ -37,7 +37,10 @@ import { send } from '@services/shared/runtime';
 import { storageGet, storageOnChanged, storageRemove, storageSet } from '@services/shared/storage';
 import { openOrFocusExtensionAppTab } from '@services/shared/webext';
 import { setSyncProviderEnabled, syncProviderEnabledStorageKey } from '@services/sync/sync-provider-gate';
-import { NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY } from '@services/sync/auto-sync/auto-sync-keys';
+import {
+  NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY,
+  OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY,
+} from '@services/sync/auto-sync/auto-sync-keys';
 import {
   DEFAULT_CHAT_WITH_PLATFORMS,
   DEFAULT_CHAT_WITH_PROMPT_TEMPLATE,
@@ -238,6 +241,7 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
   const [obsidianVideoFolder, setObsidianVideoFolder] = useState<string>('');
   const [obsidianStatus, setObsidianStatus] = useState<string>(t('statusIdle'));
   const [obsidianSyncEnabled, setObsidianSyncEnabled] = useState(true);
+  const [obsidianAutoSyncEnabled, setObsidianAutoSyncEnabled] = useState(false);
 
   // Backup
   const [exportStatus, setExportStatus] = useState<string>(t('statusIdle'));
@@ -345,6 +349,7 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
         FEISHU_SYNC_PROVIDER_ENABLED_KEY,
         OBSIDIAN_SYNC_PROVIDER_ENABLED_KEY,
         NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY,
+        OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY,
         'inpage_display_mode',
         'inpage_supported_only',
         'ai_chat_auto_save_enabled',
@@ -383,6 +388,7 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
     setNotionAutoSyncEnabled(local?.[NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY] === true);
     setFeishuSyncEnabled(local?.[FEISHU_SYNC_PROVIDER_ENABLED_KEY] !== false);
     setObsidianSyncEnabled(local?.[OBSIDIAN_SYNC_PROVIDER_ENABLED_KEY] !== false);
+    setObsidianAutoSyncEnabled(local?.[OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY] === true);
 
     const feishuStatus = unwrap(feishuRes);
     const feishuIsConnected = !!feishuStatus?.connected;
@@ -457,6 +463,10 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
       if (Object.prototype.hasOwnProperty.call(changes, OBSIDIAN_SYNC_PROVIDER_ENABLED_KEY)) {
         const nextValue = changes[OBSIDIAN_SYNC_PROVIDER_ENABLED_KEY]?.newValue;
         setObsidianSyncEnabled(nextValue !== false);
+      }
+      if (Object.prototype.hasOwnProperty.call(changes, OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY)) {
+        const nextValue = changes[OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY]?.newValue;
+        setObsidianAutoSyncEnabled(nextValue === true);
       }
       if (Object.prototype.hasOwnProperty.call(changes, FEISHU_SYNC_PROVIDER_ENABLED_KEY)) {
         const nextValue = changes[FEISHU_SYNC_PROVIDER_ENABLED_KEY]?.newValue;
@@ -672,6 +682,19 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
           setObsidianSyncEnabled(enabled);
         },
         { fallbackMessage: 'save obsidian sync enabled failed' },
+      );
+    },
+    [runTask],
+  );
+
+  const onToggleObsidianAutoSyncEnabled = useCallback(
+    async (enabled: boolean) => {
+      await runTask(
+        async () => {
+          await storageSet({ [OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY]: enabled });
+          setObsidianAutoSyncEnabled(enabled);
+        },
+        { fallbackMessage: 'save obsidian auto sync enabled failed' },
       );
     },
     [runTask],
@@ -1440,6 +1463,8 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
 
     obsidianSyncEnabled,
     onToggleObsidianSyncEnabled,
+    obsidianAutoSyncEnabled,
+    onToggleObsidianAutoSyncEnabled,
 
     obsidianApiBaseUrl,
     setObsidianApiBaseUrl,

--- a/src/viewmodels/settings/useSettingsSceneController.ts
+++ b/src/viewmodels/settings/useSettingsSceneController.ts
@@ -40,6 +40,7 @@ import { setSyncProviderEnabled, syncProviderEnabledStorageKey } from '@services
 import {
   NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY,
   OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY,
+  FEISHU_AUTO_SYNC_ENABLED_STORAGE_KEY,
 } from '@services/sync/auto-sync/auto-sync-keys';
 import {
   DEFAULT_CHAT_WITH_PLATFORMS,
@@ -226,6 +227,7 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
   const [feishuTokenExchangeProxyUrl, setFeishuTokenExchangeProxyUrl] = useState<string>('');
   const [pollingFeishu, setPollingFeishu] = useState(false);
   const [feishuSyncEnabled, setFeishuSyncEnabled] = useState(true);
+  const [feishuAutoSyncEnabled, setFeishuAutoSyncEnabled] = useState(false);
   const [feishuChatFolder, setFeishuChatFolder] = useState<string>('');
   const [feishuArticleFolder, setFeishuArticleFolder] = useState<string>('');
   const [feishuVideoFolder, setFeishuVideoFolder] = useState<string>('');
@@ -350,6 +352,7 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
         OBSIDIAN_SYNC_PROVIDER_ENABLED_KEY,
         NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY,
         OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY,
+        FEISHU_AUTO_SYNC_ENABLED_STORAGE_KEY,
         'inpage_display_mode',
         'inpage_supported_only',
         'ai_chat_auto_save_enabled',
@@ -387,6 +390,7 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
     setNotionSyncEnabled(local?.[NOTION_SYNC_PROVIDER_ENABLED_KEY] !== false);
     setNotionAutoSyncEnabled(local?.[NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY] === true);
     setFeishuSyncEnabled(local?.[FEISHU_SYNC_PROVIDER_ENABLED_KEY] !== false);
+    setFeishuAutoSyncEnabled(local?.[FEISHU_AUTO_SYNC_ENABLED_STORAGE_KEY] === true);
     setObsidianSyncEnabled(local?.[OBSIDIAN_SYNC_PROVIDER_ENABLED_KEY] !== false);
     setObsidianAutoSyncEnabled(local?.[OBSIDIAN_AUTO_SYNC_ENABLED_STORAGE_KEY] === true);
 
@@ -471,6 +475,10 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
       if (Object.prototype.hasOwnProperty.call(changes, FEISHU_SYNC_PROVIDER_ENABLED_KEY)) {
         const nextValue = changes[FEISHU_SYNC_PROVIDER_ENABLED_KEY]?.newValue;
         setFeishuSyncEnabled(nextValue !== false);
+      }
+      if (Object.prototype.hasOwnProperty.call(changes, FEISHU_AUTO_SYNC_ENABLED_STORAGE_KEY)) {
+        const nextValue = changes[FEISHU_AUTO_SYNC_ENABLED_STORAGE_KEY]?.newValue;
+        setFeishuAutoSyncEnabled(nextValue === true);
       }
       if (Object.prototype.hasOwnProperty.call(changes, MARKDOWN_READING_PROFILE_STORAGE_KEY)) {
         const nextValue = changes[MARKDOWN_READING_PROFILE_STORAGE_KEY]?.newValue;
@@ -708,6 +716,19 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
           setFeishuSyncEnabled(enabled);
         },
         { fallbackMessage: 'save feishu sync enabled failed' },
+      );
+    },
+    [runTask],
+  );
+
+  const onToggleFeishuAutoSyncEnabled = useCallback(
+    async (enabled: boolean) => {
+      await runTask(
+        async () => {
+          await storageSet({ [FEISHU_AUTO_SYNC_ENABLED_STORAGE_KEY]: enabled });
+          setFeishuAutoSyncEnabled(enabled);
+        },
+        { fallbackMessage: 'save feishu auto sync enabled failed' },
       );
     },
     [runTask],
@@ -1437,6 +1458,8 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
 
     feishuSyncEnabled,
     onToggleFeishuSyncEnabled,
+    feishuAutoSyncEnabled,
+    onToggleFeishuAutoSyncEnabled,
 
     feishuConnected,
     pollingFeishu,

--- a/tests/services/conversations-pagination-handlers.test.ts
+++ b/tests/services/conversations-pagination-handlers.test.ts
@@ -45,7 +45,7 @@ function createRouter() {
       error: { message: `unknown message type: ${msg?.type}`, extra: null },
     }),
   });
-  registerConversationHandlers(router as any);
+  registerConversationHandlers(router as any, { onConversationChanged: async () => {} });
   return router;
 }
 

--- a/tests/smoke/background-router-conversations-events.test.ts
+++ b/tests/smoke/background-router-conversations-events.test.ts
@@ -77,7 +77,7 @@ function createRouter() {
       error: { message: `unknown message type: ${msg?.type}`, extra: null },
     }),
   });
-  registerConversationHandlers(router as any);
+  registerConversationHandlers(router as any, { onConversationChanged: async () => {} });
   return router;
 }
 

--- a/tests/smoke/background-router-testkit.ts
+++ b/tests/smoke/background-router-testkit.ts
@@ -31,7 +31,7 @@ export function createTestBackgroundRouter() {
     }),
   });
 
-  registerConversationHandlers(router);
+  registerConversationHandlers(router, { onConversationChanged: async () => {} });
   registerWebArticleHandlers(router);
   registerChatWithBackgroundHandlers(router);
   registerNotionSettingsHandlers(router, { notionSyncJobStore, conversationKinds });

--- a/tests/smoke/notion-auto-sync-scheduler.test.ts
+++ b/tests/smoke/notion-auto-sync-scheduler.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createNotionAutoSyncScheduler } from '@services/sync/auto-sync/notion-auto-sync-scheduler';
-import { NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY, NOTION_AUTO_SYNC_QUEUE_STORAGE_KEY } from '@services/sync/auto-sync/auto-sync-keys';
+import {
+  NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY,
+  NOTION_AUTO_SYNC_QUEUE_STORAGE_KEY,
+} from '@services/sync/auto-sync/auto-sync-keys';
 
 const storageState: Record<string, any> = {};
 
@@ -69,7 +72,12 @@ beforeEach(() => {
   });
 
   gateMocks.isSyncProviderEnabled.mockResolvedValue(true);
-  tokenStoreMocks.getNotionOAuthToken.mockResolvedValue({ accessToken: 'token', workspaceId: 'w', workspaceName: 'W', createdAt: Date.now() });
+  tokenStoreMocks.getNotionOAuthToken.mockResolvedValue({
+    accessToken: 'token',
+    workspaceId: 'w',
+    workspaceName: 'W',
+    createdAt: Date.now(),
+  });
   alarmsMocks.isAlarmsAvailable.mockReturnValue(false);
   alarmsMocks.create.mockReset();
   alarmsMocks.clear.mockResolvedValue(true);
@@ -131,4 +139,3 @@ describe('notion-auto-sync-scheduler', () => {
     expect(jobArg?.failCount).toBe(1);
   });
 });
-

--- a/tests/smoke/notion-auto-sync-scheduler.test.ts
+++ b/tests/smoke/notion-auto-sync-scheduler.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createNotionAutoSyncScheduler } from '@services/sync/auto-sync/notion-auto-sync-scheduler';
+import { NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY, NOTION_AUTO_SYNC_QUEUE_STORAGE_KEY } from '@services/sync/auto-sync/auto-sync-keys';
+
+const storageState: Record<string, any> = {};
+
+const storageMocks = vi.hoisted(() => ({
+  storageGet: vi.fn(),
+  storageSet: vi.fn(),
+}));
+
+const gateMocks = vi.hoisted(() => ({
+  isSyncProviderEnabled: vi.fn(),
+}));
+
+const tokenStoreMocks = vi.hoisted(() => ({
+  getNotionOAuthToken: vi.fn(),
+}));
+
+const alarmsMocks = vi.hoisted(() => ({
+  isAlarmsAvailable: vi.fn(),
+  create: vi.fn(),
+  clear: vi.fn(),
+}));
+
+const jobStoreMocks = vi.hoisted(() => ({
+  setJob: vi.fn(),
+}));
+
+vi.mock('@services/shared/storage', () => ({
+  storageGet: storageMocks.storageGet,
+  storageSet: storageMocks.storageSet,
+}));
+
+vi.mock('@services/sync/sync-provider-gate', () => ({
+  isSyncProviderEnabled: gateMocks.isSyncProviderEnabled,
+}));
+
+vi.mock('@services/sync/notion/auth/token-store', () => ({
+  getNotionOAuthToken: tokenStoreMocks.getNotionOAuthToken,
+}));
+
+vi.mock('@platform/alarms/alarms', () => ({
+  isAlarmsAvailable: alarmsMocks.isAlarmsAvailable,
+  create: alarmsMocks.create,
+  clear: alarmsMocks.clear,
+}));
+
+vi.mock('@services/sync/notion/notion-sync-job-store', () => ({
+  default: {
+    setJob: jobStoreMocks.setJob,
+  },
+}));
+
+function setStoragePatch(patch: Record<string, any>) {
+  for (const [k, v] of Object.entries(patch)) storageState[k] = v;
+}
+
+beforeEach(() => {
+  for (const key of Object.keys(storageState)) delete storageState[key];
+  storageMocks.storageGet.mockImplementation(async (keys: string[]) => {
+    const out: Record<string, any> = {};
+    for (const key of keys) out[key] = storageState[key];
+    return out;
+  });
+  storageMocks.storageSet.mockImplementation(async (patch: Record<string, any>) => {
+    setStoragePatch(patch);
+  });
+
+  gateMocks.isSyncProviderEnabled.mockResolvedValue(true);
+  tokenStoreMocks.getNotionOAuthToken.mockResolvedValue({ accessToken: 'token', workspaceId: 'w', workspaceName: 'W', createdAt: Date.now() });
+  alarmsMocks.isAlarmsAvailable.mockReturnValue(false);
+  alarmsMocks.create.mockReset();
+  alarmsMocks.clear.mockResolvedValue(true);
+  jobStoreMocks.setJob.mockResolvedValue(true);
+});
+
+describe('notion-auto-sync-scheduler', () => {
+  it('enqueues and flushes due conversations via orchestrator', async () => {
+    const syncConversations = vi.fn().mockResolvedValue({});
+    setStoragePatch({
+      [NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY]: true,
+      notion_parent_page_id: 'parent',
+    });
+
+    const scheduler = createNotionAutoSyncScheduler({
+      getInstanceId: () => 'instance-1',
+      notionSyncOrchestrator: {
+        syncConversations,
+        getSyncJobStatus: async () => ({}),
+        clearSyncJobStatus: async () => ({}),
+      } as any,
+    });
+
+    await scheduler.enqueue(123, 'syncConversationMessages');
+    const queue = storageState[NOTION_AUTO_SYNC_QUEUE_STORAGE_KEY];
+    expect(queue).toBeTruthy();
+
+    // force due
+    storageState[NOTION_AUTO_SYNC_QUEUE_STORAGE_KEY] = { '123': Date.now() - 1 };
+    await scheduler.flush();
+
+    expect(syncConversations).toHaveBeenCalledWith({ conversationIds: [123], instanceId: 'instance-1' });
+  });
+
+  it('writes a visible job failure when Notion is not connected', async () => {
+    const syncConversations = vi.fn().mockResolvedValue({});
+    tokenStoreMocks.getNotionOAuthToken.mockResolvedValue(null);
+    setStoragePatch({
+      [NOTION_AUTO_SYNC_ENABLED_STORAGE_KEY]: true,
+      notion_parent_page_id: 'parent',
+      [NOTION_AUTO_SYNC_QUEUE_STORAGE_KEY]: { '7': Date.now() - 1 },
+    });
+
+    const scheduler = createNotionAutoSyncScheduler({
+      getInstanceId: () => 'instance-2',
+      notionSyncOrchestrator: {
+        syncConversations,
+        getSyncJobStatus: async () => ({}),
+        clearSyncJobStatus: async () => ({}),
+      } as any,
+    });
+
+    await scheduler.flush();
+    expect(syncConversations).not.toHaveBeenCalled();
+    expect(jobStoreMocks.setJob).toHaveBeenCalled();
+    const jobArg = jobStoreMocks.setJob.mock.calls[0]?.[0];
+    expect(jobArg?.provider).toBe('notion');
+    expect(jobArg?.status).toBe('done');
+    expect(jobArg?.failCount).toBe(1);
+  });
+});
+

--- a/tests/unit/auto-sync-scheduler.test.ts
+++ b/tests/unit/auto-sync-scheduler.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createAutoSyncSchedulerCore, type AutoSyncSchedulerInfra } from '@services/sync/auto-sync/auto-sync-scheduler-core';
+
+function makeInfra(startNow = 1_000_000) {
+  let now = startNow;
+  const storage: Record<string, any> = {};
+  const alarm = {
+    name: '',
+    when: 0,
+    cleared: false,
+  };
+
+  const infra: AutoSyncSchedulerInfra = {
+    now: () => now,
+    storage: {
+      get: async (keys) => {
+        const out: Record<string, any> = {};
+        for (const key of keys) out[key] = storage[key];
+        return out;
+      },
+      set: async (patch) => {
+        Object.assign(storage, patch);
+      },
+    },
+    alarms: {
+      isAvailable: () => true,
+      create: (name, info) => {
+        alarm.name = name;
+        alarm.when = info.when;
+        alarm.cleared = false;
+        return true;
+      },
+      clear: async (name) => {
+        if (alarm.name === name) alarm.cleared = true;
+        return true;
+      },
+    },
+  };
+
+  return {
+    infra,
+    storage,
+    alarm,
+    advance: (ms: number) => {
+      now += ms;
+    },
+    setNow: (value: number) => {
+      now = value;
+    },
+  };
+}
+
+describe('auto-sync-scheduler-core', () => {
+  const QUEUE_KEY = 'queue_key';
+  const ENABLED_KEY = 'enabled_key';
+  const ALARM_NAME = 'alarm_name';
+
+  let infraPack: ReturnType<typeof makeInfra>;
+  let isProviderEnabled: ReturnType<typeof vi.fn>;
+  let syncConversations: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    infraPack = makeInfra();
+    isProviderEnabled = vi.fn().mockResolvedValue(true);
+    syncConversations = vi.fn().mockResolvedValue(undefined);
+  });
+
+  it('updates dueAt on repeated enqueue for same conversation', async () => {
+    infraPack.storage[ENABLED_KEY] = true;
+    const scheduler = createAutoSyncSchedulerCore({
+      queueStorageKey: QUEUE_KEY,
+      enabledStorageKey: ENABLED_KEY,
+      alarmName: ALARM_NAME,
+      debounceMs: 60_000,
+      maxItems: 200,
+      infra: infraPack.infra,
+      getInstanceId: () => 'i-1',
+      isProviderEnabled,
+      syncConversations,
+    });
+
+    await scheduler.enqueue(1, 'a');
+    const firstDueAt = infraPack.storage[QUEUE_KEY]['1'];
+    infraPack.advance(5_000);
+    await scheduler.enqueue(1, 'b');
+    const secondDueAt = infraPack.storage[QUEUE_KEY]['1'];
+    expect(secondDueAt).toBeGreaterThan(firstDueAt);
+  });
+
+  it('schedules alarm at earliest dueAt across ids', async () => {
+    infraPack.storage[ENABLED_KEY] = true;
+    const scheduler = createAutoSyncSchedulerCore({
+      queueStorageKey: QUEUE_KEY,
+      enabledStorageKey: ENABLED_KEY,
+      alarmName: ALARM_NAME,
+      debounceMs: 60_000,
+      maxItems: 200,
+      infra: infraPack.infra,
+      getInstanceId: () => 'i-1',
+      isProviderEnabled,
+      syncConversations,
+    });
+
+    await scheduler.enqueue(1, 'a'); // due at now+60s
+    infraPack.advance(10_000);
+    await scheduler.enqueue(2, 'a'); // due at now+60s, later than id1
+    expect(infraPack.alarm.name).toBe(ALARM_NAME);
+    expect(infraPack.alarm.when).toBe(infraPack.storage[QUEUE_KEY]['1']);
+  });
+
+  it('flush processes due items and removes them from queue', async () => {
+    infraPack.storage[ENABLED_KEY] = true;
+    infraPack.storage[QUEUE_KEY] = { '1': infraPack.infra.now() - 1, '2': infraPack.infra.now() + 10_000 };
+    const scheduler = createAutoSyncSchedulerCore({
+      queueStorageKey: QUEUE_KEY,
+      enabledStorageKey: ENABLED_KEY,
+      alarmName: ALARM_NAME,
+      debounceMs: 60_000,
+      maxItems: 200,
+      infra: infraPack.infra,
+      getInstanceId: () => 'i-2',
+      isProviderEnabled,
+      syncConversations,
+    });
+
+    await scheduler.flush();
+    expect(syncConversations).toHaveBeenCalledWith([1], 'i-2');
+    expect(infraPack.storage[QUEUE_KEY]).toEqual({ '2': infraPack.storage[QUEUE_KEY]['2'] });
+  });
+
+  it('flush does not sync when provider is disabled, but clears due items', async () => {
+    infraPack.storage[ENABLED_KEY] = true;
+    infraPack.storage[QUEUE_KEY] = { '1': infraPack.infra.now() - 1 };
+    isProviderEnabled.mockResolvedValue(false);
+    const scheduler = createAutoSyncSchedulerCore({
+      queueStorageKey: QUEUE_KEY,
+      enabledStorageKey: ENABLED_KEY,
+      alarmName: ALARM_NAME,
+      debounceMs: 60_000,
+      maxItems: 200,
+      infra: infraPack.infra,
+      getInstanceId: () => 'i-3',
+      isProviderEnabled,
+      syncConversations,
+    });
+
+    await scheduler.flush();
+    expect(syncConversations).not.toHaveBeenCalled();
+    expect(infraPack.storage[QUEUE_KEY]).toEqual({});
+  });
+
+  it('keeps queue when sync_already_running is thrown (reschedules due items)', async () => {
+    infraPack.storage[ENABLED_KEY] = true;
+    infraPack.storage[QUEUE_KEY] = { '1': infraPack.infra.now() - 1 };
+    const err: any = new Error('sync already in progress');
+    err.code = 'sync_already_running';
+    syncConversations.mockRejectedValue(err);
+
+    const scheduler = createAutoSyncSchedulerCore({
+      queueStorageKey: QUEUE_KEY,
+      enabledStorageKey: ENABLED_KEY,
+      alarmName: ALARM_NAME,
+      debounceMs: 60_000,
+      maxItems: 200,
+      infra: infraPack.infra,
+      getInstanceId: () => 'i-4',
+      isProviderEnabled,
+      syncConversations,
+    });
+
+    const before = infraPack.storage[QUEUE_KEY]['1'];
+    await scheduler.flush();
+    const after = infraPack.storage[QUEUE_KEY]['1'];
+    expect(after).toBeGreaterThan(before);
+  });
+});
+

--- a/tests/unit/auto-sync-scheduler.test.ts
+++ b/tests/unit/auto-sync-scheduler.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createAutoSyncSchedulerCore, type AutoSyncSchedulerInfra } from '@services/sync/auto-sync/auto-sync-scheduler-core';
+import {
+  createAutoSyncSchedulerCore,
+  type AutoSyncSchedulerInfra,
+} from '@services/sync/auto-sync/auto-sync-scheduler-core';
 
 function makeInfra(startNow = 1_000_000) {
   let now = startNow;
@@ -175,4 +178,3 @@ describe('auto-sync-scheduler-core', () => {
     expect(after).toBeGreaterThan(before);
   });
 });
-

--- a/tests/unit/auto-sync-scheduler.test.ts
+++ b/tests/unit/auto-sync-scheduler.test.ts
@@ -177,4 +177,29 @@ describe('auto-sync-scheduler-core', () => {
     const after = infraPack.storage[QUEUE_KEY]['1'];
     expect(after).toBeGreaterThan(before);
   });
+
+  it('flushes due items on enqueue when alarms are unavailable (best-effort fallback)', async () => {
+    infraPack.storage[ENABLED_KEY] = true;
+
+    // Make alarms unavailable.
+    (infraPack.infra.alarms as any).isAvailable = () => false;
+
+    // Seed a due item (e.g. queued while background was asleep).
+    infraPack.storage[QUEUE_KEY] = { '1': infraPack.infra.now() - 1 };
+
+    const scheduler = createAutoSyncSchedulerCore({
+      queueStorageKey: QUEUE_KEY,
+      enabledStorageKey: ENABLED_KEY,
+      alarmName: ALARM_NAME,
+      debounceMs: 60_000,
+      maxItems: 200,
+      infra: infraPack.infra,
+      getInstanceId: () => 'i-5',
+      isProviderEnabled,
+      syncConversations,
+    });
+
+    await scheduler.enqueue(2, 'activity');
+    expect(syncConversations).toHaveBeenCalledWith([1], 'i-5');
+  });
 });

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -45,7 +45,15 @@ const resolveManifest: UserManifestFn = (env) => {
   const isSafari = env.browser === 'safari';
 
   // Base permissions shared by all browsers.
-  const permissions: string[] = ['storage', 'contextMenus', 'tabs', 'webNavigation', 'activeTab', 'scripting', 'alarms'];
+  const permissions: string[] = [
+    'storage',
+    'contextMenus',
+    'tabs',
+    'webNavigation',
+    'activeTab',
+    'scripting',
+    'alarms',
+  ];
 
   // `declarativeNetRequestWithHostAccess` is Chrome 128+; Safari uses the
   // plain `declarativeNetRequest` permission instead.  The runtime code

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -45,7 +45,7 @@ const resolveManifest: UserManifestFn = (env) => {
   const isSafari = env.browser === 'safari';
 
   // Base permissions shared by all browsers.
-  const permissions: string[] = ['storage', 'contextMenus', 'tabs', 'webNavigation', 'activeTab', 'scripting'];
+  const permissions: string[] = ['storage', 'contextMenus', 'tabs', 'webNavigation', 'activeTab', 'scripting', 'alarms'];
 
   // `declarativeNetRequestWithHostAccess` is Chrome 128+; Safari uses the
   // plain `declarativeNetRequest` permission instead.  The runtime code


### PR DESCRIPTION
## 背景
- 会话写入、图片回填和评论变更只更新本地数据，没有统一的自动同步入口，外部 provider 侧内容会停留在上一次手动同步的状态。
- Notion、Obsidian、Feishu 的同步调度分散在各自实现里，队列和 alarm 策略无法统一，触发时机容易不一致。
- 设置页没有 provider 级自动同步开关，用户只能手动同步，无法按 provider 控制自动下发。

## 变更
### 事件接入与后台调度
- 在 conversation/comment 写入路径里统一调用 `autoSync.onConversationChanged(...)`，把 upsert、消息写入、图片回填和 comments 增删改移都转成按 `conversationId` 的入队事件。
- `background-services` 按 provider 的自动同步开关和 sync-provider gate 决定是否入队；写入侧用 `fireAndForget`，避免同步调度拖慢主写入链路。
- 新的调度核心 `createAutoSyncSchedulerCore` 统一处理去重、去抖、队列上限、最近到期 alarm 和 flush；当 sync 已在运行时会把到期项重新延后，避免并发重入。
- Notion 额外做了 preflight：先确认 OAuth token 和 `parent_page_id`，失败时落一条可见的失败 job，避免静默丢失同步结果。

### 设置与运行时契约
- Settings 页面补上 Notion / Obsidian / Feishu 的自动同步开关，并且只在对应 provider 的“同步”开关开启时展示；controller 负责从 storage 读取、回写和监听状态变更。
- `wxt.config.ts` 增加 `alarms` 权限，让 MV3 可以在 debounce 到期后唤醒并 flush 队列。
- 文档补充了自动同步是事件驱动、按 provider 存储开关、只同步受影响 `conversationId` 的契约说明。

## 测试
- 做同一 conversation 连续两次入队，期望队列里仍只保留一条记录且 dueAt 被推后。
- 做两个 conversation 依次入队，期望 alarm 取最早到期时间。
- 做到期队列 flush，期望只同步到期的 conversationId 且已处理项从队列移除。
- 做 provider 关闭或自动同步关闭后 flush，期望不调用 provider sync 且到期项被清空。
- 做 Notion token 缺失且队列到期的 flush，期望不调用 orchestrator，并写入一条可见的失败 job。