### PR TITLE
fix: align chat and article outline UI

### DIFF
--- a/src/services/bootstrap/inpage-comments-panel-content-handlers.ts
+++ b/src/services/bootstrap/inpage-comments-panel-content-handlers.ts
@@ -45,13 +45,13 @@ function debugSelection(event: string, payload: Record<string, unknown>) {
   const anyGlobal = globalThis as any;
   const enabled =
     anyGlobal.__SYNCNOS_DEBUG_COMMENTS_SELECTION__ === true ||
-	    (() => {
-	      try {
-	        const storage = anyGlobal.window?.localStorage;
-	        return String(storage?.getItem?.('__SYNCNOS_DEBUG_COMMENTS_SELECTION__') || '') === '1';
-	      } catch (_e) {
-	        return false;
-	      }
+    (() => {
+      try {
+        const storage = anyGlobal.window?.localStorage;
+        return String(storage?.getItem?.('__SYNCNOS_DEBUG_COMMENTS_SELECTION__') || '') === '1';
+      } catch (_e) {
+        return false;
+      }
     })();
   if (!enabled) return;
   try {

--- a/src/ui/comments/panel.ts
+++ b/src/ui/comments/panel.ts
@@ -256,8 +256,8 @@ export function mountThreadedCommentsPanel(
     if (keyEvent.key === 'Escape' && chatWithMenuController.handleShadowEscape(keyEvent)) return;
     if (keyEvent.key !== 'Escape') return;
     escapeSignal += 1;
-      runReactUpdate(() => {
-        panelStore.setEscapeSignal(escapeSignal);
+    runReactUpdate(() => {
+      panelStore.setEscapeSignal(escapeSignal);
     });
   };
   const onShadowShortcutSubmitCapture = (event: Event) => {

--- a/src/ui/conversations/ArticleCommentsSection.tsx
+++ b/src/ui/conversations/ArticleCommentsSection.tsx
@@ -139,8 +139,8 @@ function ArticleCommentsPanelMount({
             },
           }
         : null,
-	      commentChatWith: hasCommentChatWith
-	        ? {
+      commentChatWith: hasCommentChatWith
+        ? {
             resolveActions: async (rootComment, context, replies) => {
               const resolver = commentChatWithRef.current?.resolveActions;
               if (typeof resolver !== 'function') return [];
@@ -151,10 +151,10 @@ function ArticleCommentsPanelMount({
               if (typeof resolver !== 'function') return {};
               return await resolver();
             },
-	          }
-	        : null,
-	      deferReactUpdates: true,
-	    });
+          }
+        : null,
+      deferReactUpdates: true,
+    });
     apiRef.current = mounted.api;
     sidebarSession.attachPanel(mounted.api as any);
 

--- a/src/ui/conversations/chat-outline/ChatOutlinePanel.tsx
+++ b/src/ui/conversations/chat-outline/ChatOutlinePanel.tsx
@@ -2,6 +2,12 @@ import type { CSSProperties } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { ChatOutlineEntry } from '@ui/conversations/chat-outline/outline-entries';
+import { readerOutlineLevelToMinimapWidth } from '@services/protocols/reader-outline';
+import {
+  OUTLINE_STRIP_BAR_LEVEL_1,
+  OUTLINE_STRIP_BAR_LEVEL_2,
+  outlineStripBarClassName,
+} from '@ui/reader/outline-strip-bars';
 import { ReaderRailPanel } from '@ui/reader/ReaderRailPanel';
 import { buttonMenuItemClassName } from '@ui/shared/button-styles';
 
@@ -19,9 +25,9 @@ const TRIGGER_CLASS = [
   'focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-[var(--focus-ring)]',
 ].join(' ');
 const PANEL_LIST_CLASS = 'tw-flex tw-max-h-[60vh] tw-flex-col tw-gap-1 tw-overflow-auto';
-const TRIGGER_BARS_CLASS = 'tw-flex tw-h-9 tw-w-[18px] tw-flex-col tw-justify-center tw-gap-[3px] tw-overflow-hidden';
-const TRIGGER_BAR_CLASS =
-  'tw-h-[2px] tw-flex-none tw-rounded-[var(--radius-inline)] tw-bg-[var(--text-secondary)] tw-transition-[opacity,width,background-color] tw-duration-150';
+const TRIGGER_BARS_CLASS = 'tw-flex tw-h-9 tw-w-[22px] tw-flex-col tw-justify-center tw-gap-[3px] tw-overflow-hidden';
+const TRIGGER_ACTIVE_BAR_WIDTH = readerOutlineLevelToMinimapWidth(OUTLINE_STRIP_BAR_LEVEL_1);
+const TRIGGER_INACTIVE_BAR_WIDTH = readerOutlineLevelToMinimapWidth(OUTLINE_STRIP_BAR_LEVEL_2);
 const PANEL_ENTRY_LABEL_CLASS = 'tw-min-w-0 tw-flex-1 tw-text-left';
 const PANEL_ENTRY_LABEL_STYLE: CSSProperties = {
   display: '-webkit-box',
@@ -132,10 +138,8 @@ export function ChatOutlinePanel({ entries, activeIndex = null, onPickEntry }: C
           return (
             <span
               key={entry.messageKey}
-              className={[
-                TRIGGER_BAR_CLASS,
-                isActive ? 'tw-w-[18px] tw-bg-[var(--text-primary)] tw-opacity-100' : 'tw-w-[14px] tw-opacity-50',
-              ].join(' ')}
+              className={outlineStripBarClassName(isActive)}
+              style={{ width: `${isActive ? TRIGGER_ACTIVE_BAR_WIDTH : TRIGGER_INACTIVE_BAR_WIDTH}px` }}
               data-chat-outline-trigger-bar={entry.messageKey}
               data-chat-outline-trigger-active={isActive ? 'true' : 'false'}
             />

--- a/src/ui/conversations/chat-outline/ChatOutlinePanel.tsx
+++ b/src/ui/conversations/chat-outline/ChatOutlinePanel.tsx
@@ -22,18 +22,20 @@ const PANEL_LIST_CLASS = 'tw-flex tw-max-h-[60vh] tw-flex-col tw-gap-1 tw-overfl
 const TRIGGER_BARS_CLASS = 'tw-flex tw-h-9 tw-w-[18px] tw-flex-col tw-justify-center tw-gap-[3px] tw-overflow-hidden';
 const TRIGGER_BAR_CLASS =
   'tw-h-[2px] tw-flex-none tw-rounded-[var(--radius-inline)] tw-bg-[var(--text-secondary)] tw-transition-[opacity,width,background-color] tw-duration-150';
-const PANEL_ENTRY_LABEL_CLASS = 'tw-min-w-0 tw-flex-1 tw-text-left tw-leading-snug';
+const PANEL_ENTRY_LABEL_CLASS = 'tw-min-w-0 tw-flex-1 tw-text-left';
 const PANEL_ENTRY_LABEL_STYLE: CSSProperties = {
   display: '-webkit-box',
   WebkitBoxOrient: 'vertical',
   WebkitLineClamp: 2,
+  lineHeight: 1.35,
   overflow: 'hidden',
+  overflowWrap: 'anywhere',
 };
 
 function toItemClass(active: boolean): string {
   return [
     buttonMenuItemClassName(),
-    'tw-min-h-8 tw-items-start tw-text-xs',
+    'tw-min-h-[50px] tw-items-start tw-text-xs',
     active ? '' : 'webclipper-btn--tone-muted',
   ]
     .filter(Boolean)

--- a/src/ui/conversations/chat-outline/ChatOutlinePanel.tsx
+++ b/src/ui/conversations/chat-outline/ChatOutlinePanel.tsx
@@ -12,14 +12,15 @@ export type ChatOutlinePanelProps = {
 
 const CLOSE_DELAY_MS = 160;
 const OUTLINE_LABEL = 'Outline';
+const TRIGGER_MAX_BARS = 14;
 const TRIGGER_CLASS = [
   'tw-grid tw-h-11 tw-w-9 tw-place-items-center tw-border-0 tw-bg-transparent tw-p-0 tw-shadow-none',
   'focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-[var(--focus-ring)]',
 ].join(' ');
 const PANEL_LIST_CLASS = 'tw-flex tw-max-h-[60vh] tw-flex-col tw-gap-1 tw-overflow-auto';
-const TRIGGER_BARS_CLASS = 'tw-flex tw-h-7 tw-w-[18px] tw-flex-col tw-justify-center tw-gap-1 tw-overflow-hidden';
+const TRIGGER_BARS_CLASS = 'tw-flex tw-h-7 tw-w-[18px] tw-flex-col tw-justify-center tw-gap-px tw-overflow-hidden';
 const TRIGGER_BAR_CLASS =
-  'tw-h-[2px] tw-rounded-[var(--radius-inline)] tw-bg-[var(--text-secondary)] tw-transition-[opacity,width,background-color] tw-duration-150';
+  'tw-h-px tw-flex-none tw-rounded-[var(--radius-inline)] tw-bg-[var(--text-secondary)] tw-transition-[opacity,width,background-color] tw-duration-150';
 
 function toItemClass(active: boolean): string {
   return [
@@ -36,8 +37,29 @@ function toLabel(entry: ChatOutlineEntry): string {
   return text ? `${entry.index}. ${text}` : `${entry.index}.`;
 }
 
+function pickTriggerEntries(entries: ChatOutlineEntry[], activeIndex: number | null): ChatOutlineEntry[] {
+  if (entries.length <= TRIGGER_MAX_BARS) return entries;
+
+  const activeEntry = entries.find((entry) => entry.index === activeIndex) || null;
+  const sampleCount = activeEntry ? TRIGGER_MAX_BARS - 1 : TRIGGER_MAX_BARS;
+  const picked = new Map<string, ChatOutlineEntry>();
+
+  for (let slot = 0; slot < sampleCount; slot += 1) {
+    const position = sampleCount <= 1 ? 0 : Math.round((slot * (entries.length - 1)) / (sampleCount - 1));
+    const entry = entries[position];
+    if (entry) picked.set(entry.messageKey, entry);
+  }
+
+  if (activeEntry) picked.set(activeEntry.messageKey, activeEntry);
+
+  return Array.from(picked.values())
+    .sort((left, right) => left.index - right.index)
+    .slice(0, TRIGGER_MAX_BARS);
+}
+
 export function ChatOutlinePanel({ entries, activeIndex = null, onPickEntry }: ChatOutlinePanelProps) {
   const safeEntries = useMemo(() => (Array.isArray(entries) ? entries : []), [entries]);
+  const triggerEntries = useMemo(() => pickTriggerEntries(safeEntries, activeIndex), [activeIndex, safeEntries]);
   const [open, setOpen] = useState(false);
   const handleButtonRef = useRef<HTMLButtonElement | null>(null);
   const closeTimerRef = useRef<number | null>(null);
@@ -95,7 +117,7 @@ export function ChatOutlinePanel({ entries, activeIndex = null, onPickEntry }: C
       }}
     >
       <span className={TRIGGER_BARS_CLASS} aria-hidden="true" data-chat-outline-trigger-bars={safeEntries.length}>
-        {safeEntries.map((entry) => {
+        {triggerEntries.map((entry) => {
           const isActive = Number(activeIndex) === entry.index;
           return (
             <span

--- a/src/ui/conversations/chat-outline/ChatOutlinePanel.tsx
+++ b/src/ui/conversations/chat-outline/ChatOutlinePanel.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { ChatOutlineEntry } from '@ui/conversations/chat-outline/outline-entries';
@@ -21,11 +22,18 @@ const PANEL_LIST_CLASS = 'tw-flex tw-max-h-[60vh] tw-flex-col tw-gap-1 tw-overfl
 const TRIGGER_BARS_CLASS = 'tw-flex tw-h-9 tw-w-[18px] tw-flex-col tw-justify-center tw-gap-[3px] tw-overflow-hidden';
 const TRIGGER_BAR_CLASS =
   'tw-h-[2px] tw-flex-none tw-rounded-[var(--radius-inline)] tw-bg-[var(--text-secondary)] tw-transition-[opacity,width,background-color] tw-duration-150';
+const PANEL_ENTRY_LABEL_CLASS = 'tw-min-w-0 tw-flex-1 tw-text-left tw-leading-snug';
+const PANEL_ENTRY_LABEL_STYLE: CSSProperties = {
+  display: '-webkit-box',
+  WebkitBoxOrient: 'vertical',
+  WebkitLineClamp: 2,
+  overflow: 'hidden',
+};
 
 function toItemClass(active: boolean): string {
   return [
     buttonMenuItemClassName(),
-    'tw-min-h-8 tw-items-center tw-text-xs',
+    'tw-min-h-8 tw-items-start tw-text-xs',
     active ? '' : 'webclipper-btn--tone-muted',
   ]
     .filter(Boolean)
@@ -161,7 +169,13 @@ export function ChatOutlinePanel({ entries, activeIndex = null, onPickEntry }: C
               data-chat-outline-entry={entry.messageKey}
               data-chat-outline-active={isActive ? 'true' : 'false'}
             >
-              {label}
+              <span
+                className={PANEL_ENTRY_LABEL_CLASS}
+                style={PANEL_ENTRY_LABEL_STYLE}
+                data-chat-outline-entry-label={entry.messageKey}
+              >
+                {label}
+              </span>
             </button>
           );
         })}

--- a/src/ui/conversations/chat-outline/ChatOutlinePanel.tsx
+++ b/src/ui/conversations/chat-outline/ChatOutlinePanel.tsx
@@ -6,6 +6,8 @@ import { readerOutlineLevelToMinimapWidth } from '@services/protocols/reader-out
 import {
   OUTLINE_STRIP_BAR_LEVEL_1,
   OUTLINE_STRIP_BAR_LEVEL_2,
+  OUTLINE_STRIP_BUTTON_CLASS,
+  OUTLINE_STRIP_CLASS,
   outlineStripBarClassName,
 } from '@ui/reader/outline-strip-bars';
 import { ReaderRailPanel } from '@ui/reader/ReaderRailPanel';
@@ -20,12 +22,7 @@ export type ChatOutlinePanelProps = {
 const CLOSE_DELAY_MS = 160;
 const OUTLINE_LABEL = 'Outline';
 const TRIGGER_MAX_BARS = 7;
-const TRIGGER_CLASS = [
-  'tw-grid tw-h-11 tw-w-9 tw-place-items-center tw-border-0 tw-bg-transparent tw-p-0 tw-shadow-none',
-  'focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-[var(--focus-ring)]',
-].join(' ');
 const PANEL_LIST_CLASS = 'tw-flex tw-max-h-[60vh] tw-flex-col tw-gap-1 tw-overflow-auto';
-const TRIGGER_BARS_CLASS = 'tw-flex tw-h-9 tw-w-[22px] tw-flex-col tw-justify-center tw-gap-[3px] tw-overflow-hidden';
 const TRIGGER_ACTIVE_BAR_WIDTH = readerOutlineLevelToMinimapWidth(OUTLINE_STRIP_BAR_LEVEL_1);
 const TRIGGER_INACTIVE_BAR_WIDTH = readerOutlineLevelToMinimapWidth(OUTLINE_STRIP_BAR_LEVEL_2);
 const PANEL_ENTRY_LABEL_CLASS = 'tw-min-w-0 tw-flex-1 tw-text-left';
@@ -77,7 +74,7 @@ export function ChatOutlinePanel({ entries, activeIndex = null, onPickEntry }: C
   const safeEntries = useMemo(() => (Array.isArray(entries) ? entries : []), [entries]);
   const triggerEntries = useMemo(() => pickTriggerEntries(safeEntries, activeIndex), [activeIndex, safeEntries]);
   const [open, setOpen] = useState(false);
-  const handleButtonRef = useRef<HTMLButtonElement | null>(null);
+  const firstTriggerButtonRef = useRef<HTMLButtonElement | null>(null);
   const closeTimerRef = useRef<number | null>(null);
 
   const cancelClose = useCallback(() => {
@@ -100,7 +97,7 @@ export function ChatOutlinePanel({ entries, activeIndex = null, onPickEntry }: C
     cancelClose();
     setOpen(false);
     const focusHandle = () => {
-      handleButtonRef.current?.focus();
+      firstTriggerButtonRef.current?.focus();
     };
     if (typeof globalThis.window?.requestAnimationFrame === 'function') {
       globalThis.window.requestAnimationFrame(focusHandle);
@@ -116,37 +113,35 @@ export function ChatOutlinePanel({ entries, activeIndex = null, onPickEntry }: C
   if (!safeEntries.length) return null;
 
   const trigger = (
-    <button
-      ref={handleButtonRef}
-      type="button"
-      aria-label={OUTLINE_LABEL}
-      className={TRIGGER_CLASS}
-      onKeyDown={(event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault();
-          openPanel();
-          return;
-        }
-        if (event.key !== 'Escape') return;
-        event.preventDefault();
-        closePanelAndFocusHandle();
-      }}
-    >
-      <span className={TRIGGER_BARS_CLASS} aria-hidden="true" data-chat-outline-trigger-bars={safeEntries.length}>
-        {triggerEntries.map((entry) => {
-          const isActive = Number(activeIndex) === entry.index;
-          return (
+    <nav className={OUTLINE_STRIP_CLASS} aria-label={OUTLINE_LABEL} data-chat-outline-trigger-bars={safeEntries.length}>
+      {triggerEntries.map((entry, index) => {
+        const isActive = Number(activeIndex) === entry.index;
+        const label = toLabel(entry);
+        return (
+          <button
+            key={entry.messageKey}
+            ref={index === 0 ? firstTriggerButtonRef : undefined}
+            type="button"
+            aria-label={label}
+            title={label}
+            className={OUTLINE_STRIP_BUTTON_CLASS}
+            onClick={() => onPickEntry?.(entry)}
+            onKeyDown={(event) => {
+              if (event.key !== 'Escape') return;
+              event.preventDefault();
+              closePanelAndFocusHandle();
+            }}
+          >
             <span
-              key={entry.messageKey}
               className={outlineStripBarClassName(isActive)}
               style={{ width: `${isActive ? TRIGGER_ACTIVE_BAR_WIDTH : TRIGGER_INACTIVE_BAR_WIDTH}px` }}
               data-chat-outline-trigger-bar={entry.messageKey}
               data-chat-outline-trigger-active={isActive ? 'true' : 'false'}
             />
-          );
-        })}
-      </span>
-    </button>
+          </button>
+        );
+      })}
+    </nav>
   );
 
   return (

--- a/src/ui/conversations/chat-outline/ChatOutlinePanel.tsx
+++ b/src/ui/conversations/chat-outline/ChatOutlinePanel.tsx
@@ -12,15 +12,15 @@ export type ChatOutlinePanelProps = {
 
 const CLOSE_DELAY_MS = 160;
 const OUTLINE_LABEL = 'Outline';
-const TRIGGER_MAX_BARS = 14;
+const TRIGGER_MAX_BARS = 7;
 const TRIGGER_CLASS = [
   'tw-grid tw-h-11 tw-w-9 tw-place-items-center tw-border-0 tw-bg-transparent tw-p-0 tw-shadow-none',
   'focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-[var(--focus-ring)]',
 ].join(' ');
 const PANEL_LIST_CLASS = 'tw-flex tw-max-h-[60vh] tw-flex-col tw-gap-1 tw-overflow-auto';
-const TRIGGER_BARS_CLASS = 'tw-flex tw-h-7 tw-w-[18px] tw-flex-col tw-justify-center tw-gap-px tw-overflow-hidden';
+const TRIGGER_BARS_CLASS = 'tw-flex tw-h-9 tw-w-[18px] tw-flex-col tw-justify-center tw-gap-[3px] tw-overflow-hidden';
 const TRIGGER_BAR_CLASS =
-  'tw-h-px tw-flex-none tw-rounded-[var(--radius-inline)] tw-bg-[var(--text-secondary)] tw-transition-[opacity,width,background-color] tw-duration-150';
+  'tw-h-[2px] tw-flex-none tw-rounded-[var(--radius-inline)] tw-bg-[var(--text-secondary)] tw-transition-[opacity,width,background-color] tw-duration-150';
 
 function toItemClass(active: boolean): string {
   return [

--- a/src/ui/conversations/chat-outline/outline-entries.ts
+++ b/src/ui/conversations/chat-outline/outline-entries.ts
@@ -7,27 +7,11 @@ export type ChatOutlineEntry = {
   previewText: string;
 };
 
-const DEFAULT_PREVIEW_MAX_LEN = 30;
-const ELLIPSIS = '…';
-
 function normalizeSingleLine(text: string): string {
   return String(text || '')
     .replace(/[\r\n\t]/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
-}
-
-function toValidMaxLen(raw: unknown): number {
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_PREVIEW_MAX_LEN;
-  return Math.max(1, Math.floor(parsed));
-}
-
-function truncatePreview(text: string, maxLen: number): string {
-  const normalized = normalizeSingleLine(text);
-  if (!normalized) return '';
-  if (normalized.length <= maxLen) return normalized;
-  return `${normalized.slice(0, maxLen)}${ELLIPSIS}`;
 }
 
 function markdownToReadableText(markdown: string): string {
@@ -57,12 +41,8 @@ export function extractMessagePlainText(message: ConversationMessage): string {
   return markdownToReadableText(String(message?.contentMarkdown || ''));
 }
 
-export function buildChatOutlineEntries(
-  messages: ConversationMessage[],
-  options?: { maxLen?: number },
-): ChatOutlineEntry[] {
+export function buildChatOutlineEntries(messages: ConversationMessage[]): ChatOutlineEntry[] {
   if (!Array.isArray(messages) || !messages.length) return [];
-  const maxLen = toValidMaxLen(options?.maxLen);
   const entries: ChatOutlineEntry[] = [];
 
   for (const message of messages) {
@@ -81,7 +61,7 @@ export function buildChatOutlineEntries(
       index,
       messageId,
       messageKey,
-      previewText: truncatePreview(extractMessagePlainText(message), maxLen),
+      previewText: extractMessagePlainText(message),
     });
   }
 

--- a/src/ui/conversations/views/ArticleReaderView.tsx
+++ b/src/ui/conversations/views/ArticleReaderView.tsx
@@ -478,11 +478,7 @@ export function ArticleReaderView({
     <>
       {headerToolbar}
       {outlineToolbarPortal}
-      <div
-        className={READER_SHELL_CLASS}
-        style={readerVars}
-        data-reader-shell="article"
-      >
+      <div className={READER_SHELL_CLASS} style={readerVars} data-reader-shell="article">
         <div className={READER_MAIN_CLASS} data-reader-main="article-main">
           {listError ? <p className="tw-mt-2 tw-text-sm tw-font-semibold tw-text-[var(--error)]">{listError}</p> : null}
           {loadingDetail ? (
@@ -528,9 +524,7 @@ export function ArticleReaderView({
           )}
         </div>
 
-        {shouldRenderInlineRail && !readerOutlinePortalTarget ? (
-          outlineRail
-        ) : null}
+        {shouldRenderInlineRail && !readerOutlinePortalTarget ? outlineRail : null}
       </div>
     </>
   );

--- a/src/ui/reader/ArticleOutlineMinimap.tsx
+++ b/src/ui/reader/ArticleOutlineMinimap.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react';
 
 import {
   type ReaderOutlineCandidate,
@@ -33,6 +33,13 @@ const ENTRY_MINIMAP_BUTTON_CLASS = [
 ].join(' ');
 const STRIP_CLASS = 'tw-flex tw-flex-col tw-items-end tw-gap-2 tw-py-1 tw-pr-1';
 const PANEL_LIST_CLASS = 'tw-flex tw-max-h-[60vh] tw-flex-col tw-gap-1 tw-overflow-auto';
+const PANEL_ENTRY_LABEL_CLASS = 'tw-min-w-0 tw-flex-1 tw-text-left tw-leading-snug';
+const PANEL_ENTRY_LABEL_STYLE: CSSProperties = {
+  display: '-webkit-box',
+  WebkitBoxOrient: 'vertical',
+  WebkitLineClamp: 2,
+  overflow: 'hidden',
+};
 const OUTLINE_REBUILD_SETTLE_MS = 180;
 
 function readViewportRect(scrollRoot?: Element | null): ReaderOutlineCandidate['rect'] {
@@ -63,7 +70,7 @@ function toItemClass(active: boolean, level: number): string {
   const indentClass = level >= 3 ? 'tw-pl-7' : level === 2 ? 'tw-pl-5' : '';
   return [
     buttonMenuItemClassName(),
-    'tw-min-h-8 tw-items-center tw-text-xs',
+    'tw-min-h-8 tw-items-start tw-text-xs',
     active ? '' : 'webclipper-btn--tone-muted',
     indentClass,
   ]
@@ -120,7 +127,9 @@ function renderOutlineItem(
       aria-checked={active ? 'true' : undefined}
       onClick={() => onPickPanelEntry(entry)}
     >
-      {entry.title}
+      <span className={PANEL_ENTRY_LABEL_CLASS} style={PANEL_ENTRY_LABEL_STYLE} data-reader-outline-entry-label={entry.id}>
+        {entry.title}
+      </span>
     </button>
   );
 }

--- a/src/ui/reader/ArticleOutlineMinimap.tsx
+++ b/src/ui/reader/ArticleOutlineMinimap.tsx
@@ -7,7 +7,11 @@ import {
   pickReaderOutlineActiveIndex,
 } from '@services/protocols/reader-outline';
 import { buildReaderOutlineDomEntries, type ReaderOutlineDomEntry } from '@ui/reader/article-outline-dom';
-import { outlineStripBarClassName } from '@ui/reader/outline-strip-bars';
+import {
+  OUTLINE_STRIP_BUTTON_CLASS,
+  OUTLINE_STRIP_CLASS,
+  outlineStripBarClassName,
+} from '@ui/reader/outline-strip-bars';
 import { publishReaderPerformanceStats } from '@ui/reader/reader-performance-debug';
 import { ReaderRailPanel } from '@ui/reader/ReaderRailPanel';
 import { buttonMenuItemClassName } from '@ui/shared/button-styles';
@@ -28,11 +32,6 @@ export type ArticleOutlineMinimapProps = ArticleOutlineMinimapState & {
 };
 
 const OUTLINE_LABEL = '目录';
-const ENTRY_MINIMAP_BUTTON_CLASS = [
-  'tw-flex tw-w-full tw-justify-end tw-border-0 tw-bg-transparent tw-p-0 tw-leading-none',
-  'focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-[var(--focus-ring)]',
-].join(' ');
-const STRIP_CLASS = 'tw-flex tw-flex-col tw-items-end tw-gap-2 tw-py-1 tw-pr-1';
 const PANEL_LIST_CLASS = 'tw-flex tw-max-h-[60vh] tw-flex-col tw-gap-1 tw-overflow-auto';
 const PANEL_ENTRY_LABEL_CLASS = 'tw-min-w-0 tw-flex-1 tw-text-left tw-leading-snug';
 const PANEL_ENTRY_LABEL_STYLE: CSSProperties = {
@@ -100,7 +99,7 @@ function renderOutlineItem(
         data-reader-outline-entry={entry.id}
         data-reader-outline-level={token}
         data-reader-outline-active={active ? 'true' : 'false'}
-        className={ENTRY_MINIMAP_BUTTON_CLASS}
+        className={OUTLINE_STRIP_BUTTON_CLASS}
         onClick={() => onPickStripEntry(entry)}
       >
         <span className={outlineStripBarClassName(active)} style={{ width: `${width}px` }} />
@@ -280,7 +279,7 @@ export function ArticleOutlineMinimap({
   const safeEntries = useMemo(() => (Array.isArray(entries) ? entries : []), [entries]);
   const outlineTrigger = useMemo(() => {
     return (
-      <nav className={STRIP_CLASS} aria-label={OUTLINE_LABEL}>
+      <nav className={OUTLINE_STRIP_CLASS} aria-label={OUTLINE_LABEL}>
         {safeEntries.map((entry) => renderOutlineItem(entry, activeIndex, onPickStripEntry, onPickPanelEntry, 'strip'))}
       </nav>
     );

--- a/src/ui/reader/ArticleOutlineMinimap.tsx
+++ b/src/ui/reader/ArticleOutlineMinimap.tsx
@@ -80,7 +80,7 @@ function toItemClass(active: boolean, level: number): string {
 
 function toStripBarClass(active: boolean): string {
   return [
-    'tw-h-0.5 tw-rounded-[var(--radius-inline)] tw-transition-[opacity,background-color] tw-duration-150',
+    'tw-h-[2px] tw-flex-none tw-rounded-[var(--radius-inline)] tw-transition-[opacity,background-color] tw-duration-150',
     active ? 'tw-bg-[var(--text-primary)] tw-opacity-100' : 'tw-bg-[var(--text-secondary)] tw-opacity-40',
   ].join(' ');
 }

--- a/src/ui/reader/ArticleOutlineMinimap.tsx
+++ b/src/ui/reader/ArticleOutlineMinimap.tsx
@@ -120,7 +120,11 @@ function renderOutlineItem(
       aria-checked={active ? 'true' : undefined}
       onClick={() => onPickPanelEntry(entry)}
     >
-      <span className={PANEL_ENTRY_LABEL_CLASS} style={PANEL_ENTRY_LABEL_STYLE} data-reader-outline-entry-label={entry.id}>
+      <span
+        className={PANEL_ENTRY_LABEL_CLASS}
+        style={PANEL_ENTRY_LABEL_STYLE}
+        data-reader-outline-entry-label={entry.id}
+      >
         {entry.title}
       </span>
     </button>

--- a/src/ui/reader/ArticleOutlineMinimap.tsx
+++ b/src/ui/reader/ArticleOutlineMinimap.tsx
@@ -7,6 +7,7 @@ import {
   pickReaderOutlineActiveIndex,
 } from '@services/protocols/reader-outline';
 import { buildReaderOutlineDomEntries, type ReaderOutlineDomEntry } from '@ui/reader/article-outline-dom';
+import { outlineStripBarClassName } from '@ui/reader/outline-strip-bars';
 import { publishReaderPerformanceStats } from '@ui/reader/reader-performance-debug';
 import { ReaderRailPanel } from '@ui/reader/ReaderRailPanel';
 import { buttonMenuItemClassName } from '@ui/shared/button-styles';
@@ -78,13 +79,6 @@ function toItemClass(active: boolean, level: number): string {
     .join(' ');
 }
 
-function toStripBarClass(active: boolean): string {
-  return [
-    'tw-h-[2px] tw-flex-none tw-rounded-[var(--radius-inline)] tw-transition-[opacity,background-color] tw-duration-150',
-    active ? 'tw-bg-[var(--text-primary)] tw-opacity-100' : 'tw-bg-[var(--text-secondary)] tw-opacity-40',
-  ].join(' ');
-}
-
 function renderOutlineItem(
   entry: ReaderOutlineDomEntry,
   activeIndex: number | null,
@@ -109,7 +103,7 @@ function renderOutlineItem(
         className={ENTRY_MINIMAP_BUTTON_CLASS}
         onClick={() => onPickStripEntry(entry)}
       >
-        <span className={toStripBarClass(active)} style={{ width: `${width}px` }} />
+        <span className={outlineStripBarClassName(active)} style={{ width: `${width}px` }} />
       </button>
     );
   }

--- a/src/ui/reader/ReaderToolbar.tsx
+++ b/src/ui/reader/ReaderToolbar.tsx
@@ -98,10 +98,7 @@ export function ReaderToolbar({ outline, className }: ReaderToolbarProps) {
       role="toolbar"
       aria-orientation="vertical"
       aria-label={LABELS.toolbarAria}
-      className={[
-        'webclipper-reader-toolbar tw-flex tw-w-fit tw-flex-col tw-items-start tw-gap-2',
-        className || '',
-      ]
+      className={['webclipper-reader-toolbar tw-flex tw-w-fit tw-flex-col tw-items-start tw-gap-2', className || '']
         .join(' ')
         .trim()}
     >

--- a/src/ui/reader/outline-strip-bars.ts
+++ b/src/ui/reader/outline-strip-bars.ts
@@ -1,6 +1,12 @@
 export const OUTLINE_STRIP_BAR_LEVEL_1 = 1;
 export const OUTLINE_STRIP_BAR_LEVEL_2 = 2;
 
+export const OUTLINE_STRIP_CLASS = 'tw-flex tw-flex-col tw-items-end tw-gap-2 tw-py-1 tw-pr-1';
+export const OUTLINE_STRIP_BUTTON_CLASS = [
+  'tw-flex tw-w-full tw-justify-end tw-border-0 tw-bg-transparent tw-p-0 tw-leading-none',
+  'focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-[var(--focus-ring)]',
+].join(' ');
+
 export function outlineStripBarClassName(active: boolean): string {
   return [
     'tw-h-[2px] tw-flex-none tw-rounded-[var(--radius-inline)] tw-transition-[opacity,background-color] tw-duration-150',

--- a/src/ui/reader/outline-strip-bars.ts
+++ b/src/ui/reader/outline-strip-bars.ts
@@ -1,0 +1,9 @@
+export const OUTLINE_STRIP_BAR_LEVEL_1 = 1;
+export const OUTLINE_STRIP_BAR_LEVEL_2 = 2;
+
+export function outlineStripBarClassName(active: boolean): string {
+  return [
+    'tw-h-[2px] tw-flex-none tw-rounded-[var(--radius-inline)] tw-transition-[opacity,background-color] tw-duration-150',
+    active ? 'tw-bg-[var(--text-primary)] tw-opacity-100' : 'tw-bg-[var(--text-secondary)] tw-opacity-40',
+  ].join(' ');
+}

--- a/src/viewmodels/comments/useArticleCommentsSidebarRuntime.ts
+++ b/src/viewmodels/comments/useArticleCommentsSidebarRuntime.ts
@@ -31,13 +31,13 @@ export function useArticleCommentsSidebarRuntime(input: { onClose?: () => void }
     const anyGlobal = globalThis as any;
     const enabled =
       anyGlobal.__SYNCNOS_DEBUG_COMMENTS_SELECTION__ === true ||
-	      (() => {
-	        try {
-	          const storage = anyGlobal.window?.localStorage;
-	          return String(storage?.getItem?.('__SYNCNOS_DEBUG_COMMENTS_SELECTION__') || '') === '1';
-	        } catch (_e) {
-	          return false;
-	        }
+      (() => {
+        try {
+          const storage = anyGlobal.window?.localStorage;
+          return String(storage?.getItem?.('__SYNCNOS_DEBUG_COMMENTS_SELECTION__') || '') === '1';
+        } catch (_e) {
+          return false;
+        }
       })();
     if (!enabled) return;
     try {

--- a/tests/unit/article-outline-minimap.test.ts
+++ b/tests/unit/article-outline-minimap.test.ts
@@ -241,6 +241,9 @@ describe('ArticleOutlineMinimap', () => {
     expect(firstStripBar?.style.width).toBe(`${readerOutlineLevelToMinimapWidth(1)}px`);
     expect(secondStripBar?.style.width).toBe(`${readerOutlineLevelToMinimapWidth(2)}px`);
     expect(thirdStripBar?.style.width).toBe(`${readerOutlineLevelToMinimapWidth(3)}px`);
+    expect(firstStripBar?.className).toContain('tw-h-[2px]');
+    expect(secondStripBar?.className).toContain('tw-h-[2px]');
+    expect(thirdStripBar?.className).toContain('tw-h-[2px]');
     const activeStripButton = document.querySelector(
       '[data-reader-rail-wrap="outline"] [data-reader-outline-level="lvl-2"]',
     ) as HTMLButtonElement | null;

--- a/tests/unit/article-outline-minimap.test.ts
+++ b/tests/unit/article-outline-minimap.test.ts
@@ -88,7 +88,7 @@ function buildArticleOutline(): { article: HTMLElement; entries: ReaderOutlineDo
       <article id="article">
         <h1>深度工作</h1>
         <p>段落</p>
-        <h2>第一策略</h2>
+        <h2>第一策略以及一个足够长的章节标题用于验证目录面板最多显示两行</h2>
         <h3>更细策略</h3>
       </article>
     `,
@@ -273,9 +273,13 @@ describe('ArticleOutlineMinimap', () => {
     expect(activePanelItem?.classList.contains('webclipper-btn--menu-item')).toBe(true);
     expect(activePanelItem?.getAttribute('aria-checked')).toBe('true');
 
+    const longHeading = '第一策略以及一个足够长的章节标题用于验证目录面板最多显示两行';
     const panelButtons = Array.from(panel?.querySelectorAll('button') || []) as HTMLButtonElement[];
-    const secondPanelButton = panelButtons.find((button) => button.textContent === '第一策略');
+    const secondPanelButton = panelButtons.find((button) => button.textContent === longHeading);
     expect(secondPanelButton).toBeTruthy();
+    const secondPanelLabel = panel?.querySelector('[data-reader-outline-entry-label="reader-outline-2"]') as HTMLElement | null;
+    expect(secondPanelLabel?.textContent).toBe(longHeading);
+    expect(secondPanelLabel?.getAttribute('style')).toContain('-webkit-line-clamp: 2');
 
     act(() => {
       secondPanelButton!.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));

--- a/tests/unit/article-outline-minimap.test.ts
+++ b/tests/unit/article-outline-minimap.test.ts
@@ -280,7 +280,9 @@ describe('ArticleOutlineMinimap', () => {
     const panelButtons = Array.from(panel?.querySelectorAll('button') || []) as HTMLButtonElement[];
     const secondPanelButton = panelButtons.find((button) => button.textContent === longHeading);
     expect(secondPanelButton).toBeTruthy();
-    const secondPanelLabel = panel?.querySelector('[data-reader-outline-entry-label="reader-outline-2"]') as HTMLElement | null;
+    const secondPanelLabel = panel?.querySelector(
+      '[data-reader-outline-entry-label="reader-outline-2"]',
+    ) as HTMLElement | null;
     expect(secondPanelLabel?.textContent).toBe(longHeading);
     expect(secondPanelLabel?.getAttribute('style')).toContain('-webkit-line-clamp: 2');
 

--- a/tests/unit/chat-outline-entries.test.ts
+++ b/tests/unit/chat-outline-entries.test.ts
@@ -56,7 +56,7 @@ describe('buildChatOutlineEntries', () => {
     expect(entries[0]?.previewText).toBe('line 1 line 2 line 3');
   });
 
-  it('truncates strings longer than 30 chars and keeps <=30 unchanged', () => {
+  it('keeps long preview text intact so the UI can clamp by lines', () => {
     const entries = buildChatOutlineEntries([
       msg({
         id: 401,
@@ -73,7 +73,7 @@ describe('buildChatOutlineEntries', () => {
     ]);
 
     expect(entries[0]?.previewText).toBe('123456789012345678901234567890');
-    expect(entries[1]?.previewText).toBe('123456789012345678901234567890…');
+    expect(entries[1]?.previewText).toBe('12345678901234567890123456789012345');
   });
 
   it('still creates entries with empty or missing content fields', () => {

--- a/tests/unit/chat-outline-panel.test.ts
+++ b/tests/unit/chat-outline-panel.test.ts
@@ -89,13 +89,18 @@ describe('ChatOutlinePanel', () => {
 
   it('uses the shared rail panel without visible chat-specific directory copy', () => {
     const onPickEntry = vi.fn();
+    const longPreview = '请总结这篇文章的核心观点，并按照背景、论点、证据、结论四个部分展开说明';
+    const panelEntries = [
+      { ...entries[0], previewText: longPreview },
+      entries[1],
+    ];
     act(() => {
-      root!.render(createElement(ChatOutlinePanel, { entries, activeIndex: 2, onPickEntry }));
+      root!.render(createElement(ChatOutlinePanel, { entries: panelEntries, activeIndex: 2, onPickEntry }));
     });
 
     const wrap = document.querySelector('[data-reader-rail-wrap="chat-outline"]') as HTMLElement | null;
     expect(wrap).toBeTruthy();
-    expect(wrap?.querySelectorAll('[data-chat-outline-trigger-bar]')).toHaveLength(entries.length);
+    expect(wrap?.querySelectorAll('[data-chat-outline-trigger-bar]')).toHaveLength(panelEntries.length);
     expect(wrap?.querySelector('[data-chat-outline-trigger-active="true"]')?.getAttribute('data-chat-outline-trigger-bar')).toBe(
       'u-102',
     );
@@ -111,7 +116,9 @@ describe('ChatOutlinePanel', () => {
     expect(panel?.querySelector('[data-chat-outline-active="true"]')?.textContent).toBe('2. 给我一个行动清单');
 
     const firstEntry = panel?.querySelector('[data-chat-outline-entry="u-101"]') as HTMLButtonElement | null;
-    expect(firstEntry?.textContent).toBe('1. 解释这篇文章的核心观点');
+    expect(firstEntry?.textContent).toBe(`1. ${longPreview}`);
+    const firstEntryLabel = panel?.querySelector('[data-chat-outline-entry-label="u-101"]') as HTMLElement | null;
+    expect(firstEntryLabel?.getAttribute('style')).toContain('-webkit-line-clamp: 2');
     expect(firstEntry?.classList.contains('webclipper-btn')).toBe(true);
     expect(firstEntry?.classList.contains('webclipper-btn--menu-item')).toBe(true);
     expect(firstEntry?.classList.contains('webclipper-btn--tone-muted')).toBe(true);
@@ -120,7 +127,7 @@ describe('ChatOutlinePanel', () => {
     act(() => {
       firstEntry!.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
     });
-    expect(onPickEntry).toHaveBeenCalledWith(entries[0]);
+    expect(onPickEntry).toHaveBeenCalledWith(panelEntries[0]);
   });
 
   it('keeps the trigger visible for large chat outlines while preserving the active marker', () => {

--- a/tests/unit/chat-outline-panel.test.ts
+++ b/tests/unit/chat-outline-panel.test.ts
@@ -3,6 +3,7 @@ import { act, createElement } from 'react';
 import ReactDOM from 'react-dom/client';
 import { JSDOM } from 'jsdom';
 
+import { readerOutlineLevelToMinimapWidth } from '../../src/services/protocols/reader-outline';
 import { ChatOutlinePanel } from '../../src/ui/conversations/chat-outline/ChatOutlinePanel';
 import type { ChatOutlineEntry } from '../../src/ui/conversations/chat-outline/outline-entries';
 
@@ -144,8 +145,16 @@ describe('ChatOutlinePanel', () => {
     const bars = Array.from(wrap?.querySelectorAll('[data-chat-outline-trigger-bar]') || []);
 
     expect(barsRoot?.getAttribute('data-chat-outline-trigger-bars')).toBe('50');
+    expect(barsRoot?.className).toContain('tw-w-[22px]');
     expect(bars).toHaveLength(7);
     expect(bars.every((bar) => (bar as HTMLElement).className.includes('tw-h-[2px]'))).toBe(true);
+    expect(bars.every((bar) => (bar as HTMLElement).className.includes('tw-rounded-[var(--radius-inline)]'))).toBe(true);
+    expect((wrap?.querySelector('[data-chat-outline-trigger-bar="u-37"]') as HTMLElement | null)?.style.width).toBe(
+      `${readerOutlineLevelToMinimapWidth(1)}px`,
+    );
+    expect((wrap?.querySelector('[data-chat-outline-trigger-bar="u-1"]') as HTMLElement | null)?.style.width).toBe(
+      `${readerOutlineLevelToMinimapWidth(2)}px`,
+    );
     expect(wrap?.querySelector('[data-chat-outline-trigger-bar="u-37"]')).toBeTruthy();
     expect(wrap?.querySelector('[data-chat-outline-trigger-active="true"]')?.getAttribute('data-chat-outline-trigger-bar')).toBe(
       'u-37',

--- a/tests/unit/chat-outline-panel.test.ts
+++ b/tests/unit/chat-outline-panel.test.ts
@@ -145,10 +145,18 @@ describe('ChatOutlinePanel', () => {
     const bars = Array.from(wrap?.querySelectorAll('[data-chat-outline-trigger-bar]') || []);
 
     expect(barsRoot?.getAttribute('data-chat-outline-trigger-bars')).toBe('50');
-    expect(barsRoot?.className).toContain('tw-w-[22px]');
+    expect(barsRoot?.tagName).toBe('NAV');
+    expect(barsRoot?.className).toContain('tw-gap-2');
+    expect(barsRoot?.className).toContain('tw-py-1');
+    expect(barsRoot?.className).toContain('tw-pr-1');
     expect(bars).toHaveLength(7);
     expect(bars.every((bar) => (bar as HTMLElement).className.includes('tw-h-[2px]'))).toBe(true);
     expect(bars.every((bar) => (bar as HTMLElement).className.includes('tw-rounded-[var(--radius-inline)]'))).toBe(true);
+    expect(
+      Array.from(wrap?.querySelectorAll('[data-chat-outline-trigger-bars] button') || []).every((button) =>
+        (button as HTMLElement).className.includes('tw-leading-none'),
+      ),
+    ).toBe(true);
     expect((wrap?.querySelector('[data-chat-outline-trigger-bar="u-37"]') as HTMLElement | null)?.style.width).toBe(
       `${readerOutlineLevelToMinimapWidth(1)}px`,
     );

--- a/tests/unit/chat-outline-panel.test.ts
+++ b/tests/unit/chat-outline-panel.test.ts
@@ -91,10 +91,7 @@ describe('ChatOutlinePanel', () => {
   it('uses the shared rail panel without visible chat-specific directory copy', () => {
     const onPickEntry = vi.fn();
     const longPreview = '请总结这篇文章的核心观点，并按照背景、论点、证据、结论四个部分展开说明';
-    const panelEntries = [
-      { ...entries[0], previewText: longPreview },
-      entries[1],
-    ];
+    const panelEntries = [{ ...entries[0], previewText: longPreview }, entries[1]];
     act(() => {
       root!.render(createElement(ChatOutlinePanel, { entries: panelEntries, activeIndex: 2, onPickEntry }));
     });
@@ -102,9 +99,9 @@ describe('ChatOutlinePanel', () => {
     const wrap = document.querySelector('[data-reader-rail-wrap="chat-outline"]') as HTMLElement | null;
     expect(wrap).toBeTruthy();
     expect(wrap?.querySelectorAll('[data-chat-outline-trigger-bar]')).toHaveLength(panelEntries.length);
-    expect(wrap?.querySelector('[data-chat-outline-trigger-active="true"]')?.getAttribute('data-chat-outline-trigger-bar')).toBe(
-      'u-102',
-    );
+    expect(
+      wrap?.querySelector('[data-chat-outline-trigger-active="true"]')?.getAttribute('data-chat-outline-trigger-bar'),
+    ).toBe('u-102');
 
     act(() => {
       wrap!.dispatchEvent(new window.MouseEvent('mouseover', { bubbles: true, cancelable: true }));
@@ -151,7 +148,9 @@ describe('ChatOutlinePanel', () => {
     expect(barsRoot?.className).toContain('tw-pr-1');
     expect(bars).toHaveLength(7);
     expect(bars.every((bar) => (bar as HTMLElement).className.includes('tw-h-[2px]'))).toBe(true);
-    expect(bars.every((bar) => (bar as HTMLElement).className.includes('tw-rounded-[var(--radius-inline)]'))).toBe(true);
+    expect(bars.every((bar) => (bar as HTMLElement).className.includes('tw-rounded-[var(--radius-inline)]'))).toBe(
+      true,
+    );
     expect(
       Array.from(wrap?.querySelectorAll('[data-chat-outline-trigger-bars] button') || []).every((button) =>
         (button as HTMLElement).className.includes('tw-leading-none'),
@@ -164,8 +163,8 @@ describe('ChatOutlinePanel', () => {
       `${readerOutlineLevelToMinimapWidth(2)}px`,
     );
     expect(wrap?.querySelector('[data-chat-outline-trigger-bar="u-37"]')).toBeTruthy();
-    expect(wrap?.querySelector('[data-chat-outline-trigger-active="true"]')?.getAttribute('data-chat-outline-trigger-bar')).toBe(
-      'u-37',
-    );
+    expect(
+      wrap?.querySelector('[data-chat-outline-trigger-active="true"]')?.getAttribute('data-chat-outline-trigger-bar'),
+    ).toBe('u-37');
   });
 });

--- a/tests/unit/chat-outline-panel.test.ts
+++ b/tests/unit/chat-outline-panel.test.ts
@@ -119,6 +119,9 @@ describe('ChatOutlinePanel', () => {
     expect(firstEntry?.textContent).toBe(`1. ${longPreview}`);
     const firstEntryLabel = panel?.querySelector('[data-chat-outline-entry-label="u-101"]') as HTMLElement | null;
     expect(firstEntryLabel?.getAttribute('style')).toContain('-webkit-line-clamp: 2');
+    expect(firstEntryLabel?.getAttribute('style')).toContain('line-height: 1.35');
+    expect(firstEntryLabel?.getAttribute('style')).toContain('overflow-wrap: anywhere');
+    expect(firstEntry?.className).toContain('tw-min-h-[50px]');
     expect(firstEntry?.classList.contains('webclipper-btn')).toBe(true);
     expect(firstEntry?.classList.contains('webclipper-btn--menu-item')).toBe(true);
     expect(firstEntry?.classList.contains('webclipper-btn--tone-muted')).toBe(true);

--- a/tests/unit/chat-outline-panel.test.ts
+++ b/tests/unit/chat-outline-panel.test.ts
@@ -134,7 +134,8 @@ describe('ChatOutlinePanel', () => {
     const bars = Array.from(wrap?.querySelectorAll('[data-chat-outline-trigger-bar]') || []);
 
     expect(barsRoot?.getAttribute('data-chat-outline-trigger-bars')).toBe('50');
-    expect(bars).toHaveLength(14);
+    expect(bars).toHaveLength(7);
+    expect(bars.every((bar) => (bar as HTMLElement).className.includes('tw-h-[2px]'))).toBe(true);
     expect(wrap?.querySelector('[data-chat-outline-trigger-bar="u-37"]')).toBeTruthy();
     expect(wrap?.querySelector('[data-chat-outline-trigger-active="true"]')?.getAttribute('data-chat-outline-trigger-bar')).toBe(
       'u-37',

--- a/tests/unit/chat-outline-panel.test.ts
+++ b/tests/unit/chat-outline-panel.test.ts
@@ -50,6 +50,18 @@ const entries: ChatOutlineEntry[] = [
   },
 ];
 
+function makeEntries(count: number): ChatOutlineEntry[] {
+  return Array.from({ length: count }, (_, index) => {
+    const entryIndex = index + 1;
+    return {
+      index: entryIndex,
+      messageId: 1000 + entryIndex,
+      messageKey: `u-${entryIndex}`,
+      previewText: `User prompt ${entryIndex}`,
+    };
+  });
+}
+
 describe('ChatOutlinePanel', () => {
   let root: ReactDOM.Root | null = null;
 
@@ -109,5 +121,23 @@ describe('ChatOutlinePanel', () => {
       firstEntry!.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
     });
     expect(onPickEntry).toHaveBeenCalledWith(entries[0]);
+  });
+
+  it('keeps the trigger visible for large chat outlines while preserving the active marker', () => {
+    const manyEntries = makeEntries(50);
+    act(() => {
+      root!.render(createElement(ChatOutlinePanel, { entries: manyEntries, activeIndex: 37 }));
+    });
+
+    const wrap = document.querySelector('[data-reader-rail-wrap="chat-outline"]') as HTMLElement | null;
+    const barsRoot = wrap?.querySelector('[data-chat-outline-trigger-bars]') as HTMLElement | null;
+    const bars = Array.from(wrap?.querySelectorAll('[data-chat-outline-trigger-bar]') || []);
+
+    expect(barsRoot?.getAttribute('data-chat-outline-trigger-bars')).toBe('50');
+    expect(bars).toHaveLength(14);
+    expect(wrap?.querySelector('[data-chat-outline-trigger-bar="u-37"]')).toBeTruthy();
+    expect(wrap?.querySelector('[data-chat-outline-trigger-active="true"]')?.getAttribute('data-chat-outline-trigger-bar')).toBe(
+      'u-37',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- align AI chat outline rail with article outline strip structure and bar styling
- fix two-line outline title clamping/layout for chat outline entries
- keep large chat outlines visible while preserving active markers

## Verification
- npm run test -- chat-outline-panel article-outline-minimap
- npm run compile && npm run test && npm run build