### PR TITLE
fix: 保持备份恢复后的同步连续性

### DIFF
--- a/src/platform/idb/schema.ts
+++ b/src/platform/idb/schema.ts
@@ -1,3 +1,5 @@
+import { mergeSyncMappingForIdentityMove } from '@platform/idb/sync-mapping-record';
+
 export const DB_NAME = 'webclipper';
 export const DB_VERSION = 8;
 
@@ -191,14 +193,17 @@ function migrateNotionAiThreadConversations({ db, tx }: MigrationContext): void 
 
       const targetReq = mappingsBySourceConversationKeyIndex.get(['notionai', stableKey]);
       targetReq.onsuccess = () => {
-        const target = targetReq.result;
-        if (!target) {
-          mapping.conversationKey = stableKey;
-          mapping.updatedAt = Date.now();
-          mappingsStore.put(mapping);
-        } else {
+        const target = (targetReq.result as Record<string, unknown> | undefined) || null;
+        const merged = mergeSyncMappingForIdentityMove(target, mapping, {
+          source: 'notionai',
+          conversationKey: stableKey,
+        });
+        mappingsStore.put(merged);
+        if (target) {
           const mappingId = Number((mapping as { id?: unknown }).id);
-          if (Number.isFinite(mappingId) && mappingId > 0) mappingsStore.delete(mappingId);
+          if (Number.isFinite(mappingId) && mappingId > 0 && mappingId !== Number((target as { id?: unknown }).id)) {
+            mappingsStore.delete(mappingId);
+          }
         }
         onDone({ ok: true, changed: true });
       };
@@ -522,27 +527,6 @@ function migrateLegacyArticleConversations({ db, tx }: MigrationContext): void {
     return next;
   }
 
-  function mergeMappingRecord(
-    base: Record<string, unknown>,
-    incoming: Record<string, unknown>,
-    fallbackNotionPageId: string,
-  ) {
-    const next = { ...base };
-    next.source = 'web';
-    next.conversationKey = safeString(base.conversationKey || incoming.conversationKey);
-    next.notionPageId =
-      safeString(next.notionPageId) || safeString(incoming.notionPageId) || safeString(fallbackNotionPageId);
-    next.lastSyncedMessageKey = safeString(next.lastSyncedMessageKey) || safeString(incoming.lastSyncedMessageKey);
-    next.lastSyncedSequence = pickMaxFiniteNumber(next.lastSyncedSequence, incoming.lastSyncedSequence);
-    next.lastSyncedAt = pickMaxFiniteNumber(next.lastSyncedAt, incoming.lastSyncedAt);
-    next.lastSyncedMessageUpdatedAt = pickMaxFiniteNumber(
-      next.lastSyncedMessageUpdatedAt,
-      incoming.lastSyncedMessageUpdatedAt,
-    );
-    next.updatedAt = pickMaxFiniteNumber(next.updatedAt, incoming.updatedAt, Date.now()) || Date.now();
-    return next;
-  }
-
   function migrateMessagesFromDupToKeep(input: { dupId: number; keepId: number; onDone: MigrationDone }): void {
     const { dupId, keepId, onDone } = input;
     let hadAny = false;
@@ -619,13 +603,14 @@ function migrateLegacyArticleConversations({ db, tx }: MigrationContext): void {
     targetReq.onsuccess = () => {
       const target = (targetReq.result as Record<string, unknown> | undefined) || null;
 
+      const identity = { source: 'web', conversationKey: canonicalKey, fallbackNotionPageId };
       if (!legacySource || !legacyKey || (legacySource === 'web' && legacyKey === canonicalKey)) {
         if (!target) {
           input.onDone({ ok: true, changed: false });
           return;
         }
-        const merged = mergeMappingRecord(target, {}, fallbackNotionPageId);
-        mappingsStore.put(merged);
+        const merged = mergeSyncMappingForIdentityMove(target, null, identity);
+        if (JSON.stringify(merged) !== JSON.stringify(target)) mappingsStore.put(merged);
         input.onDone({ ok: true, changed: true });
         return;
       }
@@ -635,22 +620,20 @@ function migrateLegacyArticleConversations({ db, tx }: MigrationContext): void {
         const legacy = (legacyReq.result as Record<string, unknown> | undefined) || null;
         if (!legacy) {
           if (target) {
-            const merged = mergeMappingRecord(target, {}, fallbackNotionPageId);
-            mappingsStore.put(merged);
+            const merged = mergeSyncMappingForIdentityMove(target, null, identity);
+            if (JSON.stringify(merged) !== JSON.stringify(target)) mappingsStore.put(merged);
           }
           input.onDone({ ok: true, changed: false });
           return;
         }
 
         if (!target) {
-          legacy.source = 'web';
-          legacy.conversationKey = canonicalKey;
-          mappingsStore.put(mergeMappingRecord(legacy, {}, fallbackNotionPageId));
+          mappingsStore.put(mergeSyncMappingForIdentityMove(null, legacy, identity));
           input.onDone({ ok: true, changed: true });
           return;
         }
 
-        const merged = mergeMappingRecord(target, legacy, fallbackNotionPageId);
+        const merged = mergeSyncMappingForIdentityMove(target, legacy, identity);
         mappingsStore.put(merged);
         const legacyId = Number((legacy as { id?: unknown }).id);
         if (Number.isFinite(legacyId) && legacyId > 0 && legacyId !== Number((target as { id?: unknown }).id)) {

--- a/src/platform/idb/sync-mapping-record.ts
+++ b/src/platform/idb/sync-mapping-record.ts
@@ -35,11 +35,7 @@ function finiteNumber(value: unknown): number | null {
   return Number.isFinite(numberValue) ? numberValue : null;
 }
 
-function replaceGroup(
-  target: SyncMappingRecord,
-  source: SyncMappingRecord,
-  fields: readonly string[],
-): void {
+function replaceGroup(target: SyncMappingRecord, source: SyncMappingRecord, fields: readonly string[]): void {
   for (const field of fields) {
     delete target[field];
     if (Object.prototype.hasOwnProperty.call(source, field)) target[field] = source[field];
@@ -59,8 +55,7 @@ export function mergeSyncMappingPatch(existing: unknown, patch: unknown): SyncMa
   const notionTargetChanged =
     hasNotionTargetPatch && safeString(base.notionPageId) !== safeString(incoming.notionPageId);
   const hasFeishuTargetPatch = Object.prototype.hasOwnProperty.call(incoming, 'feishuDocId');
-  const feishuTargetChanged =
-    hasFeishuTargetPatch && safeString(base.feishuDocId) !== safeString(incoming.feishuDocId);
+  const feishuTargetChanged = hasFeishuTargetPatch && safeString(base.feishuDocId) !== safeString(incoming.feishuDocId);
   const next: SyncMappingRecord = { ...base };
   if (notionTargetChanged) {
     for (const field of NOTION_CONTINUITY_FIELDS) delete next[field];

--- a/src/platform/idb/sync-mapping-record.ts
+++ b/src/platform/idb/sync-mapping-record.ts
@@ -14,9 +14,14 @@ const NOTION_CONTINUITY_FIELDS = [
 ] as const;
 
 const FEISHU_CONTINUITY_FIELDS = ['feishuDocId', 'feishuLastContentHash'] as const;
+const NOTION_NESTED_FIELDS = ['notionSections', 'notionSectionCursors', 'notionSectionDigests'] as const;
+
+function isRecord(value: unknown): value is SyncMappingRecord {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
 
 function asRecord(value: unknown): SyncMappingRecord {
-  return value && typeof value === 'object' ? (value as SyncMappingRecord) : {};
+  return isRecord(value) ? value : {};
 }
 
 function safeString(value: unknown): string {
@@ -44,6 +49,36 @@ function replaceGroup(
 export function stripSyncMappingLocalId(record: unknown): SyncMappingRecord {
   const next = { ...asRecord(record) };
   delete next.id;
+  return next;
+}
+
+export function mergeSyncMappingPatch(existing: unknown, patch: unknown): SyncMappingRecord {
+  const base = asRecord(existing);
+  const incoming = stripSyncMappingLocalId(patch);
+  const next: SyncMappingRecord = { ...base, ...incoming };
+
+  for (const field of NOTION_NESTED_FIELDS) {
+    if (!Object.prototype.hasOwnProperty.call(incoming, field)) continue;
+    const patchSections = incoming[field];
+    if (!isRecord(patchSections)) {
+      if (Object.prototype.hasOwnProperty.call(base, field)) next[field] = base[field];
+      else delete next[field];
+      continue;
+    }
+
+    const baseSections = asRecord(base[field]);
+    const mergedSections: SyncMappingRecord = { ...baseSections };
+    for (const [rawSectionId, sectionPatch] of Object.entries(patchSections)) {
+      const sectionId = safeString(rawSectionId);
+      if (!sectionId || !isRecord(sectionPatch)) continue;
+      mergedSections[sectionId] = {
+        ...asRecord(baseSections[sectionId]),
+        ...sectionPatch,
+      };
+    }
+    next[field] = mergedSections;
+  }
+
   return next;
 }
 

--- a/src/platform/idb/sync-mapping-record.ts
+++ b/src/platform/idb/sync-mapping-record.ts
@@ -82,6 +82,39 @@ export function mergeSyncMappingPatch(existing: unknown, patch: unknown): SyncMa
   return next;
 }
 
+export function mergeSyncMappingForIdentityMove(
+  target: unknown,
+  legacy: unknown,
+  identity: { source: unknown; conversationKey: unknown; fallbackNotionPageId?: unknown },
+): SyncMappingRecord {
+  const current = asRecord(target);
+  const previous = asRecord(legacy);
+  const hasTarget = Object.keys(current).length > 0;
+  const next: SyncMappingRecord = hasTarget ? { ...previous, ...current } : { ...previous };
+
+  const targetNotionPageId = safeString(current.notionPageId);
+  const legacyNotionPageId = safeString(previous.notionPageId);
+  const notionSource = targetNotionPageId ? current : legacyNotionPageId ? previous : hasTarget ? current : previous;
+  replaceGroup(next, notionSource, NOTION_CONTINUITY_FIELDS);
+  if (!safeString(next.notionPageId)) {
+    const fallbackNotionPageId = safeString(identity?.fallbackNotionPageId);
+    if (fallbackNotionPageId) next.notionPageId = fallbackNotionPageId;
+  }
+
+  const targetFeishuDocId = safeString(current.feishuDocId);
+  const legacyFeishuDocId = safeString(previous.feishuDocId);
+  const feishuSource = targetFeishuDocId ? current : legacyFeishuDocId ? previous : hasTarget ? current : previous;
+  replaceGroup(next, feishuSource, FEISHU_CONTINUITY_FIELDS);
+
+  next.source = safeString(identity?.source);
+  next.conversationKey = safeString(identity?.conversationKey);
+  if (hasTarget && Object.prototype.hasOwnProperty.call(current, 'id')) next.id = current.id;
+  else if (Object.prototype.hasOwnProperty.call(previous, 'id')) next.id = previous.id;
+  else delete next.id;
+
+  return next;
+}
+
 export function mergeSyncMappingForImport(existing: unknown, incoming: unknown): SyncMappingRecord {
   const local = stripSyncMappingLocalId(existing);
   const imported = stripSyncMappingLocalId(incoming);

--- a/src/platform/idb/sync-mapping-record.ts
+++ b/src/platform/idb/sync-mapping-record.ts
@@ -1,0 +1,87 @@
+type SyncMappingRecord = Record<string, unknown>;
+
+const NOTION_CONTINUITY_FIELDS = [
+  'notionPageId',
+  'notionPageUrl',
+  'notionWorkspaceSlug',
+  'lastSyncedMessageKey',
+  'lastSyncedSequence',
+  'lastSyncedAt',
+  'lastSyncedMessageUpdatedAt',
+  'notionSections',
+  'notionSectionCursors',
+  'notionSectionDigests',
+] as const;
+
+const FEISHU_CONTINUITY_FIELDS = ['feishuDocId', 'feishuLastContentHash'] as const;
+
+function asRecord(value: unknown): SyncMappingRecord {
+  return value && typeof value === 'object' ? (value as SyncMappingRecord) : {};
+}
+
+function safeString(value: unknown): string {
+  return String(value == null ? '' : value).trim();
+}
+
+function finiteNumber(value: unknown): number | null {
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) ? numberValue : null;
+}
+
+function replaceGroup(
+  target: SyncMappingRecord,
+  source: SyncMappingRecord,
+  fields: readonly string[],
+): void {
+  for (const field of fields) {
+    delete target[field];
+    if (Object.prototype.hasOwnProperty.call(source, field)) target[field] = source[field];
+  }
+}
+
+export function stripSyncMappingLocalId(record: unknown): SyncMappingRecord {
+  const next = { ...asRecord(record) };
+  delete next.id;
+  return next;
+}
+
+export function mergeSyncMappingForImport(existing: unknown, incoming: unknown): SyncMappingRecord {
+  const local = stripSyncMappingLocalId(existing);
+  const imported = stripSyncMappingLocalId(incoming);
+
+  if (!Object.keys(local).length) return imported;
+
+  // Generic metadata is conservative: keep local values and only fill missing keys from the imported snapshot.
+  const next: SyncMappingRecord = { ...imported, ...local };
+
+  const localNotionPageId = safeString(local.notionPageId);
+  const importedNotionPageId = safeString(imported.notionPageId);
+  let notionSource = local;
+  if (!localNotionPageId) {
+    notionSource = imported;
+  } else if (!importedNotionPageId) {
+    notionSource = local;
+  } else if (localNotionPageId !== importedNotionPageId) {
+    notionSource = local;
+  } else {
+    const localSyncedAt = finiteNumber(local.lastSyncedAt);
+    const importedSyncedAt = finiteNumber(imported.lastSyncedAt);
+    notionSource =
+      localSyncedAt != null && importedSyncedAt != null && localSyncedAt > importedSyncedAt ? local : imported;
+  }
+  replaceGroup(next, notionSource, NOTION_CONTINUITY_FIELDS);
+
+  const localFeishuDocId = safeString(local.feishuDocId);
+  const importedFeishuDocId = safeString(imported.feishuDocId);
+  const feishuSource =
+    !localFeishuDocId || (importedFeishuDocId && importedFeishuDocId === localFeishuDocId) ? imported : local;
+  replaceGroup(next, feishuSource, FEISHU_CONTINUITY_FIELDS);
+
+  const localUpdatedAt = finiteNumber(local.updatedAt);
+  const importedUpdatedAt = finiteNumber(imported.updatedAt);
+  if (localUpdatedAt != null || importedUpdatedAt != null) {
+    next.updatedAt = Math.max(localUpdatedAt ?? -Infinity, importedUpdatedAt ?? -Infinity);
+  }
+
+  return next;
+}

--- a/src/platform/idb/sync-mapping-record.ts
+++ b/src/platform/idb/sync-mapping-record.ts
@@ -55,18 +55,26 @@ export function stripSyncMappingLocalId(record: unknown): SyncMappingRecord {
 export function mergeSyncMappingPatch(existing: unknown, patch: unknown): SyncMappingRecord {
   const base = asRecord(existing);
   const incoming = stripSyncMappingLocalId(patch);
-  const next: SyncMappingRecord = { ...base, ...incoming };
+  const hasNotionTargetPatch = Object.prototype.hasOwnProperty.call(incoming, 'notionPageId');
+  const notionTargetChanged =
+    hasNotionTargetPatch && safeString(base.notionPageId) !== safeString(incoming.notionPageId);
+  const next: SyncMappingRecord = { ...base };
+  if (notionTargetChanged) {
+    for (const field of NOTION_CONTINUITY_FIELDS) delete next[field];
+  }
+  Object.assign(next, incoming);
 
+  const nestedBase = notionTargetChanged ? {} : base;
   for (const field of NOTION_NESTED_FIELDS) {
     if (!Object.prototype.hasOwnProperty.call(incoming, field)) continue;
     const patchSections = incoming[field];
     if (!isRecord(patchSections)) {
-      if (Object.prototype.hasOwnProperty.call(base, field)) next[field] = base[field];
+      if (Object.prototype.hasOwnProperty.call(nestedBase, field)) next[field] = nestedBase[field];
       else delete next[field];
       continue;
     }
 
-    const baseSections = asRecord(base[field]);
+    const baseSections = asRecord(nestedBase[field]);
     const mergedSections: SyncMappingRecord = { ...baseSections };
     for (const [rawSectionId, sectionPatch] of Object.entries(patchSections)) {
       const sectionId = safeString(rawSectionId);

--- a/src/platform/idb/sync-mapping-record.ts
+++ b/src/platform/idb/sync-mapping-record.ts
@@ -24,6 +24,8 @@ function safeString(value: unknown): string {
 }
 
 function finiteNumber(value: unknown): number | null {
+  if (value == null) return null;
+  if (typeof value === 'string' && !value.trim()) return null;
   const numberValue = Number(value);
   return Number.isFinite(numberValue) ? numberValue : null;
 }

--- a/src/platform/idb/sync-mapping-record.ts
+++ b/src/platform/idb/sync-mapping-record.ts
@@ -58,9 +58,15 @@ export function mergeSyncMappingPatch(existing: unknown, patch: unknown): SyncMa
   const hasNotionTargetPatch = Object.prototype.hasOwnProperty.call(incoming, 'notionPageId');
   const notionTargetChanged =
     hasNotionTargetPatch && safeString(base.notionPageId) !== safeString(incoming.notionPageId);
+  const hasFeishuTargetPatch = Object.prototype.hasOwnProperty.call(incoming, 'feishuDocId');
+  const feishuTargetChanged =
+    hasFeishuTargetPatch && safeString(base.feishuDocId) !== safeString(incoming.feishuDocId);
   const next: SyncMappingRecord = { ...base };
   if (notionTargetChanged) {
     for (const field of NOTION_CONTINUITY_FIELDS) delete next[field];
+  }
+  if (feishuTargetChanged) {
+    for (const field of FEISHU_CONTINUITY_FIELDS) delete next[field];
   }
   Object.assign(next, incoming);
 

--- a/src/services/comments/domain/comment-thread-graph.ts
+++ b/src/services/comments/domain/comment-thread-graph.ts
@@ -9,12 +9,54 @@ export type CommentThreadGraph<T extends ArticleCommentDto = ArticleCommentDto> 
   duplicateIds: number[];
 };
 
-function timeAsc(a: ArticleCommentDto, b: ArticleCommentDto): number {
-  return a.createdAt - b.createdAt || a.id - b.id;
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (!value || typeof value !== 'object') return value;
+  const record = value as Record<string, unknown>;
+  return Object.keys(record)
+    .sort()
+    .reduce<Record<string, unknown>>((out, key) => {
+      out[key] = stableValue(record[key]);
+      return out;
+    }, {});
 }
 
-function timeDesc(a: ArticleCommentDto, b: ArticleCommentDto): number {
-  return b.createdAt - a.createdAt || b.id - a.id;
+function stableCommentTieKey(comment: ArticleCommentDto): string {
+  return JSON.stringify({
+    updatedAt: Number(comment.updatedAt) || 0,
+    canonicalUrl: String(comment.canonicalUrl || ''),
+    authorName: String(comment.authorName || ''),
+    quoteText: String(comment.quoteText || ''),
+    commentText: String(comment.commentText || ''),
+    locator: stableValue(comment.locator ?? null),
+  });
+}
+
+function stableCommentTieCompare(a: ArticleCommentDto, b: ArticleCommentDto): number {
+  const aKey = stableCommentTieKey(a);
+  const bKey = stableCommentTieKey(b);
+  if (aKey < bKey) return -1;
+  if (aKey > bKey) return 1;
+  // Semantically indistinguishable rows may use the local id only as a final in-database tiebreaker.
+  return a.id - b.id;
+}
+
+function stableThreadTieCompare(a: CommentThread, b: CommentThread): number {
+  const aKey = JSON.stringify({
+    root: stableCommentTieKey(a.root),
+    replies: a.replies.map(stableCommentTieKey),
+  });
+  const bKey = JSON.stringify({
+    root: stableCommentTieKey(b.root),
+    replies: b.replies.map(stableCommentTieKey),
+  });
+  if (aKey < bKey) return -1;
+  if (aKey > bKey) return 1;
+  return a.root.id - b.root.id;
+}
+
+function timeAsc(a: ArticleCommentDto, b: ArticleCommentDto): number {
+  return a.createdAt - b.createdAt || stableCommentTieCompare(a, b);
 }
 
 type RootResolution = { rootId: number };
@@ -113,14 +155,14 @@ export function normalizeCommentThreadGraph<T extends ArticleCommentDto>(
     repliesByRoot.set(rootId, replies);
   }
 
-  const roots = [...rootIds]
+  const threads = [...rootIds]
     .map((id) => byId.get(id))
     .filter((item): item is T => Boolean(item))
-    .sort(timeDesc);
-  const threads = roots.map((root) => ({
-    root,
-    replies: (repliesByRoot.get(root.id) ?? []).sort(timeAsc),
-  }));
+    .map((root) => ({
+      root,
+      replies: (repliesByRoot.get(root.id) ?? []).sort(timeAsc),
+    }))
+    .sort((a, b) => b.root.createdAt - a.root.createdAt || stableThreadTieCompare(a, b));
 
   return {
     threads,

--- a/src/services/comments/domain/comment-thread-graph.ts
+++ b/src/services/comments/domain/comment-thread-graph.ts
@@ -23,6 +23,7 @@ function stableValue(value: unknown): unknown {
 
 function stableCommentTieKey(comment: ArticleCommentDto): string {
   return JSON.stringify({
+    createdAt: Number(comment.createdAt) || 0,
     updatedAt: Number(comment.updatedAt) || 0,
     canonicalUrl: String(comment.canonicalUrl || ''),
     authorName: String(comment.authorName || ''),

--- a/src/services/comments/sync/notion-comments-renderer.ts
+++ b/src/services/comments/sync/notion-comments-renderer.ts
@@ -2,7 +2,7 @@ import type { ArticleCommentDto } from '@services/comments/domain/comment-dto';
 import { normalizeCommentThreadGraph } from '@services/comments/domain/comment-thread-graph';
 
 const MAX_TEXT = 1900;
-const NOTION_COMMENTS_DIGEST_VERSION = 6;
+const NOTION_COMMENTS_DIGEST_VERSION = 7;
 const DEFAULT_COMMENT_AUTHOR = 'You';
 
 function pad2(value: number): string {
@@ -165,11 +165,8 @@ function fnv1a32(input: string): string {
   return (hash >>> 0).toString(16).padStart(8, '0');
 }
 
-export function computeNotionCommentsDigest(comments: ArticleCommentDto[]): string {
-  const graph = normalizeCommentThreadGraph(comments);
-  const normalized = graph.orderedItems.map((comment) => ({
-    id: comment.id,
-    parentId: comment.parentId,
+function normalizeCommentForDigest(comment: ArticleCommentDto) {
+  return {
     authorName: safeString(comment.authorName),
     createdAt: comment.createdAt,
     updatedAt: comment.updatedAt,
@@ -177,12 +174,14 @@ export function computeNotionCommentsDigest(comments: ArticleCommentDto[]): stri
     commentText: safeString(comment.commentText),
     locatorVersion: comment.locator?.v ?? null,
     locator: comment.locator ?? null,
+  };
+}
+
+export function computeNotionCommentsDigest(comments: ArticleCommentDto[]): string {
+  const graph = normalizeCommentThreadGraph(comments);
+  const threads = graph.threads.map((thread) => ({
+    root: normalizeCommentForDigest(thread.root),
+    replies: thread.replies.map(normalizeCommentForDigest),
   }));
-  return fnv1a32(
-    JSON.stringify({
-      v: NOTION_COMMENTS_DIGEST_VERSION,
-      graph: { orphanIds: graph.orphanIds, cycleIds: graph.cycleIds, duplicateIds: graph.duplicateIds },
-      items: normalized,
-    }),
-  );
+  return fnv1a32(JSON.stringify({ v: NOTION_COMMENTS_DIGEST_VERSION, threads }));
 }

--- a/src/services/conversations/background/storage.ts
+++ b/src/services/conversations/background/storage.ts
@@ -1,5 +1,4 @@
 import {
-  clearSyncCursor,
   deleteConversationsByIds,
   getConversationById,
   getMessagesByConversationId,
@@ -25,7 +24,6 @@ export const backgroundStorage = {
   getSyncMappingByConversation,
   patchSyncMapping,
   setSyncCursor,
-  clearSyncCursor,
   getArticleCommentsByConversationId,
   attachOrphanArticleCommentsToConversation,
 };

--- a/src/services/conversations/data/storage-idb.ts
+++ b/src/services/conversations/data/storage-idb.ts
@@ -1382,15 +1382,19 @@ export async function patchSyncMapping(conversationId: number, patch: Record<str
   const existing = (await reqToPromise(idx.get([source, conversationKey]) as any)) as any;
   const now = Date.now();
   const previousNotionPageId = safeString(existing?.notionPageId) || safeString(conversation.notionPageId);
-  const existingForPatch =
-    previousNotionPageId && !safeString(existing?.notionPageId)
-      ? { ...(existing && typeof existing === 'object' ? existing : {}), notionPageId: previousNotionPageId }
-      : existing;
+  const previousFeishuDocId = safeString(existing?.feishuDocId) || safeString(conversation.feishuDocId);
+  const existingForPatch = { ...(existing && typeof existing === 'object' ? existing : {}) } as any;
+  if (previousNotionPageId && !safeString(existingForPatch.notionPageId)) existingForPatch.notionPageId = previousNotionPageId;
+  if (previousFeishuDocId && !safeString(existingForPatch.feishuDocId)) existingForPatch.feishuDocId = previousFeishuDocId;
   const merged = mergeSyncMappingPatch(existingForPatch, patch) as any;
   const hasNotionPagePatch = Object.prototype.hasOwnProperty.call(patch, 'notionPageId');
+  const hasFeishuDocPatch = Object.prototype.hasOwnProperty.call(patch, 'feishuDocId');
   const nextNotionPageId = hasNotionPagePatch
     ? safeString(merged.notionPageId)
     : safeString(merged.notionPageId) || previousNotionPageId;
+  const nextFeishuDocId = hasFeishuDocPatch
+    ? safeString(merged.feishuDocId)
+    : safeString(merged.feishuDocId) || previousFeishuDocId;
   const notionTargetChanged = hasNotionPagePatch && previousNotionPageId !== nextNotionPageId;
   const conversationNotionTargetChanged =
     hasNotionPagePatch && safeString(conversation.notionPageId) !== nextNotionPageId;
@@ -1399,7 +1403,7 @@ export async function patchSyncMapping(conversationId: number, patch: Record<str
     source,
     conversationKey,
     notionPageId: nextNotionPageId,
-    feishuDocId: safeString(merged.feishuDocId) || safeString(existing?.feishuDocId) || safeString(conversation.feishuDocId),
+    feishuDocId: nextFeishuDocId,
     updatedAt: now,
   } as any;
   const payload: any = withOptionalId(existing && existing.id, next);
@@ -1424,8 +1428,7 @@ export async function patchSyncMapping(conversationId: number, patch: Record<str
     conversationChanged = true;
   }
 
-  const nextFeishuDocId = safeString(next.feishuDocId);
-  if (nextFeishuDocId && safeString(conversation.feishuDocId) !== nextFeishuDocId) {
+  if ((hasFeishuDocPatch || nextFeishuDocId) && safeString(conversation.feishuDocId) !== nextFeishuDocId) {
     conversation.feishuDocId = nextFeishuDocId;
     conversationChanged = true;
   }

--- a/src/services/conversations/data/storage-idb.ts
+++ b/src/services/conversations/data/storage-idb.ts
@@ -15,6 +15,7 @@ import type {
   ConversationListSummary,
 } from '@services/conversations/domain/list-pagination';
 import { openDb as openSchemaDb } from '@platform/idb/schema';
+import { mergeSyncMappingPatch } from '@platform/idb/sync-mapping-record';
 import { computeArticleCommentThreadCount } from '@services/comments/domain/comment-metrics';
 
 let cachedDb: IDBDatabase | null = null;
@@ -1410,40 +1411,13 @@ export async function patchSyncMapping(conversationId: number, patch: Record<str
   const idx = stores.sync_mappings.index('by_source_conversationKey');
   const existing = (await reqToPromise(idx.get([source, conversationKey]) as any)) as any;
   const now = Date.now();
-  const patchObj: any = { ...patch };
-  const incomingSections =
-    patchObj.notionSections && typeof patchObj.notionSections === 'object' ? patchObj.notionSections : null;
-  if (incomingSections) delete patchObj.notionSections;
-  const existingSections =
-    existing && typeof existing === 'object' && existing.notionSections && typeof existing.notionSections === 'object'
-      ? existing.notionSections
-      : null;
-  const mergedSections = incomingSections
-    ? {
-        ...(existingSections || {}),
-        ...Object.fromEntries(
-          Object.entries(incomingSections).map(([key, value]) => [
-            key,
-            {
-              ...((existingSections &&
-              (existingSections as any)[key] &&
-              typeof (existingSections as any)[key] === 'object'
-                ? (existingSections as any)[key]
-                : null) || {}),
-              ...((value && typeof value === 'object' ? value : null) || {}),
-            },
-          ]),
-        ),
-      }
-    : null;
+  const merged = mergeSyncMappingPatch(existing, patch) as any;
   const next = {
-    ...(existing && typeof existing === 'object' ? existing : null),
-    ...patchObj,
+    ...merged,
     source,
     conversationKey,
-    notionPageId: String((patch as any)?.notionPageId || existing?.notionPageId || conversation.notionPageId || ''),
-    feishuDocId: String((patch as any)?.feishuDocId || existing?.feishuDocId || conversation.feishuDocId || ''),
-    ...(mergedSections ? { notionSections: mergedSections } : null),
+    notionPageId: safeString(merged.notionPageId) || safeString(existing?.notionPageId) || safeString(conversation.notionPageId),
+    feishuDocId: safeString(merged.feishuDocId) || safeString(existing?.feishuDocId) || safeString(conversation.feishuDocId),
     updatedAt: now,
   } as any;
   const payload: any = withOptionalId(existing && existing.id, next);
@@ -1520,87 +1494,21 @@ export async function setSyncCursor(
     notionSections?: Record<string, unknown>;
   },
 ): Promise<true> {
-  const id = Number(conversationId);
-  if (!Number.isFinite(id) || id <= 0) throw new Error('invalid conversationId');
-
-  const db = await openDb();
-  const { t, stores } = tx(db, ['conversations', 'sync_mappings'], 'readwrite');
-  const conversation = (await reqToPromise(stores.conversations.get(id as any))) as any;
-  if (!conversation) throw new Error('conversation not found');
-
-  const source = String(conversation.source || '').trim();
-  const conversationKey = String(conversation.conversationKey || '').trim();
-  if (!source || !conversationKey) throw new Error('missing source or conversationKey');
-
-  const idx = stores.sync_mappings.index('by_source_conversationKey');
-  const existing = (await reqToPromise(idx.get([source, conversationKey]) as any)) as any;
-  const now = Date.now();
-  const preserved: any = existing && typeof existing === 'object' ? { ...existing } : {};
-  if (preserved && typeof preserved === 'object') delete preserved.id;
-  const mergeNestedRecord = (prev: any, incoming: any): any | null => {
-    if (!incoming || typeof incoming !== 'object') return null;
-    const base = prev && typeof prev === 'object' ? prev : {};
-    const out: any = { ...base };
-    for (const [key, value] of Object.entries(incoming)) {
-      const k = String(key || '').trim();
-      if (!k) continue;
-      out[k] = {
-        ...((base as any)[k] && typeof (base as any)[k] === 'object' ? (base as any)[k] : {}),
-        ...(value && typeof value === 'object' ? value : {}),
-      };
-    }
-    return out;
+  const finiteOrNull = (value: unknown): number | null => {
+    if (value == null) return null;
+    if (typeof value === 'string' && !value.trim()) return null;
+    const numberValue = Number(value);
+    return Number.isFinite(numberValue) ? numberValue : null;
   };
-  const mergedNotionSections = mergeNestedRecord(preserved.notionSections, input?.notionSections);
-  const mergedNotionSectionCursors = mergeNestedRecord(preserved.notionSectionCursors, input?.notionSectionCursors);
-  const mergedNotionSectionDigests = mergeNestedRecord(preserved.notionSectionDigests, input?.notionSectionDigests);
-  const payload: any = withOptionalId(existing && existing.id, {
-    ...preserved,
-    source,
-    conversationKey,
-    notionPageId: String(existing?.notionPageId || conversation.notionPageId || ''),
-    lastSyncedMessageKey: String(input?.lastSyncedMessageKey || ''),
-    lastSyncedSequence: Number.isFinite(Number(input?.lastSyncedSequence)) ? Number(input?.lastSyncedSequence) : null,
-    lastSyncedAt: Number.isFinite(Number(input?.lastSyncedAt)) ? Number(input?.lastSyncedAt) : now,
-    lastSyncedMessageUpdatedAt: Number.isFinite(Number(input?.lastSyncedMessageUpdatedAt))
-      ? Number(input?.lastSyncedMessageUpdatedAt)
-      : null,
-    ...(mergedNotionSections ? { notionSections: mergedNotionSections } : null),
-    ...(mergedNotionSectionCursors ? { notionSectionCursors: mergedNotionSectionCursors } : null),
-    ...(mergedNotionSectionDigests ? { notionSectionDigests: mergedNotionSectionDigests } : null),
-    updatedAt: now,
+  const lastSyncedAt = finiteOrNull(input?.lastSyncedAt);
+
+  return patchSyncMapping(conversationId, {
+    lastSyncedMessageKey: safeString(input?.lastSyncedMessageKey),
+    lastSyncedSequence: finiteOrNull(input?.lastSyncedSequence),
+    lastSyncedAt: lastSyncedAt ?? Date.now(),
+    lastSyncedMessageUpdatedAt: finiteOrNull(input?.lastSyncedMessageUpdatedAt),
+    ...(input?.notionSectionCursors !== undefined ? { notionSectionCursors: input.notionSectionCursors } : null),
+    ...(input?.notionSectionDigests !== undefined ? { notionSectionDigests: input.notionSectionDigests } : null),
+    ...(input?.notionSections !== undefined ? { notionSections: input.notionSections } : null),
   });
-  if (existing) await reqToPromise(stores.sync_mappings.put(payload));
-  else await reqToPromise(stores.sync_mappings.add(payload));
-
-  await txDone(t);
-  return true;
-}
-
-export async function clearSyncCursor(conversationId: number): Promise<true> {
-  const id = Number(conversationId);
-  if (!Number.isFinite(id) || id <= 0) throw new Error('invalid conversationId');
-
-  const db = await openDb();
-  const { t, stores } = tx(db, ['conversations', 'sync_mappings'], 'readwrite');
-  const conversation = (await reqToPromise(stores.conversations.get(id as any))) as any;
-  if (!conversation) throw new Error('conversation not found');
-
-  const source = String(conversation.source || '').trim();
-  const conversationKey = String(conversation.conversationKey || '').trim();
-  if (!source || !conversationKey) throw new Error('missing source or conversationKey');
-
-  const idx = stores.sync_mappings.index('by_source_conversationKey');
-  const existing = (await reqToPromise(idx.get([source, conversationKey]) as any)) as any;
-  if (existing && existing.id) {
-    existing.lastSyncedMessageKey = '';
-    existing.lastSyncedSequence = null;
-    existing.lastSyncedAt = null;
-    existing.lastSyncedMessageUpdatedAt = null;
-    existing.updatedAt = Date.now();
-    await reqToPromise(stores.sync_mappings.put(existing));
-  }
-
-  await txDone(t);
-  return true;
 }

--- a/src/services/conversations/data/storage-idb.ts
+++ b/src/services/conversations/data/storage-idb.ts
@@ -1384,8 +1384,10 @@ export async function patchSyncMapping(conversationId: number, patch: Record<str
   const previousNotionPageId = safeString(existing?.notionPageId) || safeString(conversation.notionPageId);
   const previousFeishuDocId = safeString(existing?.feishuDocId) || safeString(conversation.feishuDocId);
   const existingForPatch = { ...(existing && typeof existing === 'object' ? existing : {}) } as any;
-  if (previousNotionPageId && !safeString(existingForPatch.notionPageId)) existingForPatch.notionPageId = previousNotionPageId;
-  if (previousFeishuDocId && !safeString(existingForPatch.feishuDocId)) existingForPatch.feishuDocId = previousFeishuDocId;
+  if (previousNotionPageId && !safeString(existingForPatch.notionPageId))
+    existingForPatch.notionPageId = previousNotionPageId;
+  if (previousFeishuDocId && !safeString(existingForPatch.feishuDocId))
+    existingForPatch.feishuDocId = previousFeishuDocId;
   const merged = mergeSyncMappingPatch(existingForPatch, patch) as any;
   const hasNotionPagePatch = Object.prototype.hasOwnProperty.call(patch, 'notionPageId');
   const hasFeishuDocPatch = Object.prototype.hasOwnProperty.call(patch, 'feishuDocId');
@@ -1416,11 +1418,7 @@ export async function patchSyncMapping(conversationId: number, patch: Record<str
     conversationChanged = true;
   }
   for (const field of ['notionPageUrl', 'notionWorkspaceSlug'] as const) {
-    if (
-      !notionTargetChanged &&
-      !conversationNotionTargetChanged &&
-      !Object.prototype.hasOwnProperty.call(patch, field)
-    )
+    if (!notionTargetChanged && !conversationNotionTargetChanged && !Object.prototype.hasOwnProperty.call(patch, field))
       continue;
     const value = safeString(next[field]);
     if (safeString(conversation[field]) === value) continue;

--- a/src/services/conversations/data/storage-idb.ts
+++ b/src/services/conversations/data/storage-idb.ts
@@ -15,7 +15,7 @@ import type {
   ConversationListSummary,
 } from '@services/conversations/domain/list-pagination';
 import { openDb as openSchemaDb } from '@platform/idb/schema';
-import { mergeSyncMappingPatch } from '@platform/idb/sync-mapping-record';
+import { mergeSyncMappingForIdentityMove, mergeSyncMappingPatch } from '@platform/idb/sync-mapping-record';
 import { computeArticleCommentThreadCount } from '@services/comments/domain/comment-metrics';
 
 let cachedDb: IDBDatabase | null = null;
@@ -332,31 +332,6 @@ function mergeWarningFlags(preferred: unknown, fallback: unknown): string[] {
   return out;
 }
 
-function mergeSyncMappingRecord(base: any, incoming: any, fallbackNotionPageId: string): any {
-  const current = base && typeof base === 'object' ? { ...base } : {};
-  const next = incoming && typeof incoming === 'object' ? incoming : {};
-  const notionPageId =
-    safeString(current.notionPageId) || safeString(next.notionPageId) || safeString(fallbackNotionPageId);
-  const lastSyncedMessageKey = safeString(current.lastSyncedMessageKey) || safeString(next.lastSyncedMessageKey);
-  const lastSyncedSequence = pickMaxFiniteNumber(current.lastSyncedSequence, next.lastSyncedSequence);
-  const lastSyncedAt = pickMaxFiniteNumber(current.lastSyncedAt, next.lastSyncedAt);
-  const lastSyncedMessageUpdatedAt = pickMaxFiniteNumber(
-    current.lastSyncedMessageUpdatedAt,
-    next.lastSyncedMessageUpdatedAt,
-  );
-  const updatedAt = pickMaxFiniteNumber(current.updatedAt, next.updatedAt, Date.now()) || Date.now();
-
-  return {
-    ...current,
-    notionPageId,
-    lastSyncedMessageKey,
-    lastSyncedSequence,
-    lastSyncedAt,
-    lastSyncedMessageUpdatedAt,
-    updatedAt,
-  };
-}
-
 async function migrateSyncMappingKey(
   syncMappingsStore: IDBObjectStore,
   input: {
@@ -377,43 +352,38 @@ async function migrateSyncMappingKey(
   const idx = syncMappingsStore.index('by_source_conversationKey');
 
   const target = (await reqToPromise(idx.get([nextSource, nextConversationKey]) as any)) as any;
-  if (legacySource === nextSource && legacyConversationKey === nextConversationKey) {
+  const identity = { source: nextSource, conversationKey: nextConversationKey, fallbackNotionPageId };
+  const persistTargetFallback = async () => {
     if (!target) return;
-    const merged = mergeSyncMappingRecord(target, null, fallbackNotionPageId);
+    const merged = mergeSyncMappingForIdentityMove(target, null, identity) as any;
     if (JSON.stringify(merged) !== JSON.stringify(target)) {
       await reqToPromise(syncMappingsStore.put(merged));
     }
+  };
+
+  if (legacySource === nextSource && legacyConversationKey === nextConversationKey) {
+    await persistTargetFallback();
     return;
   }
 
   if (!legacySource || !legacyConversationKey) {
-    if (!target) return;
-    const merged = mergeSyncMappingRecord(target, null, fallbackNotionPageId);
-    if (JSON.stringify(merged) !== JSON.stringify(target)) {
-      await reqToPromise(syncMappingsStore.put(merged));
-    }
+    await persistTargetFallback();
     return;
   }
 
   const legacy = (await reqToPromise(idx.get([legacySource, legacyConversationKey]) as any)) as any;
   if (!legacy) {
-    if (!target) return;
-    const merged = mergeSyncMappingRecord(target, null, fallbackNotionPageId);
-    if (JSON.stringify(merged) !== JSON.stringify(target)) {
-      await reqToPromise(syncMappingsStore.put(merged));
-    }
+    await persistTargetFallback();
     return;
   }
 
   if (!target) {
-    legacy.source = nextSource;
-    legacy.conversationKey = nextConversationKey;
-    const merged = mergeSyncMappingRecord(legacy, null, fallbackNotionPageId);
-    await reqToPromise(syncMappingsStore.put(merged));
+    const moved = mergeSyncMappingForIdentityMove(null, legacy, identity) as any;
+    await reqToPromise(syncMappingsStore.put(moved));
     return;
   }
 
-  const merged = mergeSyncMappingRecord(target, legacy, fallbackNotionPageId);
+  const merged = mergeSyncMappingForIdentityMove(target, legacy, identity) as any;
   await reqToPromise(syncMappingsStore.put(merged));
 
   const legacyId = Number(legacy.id);

--- a/src/services/conversations/data/storage-idb.ts
+++ b/src/services/conversations/data/storage-idb.ts
@@ -1381,12 +1381,24 @@ export async function patchSyncMapping(conversationId: number, patch: Record<str
   const idx = stores.sync_mappings.index('by_source_conversationKey');
   const existing = (await reqToPromise(idx.get([source, conversationKey]) as any)) as any;
   const now = Date.now();
-  const merged = mergeSyncMappingPatch(existing, patch) as any;
+  const previousNotionPageId = safeString(existing?.notionPageId) || safeString(conversation.notionPageId);
+  const existingForPatch =
+    previousNotionPageId && !safeString(existing?.notionPageId)
+      ? { ...(existing && typeof existing === 'object' ? existing : {}), notionPageId: previousNotionPageId }
+      : existing;
+  const merged = mergeSyncMappingPatch(existingForPatch, patch) as any;
+  const hasNotionPagePatch = Object.prototype.hasOwnProperty.call(patch, 'notionPageId');
+  const nextNotionPageId = hasNotionPagePatch
+    ? safeString(merged.notionPageId)
+    : safeString(merged.notionPageId) || previousNotionPageId;
+  const notionTargetChanged = hasNotionPagePatch && previousNotionPageId !== nextNotionPageId;
+  const conversationNotionTargetChanged =
+    hasNotionPagePatch && safeString(conversation.notionPageId) !== nextNotionPageId;
   const next = {
     ...merged,
     source,
     conversationKey,
-    notionPageId: safeString(merged.notionPageId) || safeString(existing?.notionPageId) || safeString(conversation.notionPageId),
+    notionPageId: nextNotionPageId,
     feishuDocId: safeString(merged.feishuDocId) || safeString(existing?.feishuDocId) || safeString(conversation.feishuDocId),
     updatedAt: now,
   } as any;
@@ -1394,11 +1406,30 @@ export async function patchSyncMapping(conversationId: number, patch: Record<str
   if (existing) await reqToPromise(stores.sync_mappings.put(payload));
   else await reqToPromise(stores.sync_mappings.add(payload));
 
+  let conversationChanged = false;
+  if (hasNotionPagePatch && safeString(conversation.notionPageId) !== nextNotionPageId) {
+    conversation.notionPageId = nextNotionPageId;
+    conversationChanged = true;
+  }
+  for (const field of ['notionPageUrl', 'notionWorkspaceSlug'] as const) {
+    if (
+      !notionTargetChanged &&
+      !conversationNotionTargetChanged &&
+      !Object.prototype.hasOwnProperty.call(patch, field)
+    )
+      continue;
+    const value = safeString(next[field]);
+    if (safeString(conversation[field]) === value) continue;
+    conversation[field] = value;
+    conversationChanged = true;
+  }
+
   const nextFeishuDocId = safeString(next.feishuDocId);
   if (nextFeishuDocId && safeString(conversation.feishuDocId) !== nextFeishuDocId) {
     conversation.feishuDocId = nextFeishuDocId;
-    await reqToPromise(stores.conversations.put(conversation));
+    conversationChanged = true;
   }
+  if (conversationChanged) await reqToPromise(stores.conversations.put(conversation));
 
   await txDone(t);
   return true;
@@ -1409,47 +1440,13 @@ export async function setConversationNotionPageId(
   notionPageId: string,
   meta?: { notionPageUrl?: string; notionWorkspaceSlug?: string },
 ): Promise<true> {
-  const id = Number(conversationId);
-  if (!Number.isFinite(id) || id <= 0) throw new Error('invalid conversationId');
-
-  const db = await openDb();
-  const { t, stores } = tx(db, ['conversations', 'sync_mappings'], 'readwrite');
-  const conversation = (await reqToPromise(stores.conversations.get(id as any))) as any;
-  if (!conversation) throw new Error('conversation not found');
-
-  conversation.notionPageId = notionPageId || '';
-  if (meta && typeof meta === 'object') {
-    const url = safeString(meta.notionPageUrl);
-    const slug = safeString(meta.notionWorkspaceSlug);
-    if (url) conversation.notionPageUrl = url;
-    if (slug) conversation.notionWorkspaceSlug = slug;
-  }
-  await reqToPromise(stores.conversations.put(conversation));
-
-  const source = String(conversation.source || '').trim();
-  const conversationKey = String(conversation.conversationKey || '').trim();
-  if (source && conversationKey) {
-    const idx = stores.sync_mappings.index('by_source_conversationKey');
-    const existing = (await reqToPromise(idx.get([source, conversationKey]) as any)) as any;
-    const preserved: any = existing && typeof existing === 'object' ? { ...existing } : {};
-    if (preserved && typeof preserved === 'object') delete preserved.id;
-    const nextNotionPageUrl = meta && typeof meta === 'object' ? safeString(meta.notionPageUrl) : '';
-    const nextNotionWorkspaceSlug = meta && typeof meta === 'object' ? safeString(meta.notionWorkspaceSlug) : '';
-    const payload: any = withOptionalId(existing && existing.id, {
-      ...preserved,
-      source,
-      conversationKey,
-      notionPageId: notionPageId || '',
-      ...(nextNotionPageUrl ? { notionPageUrl: nextNotionPageUrl } : null),
-      ...(nextNotionWorkspaceSlug ? { notionWorkspaceSlug: nextNotionWorkspaceSlug } : null),
-      updatedAt: Date.now(),
-    });
-    if (existing) await reqToPromise(stores.sync_mappings.put(payload));
-    else await reqToPromise(stores.sync_mappings.add(payload));
-  }
-
-  await txDone(t);
-  return true;
+  const notionPageUrl = meta && typeof meta === 'object' ? safeString(meta.notionPageUrl) : '';
+  const notionWorkspaceSlug = meta && typeof meta === 'object' ? safeString(meta.notionWorkspaceSlug) : '';
+  return patchSyncMapping(conversationId, {
+    notionPageId: safeString(notionPageId),
+    ...(notionPageUrl ? { notionPageUrl } : null),
+    ...(notionWorkspaceSlug ? { notionWorkspaceSlug } : null),
+  });
 }
 
 export async function setSyncCursor(

--- a/src/services/sync/backup/backup-utils.ts
+++ b/src/services/sync/backup/backup-utils.ts
@@ -55,11 +55,6 @@ function pickStringPreferExisting(existing: unknown, incoming: unknown) {
   return isNonEmptyString(b) ? b.trim() : '';
 }
 
-function safeFiniteNumber(value: unknown): number | null {
-  const num = Number(value);
-  return Number.isFinite(num) ? num : null;
-}
-
 function mergeWarningFlags(existing: unknown, incoming: unknown): string[] {
   const a = Array.isArray(existing) ? existing : [];
   const b = Array.isArray(incoming) ? incoming : [];
@@ -133,54 +128,6 @@ export function mergeMessageRecord(existing: UnknownRecord, incoming: UnknownRec
   if (Number.isFinite(bSeq)) next.sequence = bSeq;
   else if (Number.isFinite(aSeq)) next.sequence = aSeq;
   else next.sequence = 0;
-
-  return next;
-}
-
-export function mergeSyncMappingRecord(existing: UnknownRecord, incoming: UnknownRecord): UnknownRecord {
-  const a = existing && typeof existing === 'object' ? existing : {};
-  const b = incoming && typeof incoming === 'object' ? incoming : {};
-
-  const next: UnknownRecord = { ...a };
-  next.source = pickStringPreferExisting(a.source, b.source);
-  next.conversationKey = pickStringPreferExisting(a.conversationKey, b.conversationKey);
-
-  // notionPageId: only fill when missing locally.
-  next.notionPageId = pickStringPreferExisting(a.notionPageId, b.notionPageId);
-  // feishuDocId: only fill when missing locally.
-  next.feishuDocId = pickStringPreferExisting(a.feishuDocId, b.feishuDocId);
-
-  // cursor: prefer existing local value; only fill when missing locally.
-  next.lastSyncedMessageKey = pickStringPreferExisting(a.lastSyncedMessageKey, b.lastSyncedMessageKey);
-  const aSeq = Number(a.lastSyncedSequence);
-  const bSeq = Number(b.lastSyncedSequence);
-  if (Number.isFinite(aSeq)) next.lastSyncedSequence = aSeq;
-  else if (Number.isFinite(bSeq)) next.lastSyncedSequence = bSeq;
-
-  const chosenKey = pickStringPreferExisting(next.lastSyncedMessageKey, '');
-  const chosenSeq = safeFiniteNumber(next.lastSyncedSequence);
-  const existingKey = pickStringPreferExisting(a.lastSyncedMessageKey, '');
-  const incomingKey = pickStringPreferExisting(b.lastSyncedMessageKey, '');
-  const existingMatchesChosen = chosenKey
-    ? existingKey === chosenKey
-    : chosenSeq != null && Number.isFinite(aSeq) && aSeq === chosenSeq;
-  const incomingMatchesChosen = chosenKey
-    ? incomingKey === chosenKey
-    : chosenSeq != null && Number.isFinite(bSeq) && bSeq === chosenSeq;
-
-  const aAt = Number(a.lastSyncedAt);
-  const bAt = Number(b.lastSyncedAt);
-  if (Number.isFinite(aAt)) next.lastSyncedAt = aAt;
-  else if (Number.isFinite(bAt)) next.lastSyncedAt = bAt;
-
-  const aMessageUpdatedAt = safeFiniteNumber(a.lastSyncedMessageUpdatedAt);
-  const bMessageUpdatedAt = safeFiniteNumber(b.lastSyncedMessageUpdatedAt);
-  if (existingMatchesChosen && aMessageUpdatedAt != null) next.lastSyncedMessageUpdatedAt = aMessageUpdatedAt;
-  else if (incomingMatchesChosen && bMessageUpdatedAt != null) next.lastSyncedMessageUpdatedAt = bMessageUpdatedAt;
-
-  const aUpdated = Number(a.updatedAt) || 0;
-  const bUpdated = Number(b.updatedAt) || 0;
-  next.updatedAt = Math.max(aUpdated, bUpdated, 0);
 
   return next;
 }

--- a/src/services/sync/backup/export.ts
+++ b/src/services/sync/backup/export.ts
@@ -1,3 +1,4 @@
+import { stripSyncMappingLocalId } from '@platform/idb/sync-mapping-record';
 import { storageGetAll, storageSet } from '@platform/storage/local';
 import {
   BACKUP_ZIP_SCHEMA_VERSION,
@@ -48,12 +49,6 @@ function stripLocalMessage(message: AnyRecord) {
   const m = message && typeof message === 'object' ? { ...message } : {};
   delete (m as any).id;
   delete (m as any).conversationId;
-  return m;
-}
-
-function stripLocalMapping(mapping: AnyRecord) {
-  const m = mapping && typeof mapping === 'object' ? { ...mapping } : {};
-  delete (m as any).id;
   return m;
 }
 
@@ -303,7 +298,7 @@ export async function exportBackupZipV2(
       const uk = uniqueConversationKey(c);
       const mapping = uk ? mappingByUniqueKey.get(uk) || null : null;
       const safeConversation = stripLocalConversation(c);
-      const safeMapping = mapping ? stripLocalMapping(mapping) : null;
+      const safeMapping = mapping ? stripSyncMappingLocalId(mapping) : null;
 
       const bundle = {
         schemaVersion: 1,

--- a/src/services/sync/backup/import.ts
+++ b/src/services/sync/backup/import.ts
@@ -1,10 +1,10 @@
+import { mergeSyncMappingForImport } from '@platform/idb/sync-mapping-record';
 import { storageSet } from '@platform/storage/local';
 import {
   filterStorageForBackup,
   validateImageCacheIndexDocument,
   mergeConversationRecord,
   mergeMessageRecord,
-  mergeSyncMappingRecord,
   uniqueConversationKey,
   validateBackupDocument,
   validateBackupManifest,
@@ -171,6 +171,65 @@ function normalizeListDerivedKeys(record: AnyRecord): AnyRecord {
   };
 }
 
+const CONVERSATION_MAPPING_MIRROR_FIELDS = [
+  'notionPageId',
+  'notionPageUrl',
+  'notionWorkspaceSlug',
+  'feishuDocId',
+] as const;
+
+async function upsertImportedSyncMappings(input: {
+  db: IDBDatabase;
+  mappings: AnyRecord[];
+  stats: ImportStats;
+  stage: string;
+  bump: (delta: number, stage: string) => void;
+}): Promise<void> {
+  const { t, stores } = tx(input.db, ['sync_mappings', 'conversations'], 'readwrite');
+  const mappingIndex = stores.sync_mappings.index('by_source_conversationKey');
+  const conversationIndex = stores.conversations.index('by_source_conversationKey');
+
+  for (const incoming of input.mappings) {
+    const source = safeString(incoming?.source);
+    const conversationKey = safeString(incoming?.conversationKey);
+    if (!source || !conversationKey) {
+      input.bump(1, input.stage);
+      continue;
+    }
+
+    const existing = (await reqToPromise(mappingIndex.get([source, conversationKey]) as any)) as AnyRecord;
+    const merged = mergeSyncMappingForImport(existing, incoming) as AnyRecord;
+    merged.source = source;
+    merged.conversationKey = conversationKey;
+
+    if (existing?.id) {
+      merged.id = existing.id;
+      await reqToPromise(stores.sync_mappings.put(merged as any));
+      input.stats.mappingsUpdated += 1;
+    } else {
+      delete merged.id;
+      await reqToPromise(stores.sync_mappings.add(merged as any));
+      input.stats.mappingsAdded += 1;
+    }
+
+    const conversation = (await reqToPromise(conversationIndex.get([source, conversationKey]) as any)) as AnyRecord;
+    if (conversation?.id) {
+      let changed = false;
+      for (const field of CONVERSATION_MAPPING_MIRROR_FIELDS) {
+        const value = safeString(merged[field]);
+        if (!value || safeString(conversation[field]) === value) continue;
+        conversation[field] = value;
+        changed = true;
+      }
+      if (changed) await reqToPromise(stores.conversations.put(conversation));
+    }
+
+    input.bump(1, input.stage);
+  }
+
+  await txDone(t);
+}
+
 export async function importBackupLegacyJsonMerge(
   doc: unknown,
   onProgress?: (p: ImportProgress) => void,
@@ -303,69 +362,15 @@ export async function importBackupLegacyJsonMerge(
     await txDone(t);
   }
 
-  // 3) Upsert sync mappings by (source, conversationKey) and fill missing convo.notionPageId (also preserves feishuDocId).
-  {
-    const { t, stores: s } = tx(db, ['sync_mappings', 'conversations'], 'readwrite');
-    const idx = s.sync_mappings.index('by_source_conversationKey');
-    const convoIdx = s.conversations.index('by_source_conversationKey');
-
-    progress.stage = 'mappings';
-    report();
-    for (let i = 0; i < backupMappings.length; i += 1) {
-      const incoming = backupMappings[i];
-      if (!incoming) {
-        bump(1, 'mappings');
-        continue;
-      }
-      const source = incoming.source ? String(incoming.source) : '';
-      const conversationKey = incoming.conversationKey ? String(incoming.conversationKey) : '';
-      if (!source || !conversationKey) {
-        bump(1, 'mappings');
-        continue;
-      }
-
-      const existing: AnyRecord = await reqToPromise(idx.get([source, conversationKey]) as any);
-      const merged = mergeSyncMappingRecord(existing, incoming);
-
-      if (existing && existing.id) {
-        merged.id = existing.id;
-
-        await reqToPromise(s.sync_mappings.put(merged as any));
-        stats.mappingsUpdated += 1;
-      } else {
-        await reqToPromise(s.sync_mappings.add(merged as any));
-        stats.mappingsAdded += 1;
-      }
-
-      const notionPageId = merged.notionPageId ? String(merged.notionPageId) : '';
-      const feishuDocId = merged.feishuDocId ? String(merged.feishuDocId) : '';
-      if (notionPageId) {
-        const convo: AnyRecord = await reqToPromise<AnyRecord>(convoIdx.get([source, conversationKey]) as any);
-        if (convo && convo.id) {
-          let changed = false;
-          if (!convo.notionPageId || !String(convo.notionPageId).trim()) {
-            convo.notionPageId = notionPageId;
-            changed = true;
-          }
-          if (feishuDocId && (!convo.feishuDocId || !String(convo.feishuDocId).trim())) {
-            convo.feishuDocId = feishuDocId;
-            changed = true;
-          }
-          if (changed) await reqToPromise(s.conversations.put(convo));
-        }
-      } else if (feishuDocId) {
-        const convo: AnyRecord = await reqToPromise<AnyRecord>(convoIdx.get([source, conversationKey]) as any);
-        if (convo && convo.id && (!convo.feishuDocId || !String(convo.feishuDocId).trim())) {
-          convo.feishuDocId = feishuDocId;
-          await reqToPromise(s.conversations.put(convo));
-        }
-      }
-
-      bump(1, 'mappings');
-    }
-
-    await txDone(t);
-  }
+  progress.stage = 'mappings';
+  report();
+  await upsertImportedSyncMappings({
+    db,
+    mappings: backupMappings,
+    stats,
+    stage: 'mappings',
+    bump,
+  });
 
   // 4) Apply non-sensitive chrome.storage.local settings (merge-only).
   progress.stage = 'settings';
@@ -904,53 +909,15 @@ export async function importBackupZipV2Merge(
     await txDone(t);
   }
 
-  // 3) Upsert sync mappings by (source, conversationKey) and fill missing convo.notionPageId (also preserves feishuDocId).
-  {
-    const { t, stores: s } = tx(db, ['sync_mappings', 'conversations'], 'readwrite');
-    const idx = s.sync_mappings.index('by_source_conversationKey');
-    const convoIdx = s.conversations.index('by_source_conversationKey');
-
-    progress.stage = 'Mappings';
-    report();
-    for (let i = 0; i < incomingMappings.length; i += 1) {
-      const incoming = incomingMappings[i];
-      const source = incoming && incoming.source ? String(incoming.source) : '';
-      const conversationKey = incoming && incoming.conversationKey ? String(incoming.conversationKey) : '';
-      if (!source || !conversationKey) {
-        bump(1, 'Mappings');
-        continue;
-      }
-
-      const existing: AnyRecord = await reqToPromise(idx.get([source, conversationKey]) as any);
-      const merged = mergeSyncMappingRecord(existing, incoming);
-      merged.source = source;
-      merged.conversationKey = conversationKey;
-
-      if (existing && existing.id) {
-        merged.id = existing.id;
-
-        await reqToPromise(s.sync_mappings.put(merged as any));
-        stats.mappingsUpdated += 1;
-      } else {
-        await reqToPromise(s.sync_mappings.add(merged as any));
-        stats.mappingsAdded += 1;
-      }
-
-      const notionPageId = merged.notionPageId ? String(merged.notionPageId) : '';
-      if (notionPageId) {
-        const convo: AnyRecord = await reqToPromise<AnyRecord>(convoIdx.get([source, conversationKey]) as any);
-        if (convo && convo.id && (!convo.notionPageId || !String(convo.notionPageId).trim())) {
-          convo.notionPageId = notionPageId;
-
-          await reqToPromise(s.conversations.put(convo));
-        }
-      }
-
-      bump(1, 'Mappings');
-    }
-
-    await txDone(t);
-  }
+  progress.stage = 'Mappings';
+  report();
+  await upsertImportedSyncMappings({
+    db,
+    mappings: incomingMappings,
+    stats,
+    stage: 'Mappings',
+    bump,
+  });
 
   // 4) Apply non-sensitive chrome.storage.local settings (merge-only).
   progress.stage = 'Settings';

--- a/src/services/sync/notion/notion-managed-sections.ts
+++ b/src/services/sync/notion/notion-managed-sections.ts
@@ -38,17 +38,6 @@ export function getNotionSectionAnchorsFromMapping(mapping: unknown): NotionSect
   return out;
 }
 
-export function mergeNotionSectionAnchorsPatch(
-  prevAnchors: NotionSectionAnchors,
-  patch: { sectionId: string; headingBlockId: string },
-): { notionSections: NotionSectionAnchors } {
-  const next: NotionSectionAnchors = { ...(prevAnchors || {}) };
-  const sectionId = safeString(patch?.sectionId);
-  const headingBlockId = safeString(patch?.headingBlockId);
-  if (sectionId) next[sectionId] = { headingBlockId };
-  return { notionSections: next };
-}
-
 export function layoutSpecForConversationKind(kindId: string): NotionManagedLayoutSpec {
   const id = safeString(kindId).toLowerCase();
   if (id === 'article') {
@@ -103,7 +92,7 @@ export async function ensureSectionHeadingBlockId(input: {
   }
 
   if (foundId) {
-    await maybePersistHeadingIdToMapping(input, anchors, sectionId, foundId);
+    await maybePersistHeadingIdToMapping(input, sectionId, foundId);
     return { headingBlockId: foundId, discoveredBy: 'scan' };
   }
 
@@ -113,7 +102,7 @@ export async function ensureSectionHeadingBlockId(input: {
   const results = Array.isArray((appended as any)?.results) ? (appended as any).results : [];
   const createdId = safeString(results?.[0]?.id);
   if (!createdId) throw new Error('failed to create section heading');
-  await maybePersistHeadingIdToMapping(input, anchors, sectionId, createdId);
+  await maybePersistHeadingIdToMapping(input, sectionId, createdId);
   return { headingBlockId: createdId, discoveredBy: 'created' };
 }
 
@@ -122,15 +111,15 @@ async function maybePersistHeadingIdToMapping(
     storage?: { patchSyncMapping?: (conversationId: number, patch: Record<string, unknown>) => Promise<any> };
     conversationId?: number;
   },
-  anchors: NotionSectionAnchors,
   sectionId: string,
   headingBlockId: string,
 ): Promise<void> {
   const conversationId = Number(input?.conversationId);
   if (!Number.isFinite(conversationId) || conversationId <= 0) return;
   if (!input?.storage?.patchSyncMapping) return;
-  const patch = mergeNotionSectionAnchorsPatch(anchors, { sectionId, headingBlockId });
-  await input.storage.patchSyncMapping(conversationId, patch as any);
+  await input.storage.patchSyncMapping(conversationId, {
+    notionSections: { [sectionId]: { headingBlockId } },
+  });
 }
 
 export async function rebuildSectionByArchivingHeading(input: {

--- a/src/ui/settings/sections/InpageSection.tsx
+++ b/src/ui/settings/sections/InpageSection.tsx
@@ -239,7 +239,6 @@ export function InpageSection(props: {
             onResetRules={onResetAntiHotlinkRules}
           />
         ) : null}
-
       </section>
     </div>
   );

--- a/tests/domains/backup-service.test.ts
+++ b/tests/domains/backup-service.test.ts
@@ -165,6 +165,175 @@ describe('backup service', () => {
     expect(entries.has(imageIndex.assets[0].blobPath)).toBe(true);
   });
 
+  it('round-trips complete provider continuity through a real ZIP transfer into an empty database', async () => {
+    const chromeMock = mockChromeStorage({
+      notion_oauth_client_id: 'client-a',
+      notion_parent_page_id: 'parent-a',
+      notion_oauth_token_v1: { accessToken: 'secret-a' },
+    });
+    // @ts-expect-error test global
+    globalThis.chrome = chromeMock;
+    // @ts-expect-error test global
+    globalThis.browser = undefined;
+
+    const dbA = await openDb();
+    const txA = dbA.transaction(['conversations', 'messages', 'sync_mappings'], 'readwrite');
+    const conversationIdA = await reqToPromise<number>(
+      txA.objectStore('conversations').add({
+        id: 100,
+        sourceType: 'chat',
+        source: 'chatgpt',
+        conversationKey: 'continuity-round-trip',
+        title: 'Continuity',
+        url: 'https://chatgpt.com/c/continuity-round-trip',
+        notionPageId: 'page-1',
+        notionPageUrl: 'https://www.notion.so/workspace/page-1',
+        notionWorkspaceSlug: 'workspace',
+        feishuDocId: 'doc-1',
+        warningFlags: [],
+        lastCapturedAt: 10,
+      }) as any,
+    );
+    await reqToPromise(
+      txA.objectStore('messages').add({
+        id: 300,
+        conversationId: conversationIdA,
+        messageKey: 'm1',
+        role: 'assistant',
+        contentText: 'already synced',
+        contentMarkdown: 'already synced',
+        sequence: 1,
+        updatedAt: 20,
+      }) as any,
+    );
+    const mappingIdA = await reqToPromise<number>(
+      txA.objectStore('sync_mappings').add({
+        id: 200,
+        source: 'chatgpt',
+        conversationKey: 'continuity-round-trip',
+        notionPageId: 'page-1',
+        notionPageUrl: 'https://www.notion.so/workspace/page-1',
+        notionWorkspaceSlug: 'workspace',
+        lastSyncedMessageKey: 'm1',
+        lastSyncedSequence: 1,
+        lastSyncedAt: 100,
+        lastSyncedMessageUpdatedAt: 20,
+        notionSections: {
+          conversations: { headingBlockId: 'heading-conversations', recoveredAt: 90 },
+          comments: { headingBlockId: 'heading-comments' },
+        },
+        notionSectionCursors: {
+          conversations: {
+            lastSyncedMessageKey: 'm1',
+            lastSyncedSequence: 1,
+            lastSyncedMessageUpdatedAt: 20,
+          },
+        },
+        notionSectionDigests: {
+          article: { digest: 'article-digest', lastSyncedAt: 100 },
+          comments: { digest: 'comments-digest', lastSyncedAt: 100 },
+        },
+        feishuDocId: 'doc-1',
+        feishuLastContentHash: 'content-hash-1',
+        futureProviderMetadata: { version: 3, nested: { keep: true } },
+        updatedAt: 101,
+      }) as any,
+    );
+    await new Promise<void>((resolve, reject) => {
+      txA.oncomplete = () => resolve();
+      txA.onerror = () => reject(txA.error);
+      txA.onabort = () => reject(txA.error);
+    });
+    dbA.close();
+
+    expect(conversationIdA).toBe(100);
+    expect(mappingIdA).toBe(200);
+
+    const exported = await exportBackupZipV2();
+    const entries = await extractZipEntries(exported.blob);
+    const manifest = JSON.parse(new TextDecoder().decode(entries.get('manifest.json')!));
+    const bundlePath = String(manifest.sources?.[0]?.files?.[0] || '');
+    const bundle = JSON.parse(new TextDecoder().decode(entries.get(bundlePath)!));
+    const config = JSON.parse(new TextDecoder().decode(entries.get('config/storage-local.json')!));
+
+    expect(bundle.syncMapping.id).toBeUndefined();
+    expect(bundle.syncMapping.futureProviderMetadata).toEqual({ version: 3, nested: { keep: true } });
+    expect(config.storageLocal.notion_oauth_token_v1).toBeUndefined();
+
+    // Browser B keeps its own secret while restoring A's portable, non-secret settings.
+    chromeMock.__store.notion_oauth_token_v1 = { accessToken: 'secret-b' };
+    delete chromeMock.__store.notion_oauth_client_id;
+    delete chromeMock.__store.notion_parent_page_id;
+
+    await __closeDbForTests();
+    await deleteDb('webclipper');
+
+    const stats = await importBackupZipV2Merge(entries);
+    expect(stats.conversationsAdded).toBe(1);
+    expect(stats.messagesAdded).toBe(1);
+    expect(stats.mappingsAdded).toBe(1);
+
+    const dbB = await openDb();
+    const txB = dbB.transaction(['conversations', 'messages', 'sync_mappings'], 'readonly');
+    const conversations = await reqToPromise<any[]>(txB.objectStore('conversations').getAll() as any);
+    const messages = await reqToPromise<any[]>(txB.objectStore('messages').getAll() as any);
+    const mappings = await reqToPromise<any[]>(txB.objectStore('sync_mappings').getAll() as any);
+    await new Promise<void>((resolve, reject) => {
+      txB.oncomplete = () => resolve();
+      txB.onerror = () => reject(txB.error);
+      txB.onabort = () => reject(txB.error);
+    });
+    dbB.close();
+
+    expect(conversations).toHaveLength(1);
+    expect(messages).toHaveLength(1);
+    expect(mappings).toHaveLength(1);
+    expect(mappings[0].id).not.toBe(mappingIdA);
+    expect(mappings[0]).toMatchObject({
+      source: 'chatgpt',
+      conversationKey: 'continuity-round-trip',
+      notionPageId: 'page-1',
+      notionPageUrl: 'https://www.notion.so/workspace/page-1',
+      notionWorkspaceSlug: 'workspace',
+      lastSyncedMessageKey: 'm1',
+      lastSyncedSequence: 1,
+      lastSyncedAt: 100,
+      lastSyncedMessageUpdatedAt: 20,
+      notionSections: {
+        conversations: { headingBlockId: 'heading-conversations', recoveredAt: 90 },
+        comments: { headingBlockId: 'heading-comments' },
+      },
+      notionSectionCursors: {
+        conversations: {
+          lastSyncedMessageKey: 'm1',
+          lastSyncedSequence: 1,
+          lastSyncedMessageUpdatedAt: 20,
+        },
+      },
+      notionSectionDigests: {
+        article: { digest: 'article-digest', lastSyncedAt: 100 },
+        comments: { digest: 'comments-digest', lastSyncedAt: 100 },
+      },
+      feishuDocId: 'doc-1',
+      feishuLastContentHash: 'content-hash-1',
+      futureProviderMetadata: { version: 3, nested: { keep: true } },
+    });
+    expect(conversations[0]).toMatchObject({
+      notionPageId: mappings[0].notionPageId,
+      notionPageUrl: mappings[0].notionPageUrl,
+      notionWorkspaceSlug: mappings[0].notionWorkspaceSlug,
+      feishuDocId: mappings[0].feishuDocId,
+    });
+    expect(messages[0]).toMatchObject({
+      conversationId: conversations[0].id,
+      messageKey: 'm1',
+      contentText: 'already synced',
+    });
+    expect(chromeMock.__store.notion_oauth_token_v1).toEqual({ accessToken: 'secret-b' });
+    expect(chromeMock.__store.notion_oauth_client_id).toBe('client-a');
+    expect(chromeMock.__store.notion_parent_page_id).toBe('parent-a');
+  });
+
   it('importBackupZipV2Merge restores image cache and rewrites syncnos-asset urls', async () => {
     const chromeMock = mockChromeStorage();
     // @ts-expect-error test global

--- a/tests/domains/backup-service.test.ts
+++ b/tests/domains/backup-service.test.ts
@@ -153,6 +153,7 @@ describe('backup service', () => {
     expect(bundle.conversation.source).toBe('chatgpt');
     expect(bundle.messages.length).toBe(1);
     expect(bundle.syncMapping.notionPageId).toBe('np1');
+    expect(bundle.syncMapping.id).toBeUndefined();
 
     expect(entries.has('assets/image-cache/index.json')).toBe(true);
     const imageIndex = JSON.parse(new TextDecoder().decode(entries.get('assets/image-cache/index.json')!));
@@ -642,11 +643,25 @@ describe('backup service', () => {
         ],
         sync_mappings: [
           {
-            id: 2,
+            id: 200,
             source: 'chatgpt',
             conversationKey: 'c1',
             notionPageId: 'np1',
-            updatedAt: 1,
+            notionPageUrl: 'https://www.notion.so/ws/np1',
+            notionWorkspaceSlug: 'ws',
+            lastSyncedMessageKey: 'm1',
+            lastSyncedSequence: 1,
+            lastSyncedAt: 100,
+            lastSyncedMessageUpdatedAt: 1,
+            notionSections: { conversations: { headingBlockId: 'h1' } },
+            notionSectionCursors: {
+              conversations: { lastSyncedMessageKey: 'm1', lastSyncedSequence: 1, lastSyncedMessageUpdatedAt: 1 },
+            },
+            notionSectionDigests: { article: { digest: 'digest-1', lastSyncedAt: 100 } },
+            feishuDocId: 'doc1',
+            feishuLastContentHash: 'hash1',
+            futureProviderMetadata: { version: 1 },
+            updatedAt: 101,
           },
         ],
       },
@@ -678,11 +693,228 @@ describe('backup service', () => {
     expect(convs.length).toBe(1);
     expect(msgs.length).toBe(1);
     expect(maps.length).toBe(1);
+    expect(maps[0]).toMatchObject({
+      source: 'chatgpt',
+      conversationKey: 'c1',
+      notionPageId: 'np1',
+      notionPageUrl: 'https://www.notion.so/ws/np1',
+      notionWorkspaceSlug: 'ws',
+      notionSections: { conversations: { headingBlockId: 'h1' } },
+      notionSectionCursors: { conversations: { lastSyncedMessageKey: 'm1', lastSyncedSequence: 1 } },
+      notionSectionDigests: { article: { digest: 'digest-1' } },
+      feishuDocId: 'doc1',
+      feishuLastContentHash: 'hash1',
+      futureProviderMetadata: { version: 1 },
+    });
+    expect(maps[0].id).not.toBe(200);
+    expect(convs[0]).toMatchObject({
+      notionPageId: 'np1',
+      notionPageUrl: 'https://www.notion.so/ws/np1',
+      notionWorkspaceSlug: 'ws',
+      feishuDocId: 'doc1',
+    });
 
     // Ensure secrets are not stored via settings merge.
     expect(chromeMock.__setPayloads.some((p) => Object.prototype.hasOwnProperty.call(p, 'notion_oauth_token_v1'))).toBe(
       false,
     );
     expect(chromeMock.__setPayloads.some((p) => (p as any).notion_oauth_client_id === 'cid')).toBe(true);
+  });
+
+  it('importBackupZipV2Merge keeps provider states atomic and mirrors the final targets', async () => {
+    const chromeMock = mockChromeStorage();
+    // @ts-expect-error test global
+    globalThis.chrome = chromeMock;
+    // @ts-expect-error test global
+    globalThis.browser = undefined;
+
+    const db = await openDb();
+    const seedTx = db.transaction(['conversations', 'sync_mappings'], 'readwrite');
+    for (const key of ['same', 'different']) {
+      await reqToPromise(
+        seedTx.objectStore('conversations').add({
+          sourceType: 'chat',
+          source: 'chatgpt',
+          conversationKey: key,
+          title: key,
+          url: `https://example.com/${key}`,
+          notionPageId: key === 'same' ? 'page-same' : 'page-local',
+          notionPageUrl: key === 'same' ? 'https://notion.so/old-same' : 'https://notion.so/page-local',
+          notionWorkspaceSlug: 'local-ws',
+          feishuDocId: key === 'same' ? 'doc-same' : 'doc-local',
+          lastCapturedAt: 1,
+        }) as any,
+      );
+    }
+    await reqToPromise(
+      seedTx.objectStore('sync_mappings').add({
+        source: 'chatgpt',
+        conversationKey: 'same',
+        notionPageId: 'page-same',
+        notionPageUrl: 'https://notion.so/old-same',
+        notionWorkspaceSlug: 'old-ws',
+        lastSyncedMessageKey: 'local-m1',
+        lastSyncedSequence: 1,
+        lastSyncedAt: 10,
+        notionSections: { conversations: { headingBlockId: 'local-heading' } },
+        notionSectionCursors: { conversations: { lastSyncedMessageKey: 'local-m1', lastSyncedSequence: 1 } },
+        feishuDocId: 'doc-same',
+        feishuLastContentHash: 'local-hash',
+        localOnly: 'keep',
+        updatedAt: 500,
+      }) as any,
+    );
+    await reqToPromise(
+      seedTx.objectStore('sync_mappings').add({
+        source: 'chatgpt',
+        conversationKey: 'different',
+        notionPageId: 'page-local',
+        notionPageUrl: 'https://notion.so/page-local',
+        notionWorkspaceSlug: 'local-ws',
+        lastSyncedMessageKey: 'local-m2',
+        lastSyncedSequence: 2,
+        lastSyncedAt: 20,
+        notionSections: { conversations: { headingBlockId: 'local-heading-2' } },
+        feishuDocId: 'doc-local',
+        feishuLastContentHash: 'local-hash-2',
+        updatedAt: 20,
+      }) as any,
+    );
+    await new Promise<void>((resolve, reject) => {
+      seedTx.oncomplete = () => resolve();
+      seedTx.onerror = () => reject(seedTx.error);
+      seedTx.onabort = () => reject(seedTx.error);
+    });
+    db.close();
+
+    const bundles = [
+      {
+        key: 'same',
+        mapping: {
+          source: 'chatgpt',
+          conversationKey: 'same',
+          notionPageId: 'page-same',
+          notionPageUrl: 'https://notion.so/new-same',
+          notionWorkspaceSlug: 'new-ws',
+          lastSyncedMessageKey: 'incoming-m9',
+          lastSyncedSequence: 9,
+          lastSyncedAt: 100,
+          notionSections: { conversations: { headingBlockId: 'incoming-heading' } },
+          notionSectionCursors: { conversations: { lastSyncedMessageKey: 'incoming-m9', lastSyncedSequence: 9 } },
+          feishuDocId: 'doc-same',
+          feishuLastContentHash: 'incoming-hash',
+          incomingOnly: 'filled',
+          updatedAt: 100,
+        },
+      },
+      {
+        key: 'different',
+        mapping: {
+          source: 'chatgpt',
+          conversationKey: 'different',
+          notionPageId: 'page-other',
+          notionPageUrl: 'https://notion.so/page-other',
+          notionWorkspaceSlug: 'other-ws',
+          lastSyncedMessageKey: 'incoming-other',
+          lastSyncedSequence: 99,
+          lastSyncedAt: 999,
+          notionSections: { conversations: { headingBlockId: 'other-heading' } },
+          feishuDocId: 'doc-other',
+          feishuLastContentHash: 'other-hash',
+          incomingOnly: 'filled-different',
+          updatedAt: 999,
+        },
+      },
+    ];
+    const files = bundles.map((item) => `sources/chatgpt/${item.key}.json`);
+    const manifest = {
+      backupSchemaVersion: 2,
+      exportedAt: '2026-08-21T00:00:00.000Z',
+      db: { name: 'webclipper', version: 8 },
+      counts: { conversations: 2, messages: 0, sync_mappings: 2 },
+      config: { storageLocalPath: 'config/storage-local.json' },
+      index: { conversationsCsvPath: 'sources/conversations.csv' },
+      sources: [{ source: 'chatgpt', conversationCount: 2, files }],
+    };
+    const enc = new TextEncoder();
+    const entries = new Map<string, Uint8Array>([
+      ['manifest.json', enc.encode(JSON.stringify(manifest))],
+      ['config/storage-local.json', enc.encode(JSON.stringify({ schemaVersion: 1, storageLocal: {} }))],
+      ['sources/conversations.csv', enc.encode('source,conversationKey\n')],
+    ]);
+    bundles.forEach((item, index) => {
+      entries.set(
+        files[index]!,
+        enc.encode(
+          JSON.stringify({
+            schemaVersion: 1,
+            conversation: {
+              sourceType: 'chat',
+              source: 'chatgpt',
+              conversationKey: item.key,
+              title: item.key,
+              url: `https://example.com/${item.key}`,
+              lastCapturedAt: 2,
+            },
+            messages: [],
+            syncMapping: item.mapping,
+          }),
+        ),
+      );
+    });
+
+    await importBackupZipV2Merge(entries);
+
+    const verifyDb = await openDb();
+    const verifyTx = verifyDb.transaction(['conversations', 'sync_mappings'], 'readonly');
+    const conversations = await reqToPromise<any[]>(verifyTx.objectStore('conversations').getAll() as any);
+    const mappings = await reqToPromise<any[]>(verifyTx.objectStore('sync_mappings').getAll() as any);
+    await new Promise<void>((resolve, reject) => {
+      verifyTx.oncomplete = () => resolve();
+      verifyTx.onerror = () => reject(verifyTx.error);
+      verifyTx.onabort = () => reject(verifyTx.error);
+    });
+    verifyDb.close();
+
+    const sameMapping = mappings.find((row) => row.conversationKey === 'same');
+    expect(sameMapping).toMatchObject({
+      notionPageId: 'page-same',
+      notionPageUrl: 'https://notion.so/new-same',
+      notionWorkspaceSlug: 'new-ws',
+      lastSyncedMessageKey: 'incoming-m9',
+      notionSections: { conversations: { headingBlockId: 'incoming-heading' } },
+      feishuDocId: 'doc-same',
+      feishuLastContentHash: 'incoming-hash',
+      localOnly: 'keep',
+      incomingOnly: 'filled',
+      updatedAt: 500,
+    });
+    const sameConversation = conversations.find((row) => row.conversationKey === 'same');
+    expect(sameConversation).toMatchObject({
+      notionPageId: 'page-same',
+      notionPageUrl: 'https://notion.so/new-same',
+      notionWorkspaceSlug: 'new-ws',
+      feishuDocId: 'doc-same',
+    });
+
+    const differentMapping = mappings.find((row) => row.conversationKey === 'different');
+    expect(differentMapping).toMatchObject({
+      notionPageId: 'page-local',
+      notionPageUrl: 'https://notion.so/page-local',
+      notionWorkspaceSlug: 'local-ws',
+      lastSyncedMessageKey: 'local-m2',
+      notionSections: { conversations: { headingBlockId: 'local-heading-2' } },
+      feishuDocId: 'doc-local',
+      feishuLastContentHash: 'local-hash-2',
+      incomingOnly: 'filled-different',
+      updatedAt: 999,
+    });
+    const differentConversation = conversations.find((row) => row.conversationKey === 'different');
+    expect(differentConversation).toMatchObject({
+      notionPageId: 'page-local',
+      notionPageUrl: 'https://notion.so/page-local',
+      notionWorkspaceSlug: 'local-ws',
+      feishuDocId: 'doc-local',
+    });
   });
 });

--- a/tests/domains/backup-utils.test.ts
+++ b/tests/domains/backup-utils.test.ts
@@ -4,7 +4,6 @@ import {
   filterStorageForBackup,
   mergeConversationRecord,
   mergeMessageRecord,
-  mergeSyncMappingRecord,
   uniqueConversationKey,
   validateBackupDocument,
   validateBackupManifest,
@@ -173,61 +172,5 @@ describe('backup backup-utils', () => {
     expect(merged2.contentText).toBe('hi!');
     expect(merged2.updatedAt).toBe(12);
     expect(merged2.sequence).toBe(2);
-  });
-
-  it('mergeSyncMappingRecord does not mix incoming message updatedAt into a different local cursor anchor', () => {
-    const merged = mergeSyncMappingRecord(
-      {
-        id: 10,
-        source: 'chatgpt',
-        conversationKey: 'c1',
-        notionPageId: 'page_local',
-        lastSyncedMessageKey: 'm1',
-        lastSyncedSequence: 1,
-        lastSyncedAt: 100,
-        updatedAt: 200,
-      },
-      {
-        source: 'chatgpt',
-        conversationKey: 'c1',
-        notionPageId: 'page_backup',
-        lastSyncedMessageKey: 'm2',
-        lastSyncedSequence: 2,
-        lastSyncedAt: 300,
-        lastSyncedMessageUpdatedAt: 456,
-        updatedAt: 400,
-      },
-    );
-
-    expect(merged.notionPageId).toBe('page_local');
-    expect(merged.lastSyncedMessageKey).toBe('m1');
-    expect(merged.lastSyncedSequence).toBe(1);
-    expect(merged.lastSyncedAt).toBe(100);
-    expect(merged.lastSyncedMessageUpdatedAt).toBeUndefined();
-    expect(merged.updatedAt).toBe(400);
-  });
-
-  it('mergeSyncMappingRecord can fill message updatedAt when incoming cursor matches the chosen anchor', () => {
-    const merged = mergeSyncMappingRecord(
-      {
-        source: 'chatgpt',
-        conversationKey: 'c1',
-        notionPageId: 'page_local',
-      },
-      {
-        source: 'chatgpt',
-        conversationKey: 'c1',
-        notionPageId: 'page_backup',
-        lastSyncedMessageKey: 'm2',
-        lastSyncedSequence: 2,
-        lastSyncedAt: 300,
-        lastSyncedMessageUpdatedAt: 456,
-        updatedAt: 400,
-      },
-    );
-
-    expect(merged.lastSyncedMessageKey).toBe('m2');
-    expect(merged.lastSyncedSequence).toBe(2);
-    expect(merged.lastSyncedMessageUpdatedAt).toBe(456);
   });
 });

--- a/tests/integration/backup-notion-sync-continuity.test.ts
+++ b/tests/integration/backup-notion-sync-continuity.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { IDBKeyRange, indexedDB } from 'fake-indexeddb';
 
-import { addArticleComment, listArticleCommentsByConversationId } from '@services/comments/data/storage';
+import {
+  addArticleComment,
+  deleteArticleCommentById,
+  listArticleCommentsByConversationId,
+} from '@services/comments/data/storage';
 import { __closeDbForTests as closeCommentsDbForTests } from '@services/comments/data/storage-idb';
 import { computeNotionCommentsDigest } from '@services/comments/sync/notion-comments-renderer';
 import { conversationKinds } from '@services/protocols/conversation-kinds';
@@ -374,6 +378,27 @@ describe('backup -> Notion sync continuity', () => {
     await txDone(txA);
     dbA.close();
 
+    const discardedA = await addArticleComment({
+      canonicalUrl: articleUrl,
+      conversationId: conversationIdA,
+      authorName: 'Discarded A',
+      quoteText: '',
+      commentText: 'advance local id',
+      createdAt: 280,
+      updatedAt: 280,
+    });
+    const discardedB = await addArticleComment({
+      canonicalUrl: articleUrl,
+      conversationId: conversationIdA,
+      authorName: 'Discarded B',
+      quoteText: '',
+      commentText: 'advance local id again',
+      createdAt: 290,
+      updatedAt: 290,
+    });
+    await deleteArticleCommentById(discardedA.id);
+    await deleteArticleCommentById(discardedB.id);
+
     const rootComment = await addArticleComment({
       canonicalUrl: articleUrl,
       conversationId: conversationIdA,
@@ -395,6 +420,7 @@ describe('backup -> Notion sync continuity', () => {
     });
     const commentsA = await listArticleCommentsByConversationId(conversationIdA);
     expect(commentsA).toHaveLength(2);
+    expect(commentsA.map((comment) => comment.id).sort((a, b) => a - b)).toEqual([3, 4]);
     const commentsSectionDigest = computeNotionCommentsDigest(commentsA);
 
     const dbAMapping = await openDb();
@@ -429,6 +455,7 @@ describe('backup -> Notion sync continuity', () => {
     const conversationIdB = await getOnlyConversationId();
     const importedComments = await listArticleCommentsByConversationId(conversationIdB);
     expect(importedComments).toHaveLength(2);
+    expect(importedComments.map((comment) => comment.id).sort((a, b) => a - b)).toEqual([1, 2]);
     expect(computeNotionCommentsDigest(importedComments)).toBe(commentsSectionDigest);
 
     const imported = await backgroundStorage.getSyncMappingByConversation(conversationIdB);

--- a/tests/integration/backup-notion-sync-continuity.test.ts
+++ b/tests/integration/backup-notion-sync-continuity.test.ts
@@ -1,7 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { IDBKeyRange, indexedDB } from 'fake-indexeddb';
 
+import { addArticleComment, listArticleCommentsByConversationId } from '@services/comments/data/storage';
+import { __closeDbForTests as closeCommentsDbForTests } from '@services/comments/data/storage-idb';
+import { computeNotionCommentsDigest } from '@services/comments/sync/notion-comments-renderer';
 import { conversationKinds } from '@services/protocols/conversation-kinds';
 import { backgroundStorage } from '@services/conversations/background/storage';
 import { __closeDbForTests as closeConversationDbForTests } from '@services/conversations/data/storage-idb';
@@ -10,6 +13,7 @@ import { importBackupZipV2Merge } from '@services/sync/backup/import';
 import { __closeDbForTests as closeBackupDbForTests } from '@services/sync/backup/idb';
 import { extractZipEntries } from '@services/sync/backup/zip-utils';
 import { createNotionSyncOrchestrator } from '@services/sync/notion/notion-sync-orchestrator';
+import { normalizeStandaloneImageCaptionLines } from '@services/sync/shared/markdown-image-normalizer';
 import { openDb } from '../../src/platform/idb/schema';
 
 function reqToPromise<T>(request: IDBRequest<T>): Promise<T> {
@@ -62,8 +66,24 @@ function mockChromeStorage(initial: Record<string, unknown> = {}) {
 }
 
 async function closeDbCaches(): Promise<void> {
+  await closeCommentsDbForTests();
   await closeConversationDbForTests();
   await closeBackupDbForTests();
+}
+
+function fnv1a32(input: unknown): string {
+  const text = String(input || '');
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+function articleDigest(markdown: string): string {
+  const normalizedMarkdown = normalizeStandaloneImageCaptionLines(String(markdown || '').trim());
+  return fnv1a32(JSON.stringify({ markdown: normalizedMarkdown }));
 }
 
 async function transferCurrentDbToEmptyDb(): Promise<void> {
@@ -120,6 +140,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  vi.unstubAllGlobals();
   await closeDbCaches();
   await deleteDb();
 });
@@ -315,6 +336,234 @@ describe('backup -> Notion sync continuity', () => {
         lastSyncedSequence: 2,
         lastSyncedMessageUpdatedAt: 200,
       },
+    });
+  });
+
+  it('keeps an already-synced article and comments at no_changes after a real ZIP transfer', async () => {
+    const articleUrl = 'https://example.com/article';
+    const articleMarkdown = '# Stable article\n\nBody stays unchanged.';
+    const articleSectionDigest = articleDigest(articleMarkdown);
+
+    const dbA = await openDb();
+    const txA = dbA.transaction(['conversations', 'messages'], 'readwrite');
+    const conversationIdA = await reqToPromise<number>(
+      txA.objectStore('conversations').add({
+        sourceType: 'article',
+        source: 'web',
+        conversationKey: 'article-round-trip',
+        title: 'Already synced article',
+        url: articleUrl,
+        notionPageId: 'page-article',
+        notionPageUrl: 'https://www.notion.so/workspace/page-article',
+        notionWorkspaceSlug: 'workspace',
+        warningFlags: [],
+        lastCapturedAt: 200,
+      }) as any,
+    );
+    await reqToPromise(
+      txA.objectStore('messages').add({
+        conversationId: conversationIdA,
+        messageKey: 'article_body',
+        role: 'article',
+        contentText: articleMarkdown,
+        contentMarkdown: articleMarkdown,
+        sequence: 1,
+        updatedAt: 200,
+      }) as any,
+    );
+    await txDone(txA);
+    dbA.close();
+
+    const rootComment = await addArticleComment({
+      canonicalUrl: articleUrl,
+      conversationId: conversationIdA,
+      authorName: 'Alice',
+      quoteText: 'Stable quote',
+      commentText: 'Stable root comment',
+      createdAt: 300,
+      updatedAt: 300,
+    });
+    await addArticleComment({
+      canonicalUrl: articleUrl,
+      conversationId: conversationIdA,
+      parentId: rootComment.id,
+      authorName: 'Bob',
+      quoteText: '',
+      commentText: 'Stable reply',
+      createdAt: 310,
+      updatedAt: 310,
+    });
+    const commentsA = await listArticleCommentsByConversationId(conversationIdA);
+    expect(commentsA).toHaveLength(2);
+    const commentsSectionDigest = computeNotionCommentsDigest(commentsA);
+
+    const dbAMapping = await openDb();
+    const mappingTx = dbAMapping.transaction(['sync_mappings'], 'readwrite');
+    await reqToPromise(
+      mappingTx.objectStore('sync_mappings').add({
+        source: 'web',
+        conversationKey: 'article-round-trip',
+        notionPageId: 'page-article',
+        notionPageUrl: 'https://www.notion.so/workspace/page-article',
+        notionWorkspaceSlug: 'workspace',
+        lastSyncedMessageKey: 'article_body',
+        lastSyncedSequence: 1,
+        lastSyncedAt: 1_000,
+        lastSyncedMessageUpdatedAt: 200,
+        notionSections: {
+          article: { headingBlockId: 'heading-article' },
+          comments: { headingBlockId: 'heading-comments' },
+        },
+        notionSectionDigests: {
+          article: { digest: articleSectionDigest, lastSyncedAt: 1_000 },
+          comments: { digest: commentsSectionDigest, lastSyncedAt: 1_000 },
+        },
+        updatedAt: 1_001,
+      }) as any,
+    );
+    await txDone(mappingTx);
+    dbAMapping.close();
+
+    await transferCurrentDbToEmptyDb();
+
+    const conversationIdB = await getOnlyConversationId();
+    const importedComments = await listArticleCommentsByConversationId(conversationIdB);
+    expect(importedComments).toHaveLength(2);
+    expect(computeNotionCommentsDigest(importedComments)).toBe(commentsSectionDigest);
+
+    const imported = await backgroundStorage.getSyncMappingByConversation(conversationIdB);
+    expect(imported?.mapping).toMatchObject({
+      notionPageId: 'page-article',
+      notionSections: {
+        article: { headingBlockId: 'heading-article' },
+        comments: { headingBlockId: 'heading-comments' },
+      },
+      notionSectionDigests: {
+        article: { digest: articleSectionDigest },
+        comments: { digest: commentsSectionDigest },
+      },
+    });
+
+    const kind = conversationKinds.pick(imported?.conversation);
+    expect(kind?.id).toBe('article');
+    const desiredProperties = kind!.notion.pageSpec.buildUpdateProperties({
+      ...imported!.conversation,
+      commentThreadCount: 1,
+    });
+    const calls = {
+      getPage: 0,
+      createPage: 0,
+      updatePage: 0,
+      appendChildren: 0,
+      clearPageChildren: 0,
+      messagesToBlocks: 0,
+      directNotionHttp: 0,
+    };
+    vi.stubGlobal('fetch', async () => {
+      calls.directNotionHttp += 1;
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        text: async () => JSON.stringify({ results: [], has_more: false, next_cursor: null }),
+      } as any;
+    });
+
+    const orchestrator = createNotionSyncOrchestrator({
+      tokenStore: {
+        async getToken() {
+          return { accessToken: 'test-token' };
+        },
+      },
+      storage: backgroundStorage,
+      conversationKinds,
+      notionApi: {},
+      notionFilesApi: {},
+      dbManager: {
+        async ensureDatabase() {
+          return { databaseId: 'db-article' };
+        },
+      },
+      syncService: {
+        async getPage() {
+          calls.getPage += 1;
+          return {
+            id: 'page-article',
+            url: 'https://www.notion.so/workspace/page-article',
+            properties: desiredProperties,
+          };
+        },
+        async createPageInDatabase() {
+          calls.createPage += 1;
+          return { id: 'unexpected-created-page' };
+        },
+        async updatePageProperties() {
+          calls.updatePage += 1;
+          return {};
+        },
+        async clearPageChildren() {
+          calls.clearPageChildren += 1;
+          return {};
+        },
+        async appendChildren() {
+          calls.appendChildren += 1;
+          return { results: [] };
+        },
+        messagesToBlocks() {
+          calls.messagesToBlocks += 1;
+          return [];
+        },
+        isPageUsableForDatabase(_page: unknown, databaseId?: string) {
+          return databaseId === 'db-article';
+        },
+        pageBelongsToDatabase(_page: unknown, databaseId: string) {
+          return databaseId === 'db-article';
+        },
+        hasExternalImageBlocks() {
+          return false;
+        },
+        async upgradeImageBlocksToFileUploads(_accessToken: string, blocks: any[]) {
+          return blocks;
+        },
+      },
+      jobStore: createMemoryJobStore(),
+    });
+
+    const result = await orchestrator.syncConversations({
+      instanceId: 'integration-test',
+      conversationIds: [conversationIdB],
+    });
+
+    expect(result).toMatchObject({
+      provider: 'notion',
+      okCount: 1,
+      failCount: 0,
+    });
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]).toMatchObject({
+      conversationId: conversationIdB,
+      ok: true,
+      mode: 'no_changes',
+      appended: 0,
+    });
+    expect(calls).toEqual({
+      getPage: 1,
+      createPage: 0,
+      updatePage: 0,
+      appendChildren: 0,
+      clearPageChildren: 0,
+      messagesToBlocks: 0,
+      directNotionHttp: 0,
+    });
+
+    const afterSync = await backgroundStorage.getSyncMappingByConversation(conversationIdB);
+    expect(afterSync?.mapping?.notionSections).toMatchObject({
+      article: { headingBlockId: 'heading-article' },
+      comments: { headingBlockId: 'heading-comments' },
+    });
+    expect(afterSync?.mapping?.notionSectionDigests).toMatchObject({
+      article: { digest: articleSectionDigest },
+      comments: { digest: commentsSectionDigest },
     });
   });
 });

--- a/tests/integration/backup-notion-sync-continuity.test.ts
+++ b/tests/integration/backup-notion-sync-continuity.test.ts
@@ -1,0 +1,320 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb';
+
+import { conversationKinds } from '@services/protocols/conversation-kinds';
+import { backgroundStorage } from '@services/conversations/background/storage';
+import { __closeDbForTests as closeConversationDbForTests } from '@services/conversations/data/storage-idb';
+import { exportBackupZipV2 } from '@services/sync/backup/export';
+import { importBackupZipV2Merge } from '@services/sync/backup/import';
+import { __closeDbForTests as closeBackupDbForTests } from '@services/sync/backup/idb';
+import { extractZipEntries } from '@services/sync/backup/zip-utils';
+import { createNotionSyncOrchestrator } from '@services/sync/notion/notion-sync-orchestrator';
+import { openDb } from '../../src/platform/idb/schema';
+
+function reqToPromise<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error || new Error('indexedDB request failed'));
+  });
+}
+
+function txDone(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error || new Error('transaction failed'));
+    transaction.onabort = () => reject(transaction.error || new Error('transaction aborted'));
+  });
+}
+
+async function deleteDb(): Promise<void> {
+  await reqToPromise(indexedDB.deleteDatabase('webclipper') as unknown as IDBRequest<unknown>);
+}
+
+function mockChromeStorage(initial: Record<string, unknown> = {}) {
+  const store: Record<string, unknown> = { ...initial };
+  return {
+    runtime: { lastError: null as any },
+    storage: {
+      local: {
+        get(keys: any, callback: (result: Record<string, unknown>) => void) {
+          if (keys == null) {
+            callback({ ...store });
+            return;
+          }
+          const list = Array.isArray(keys) ? keys : [];
+          const result: Record<string, unknown> = {};
+          for (const key of list) result[key] = Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null;
+          callback(result);
+        },
+        set(payload: Record<string, unknown>, callback: () => void) {
+          Object.assign(store, payload || {});
+          callback();
+        },
+        remove(keys: string[], callback: () => void) {
+          for (const key of keys || []) delete store[key];
+          callback();
+        },
+      },
+    },
+    __store: store,
+  };
+}
+
+async function closeDbCaches(): Promise<void> {
+  await closeConversationDbForTests();
+  await closeBackupDbForTests();
+}
+
+async function transferCurrentDbToEmptyDb(): Promise<void> {
+  const exported = await exportBackupZipV2();
+  const entries = await extractZipEntries(exported.blob);
+  await closeDbCaches();
+  await deleteDb();
+  await importBackupZipV2Merge(entries);
+}
+
+async function getOnlyConversationId(): Promise<number> {
+  const db = await openDb();
+  const transaction = db.transaction(['conversations'], 'readonly');
+  const rows = await reqToPromise<any[]>(transaction.objectStore('conversations').getAll() as any);
+  await txDone(transaction);
+  db.close();
+  expect(rows).toHaveLength(1);
+  return Number(rows[0]?.id);
+}
+
+function createMemoryJobStore() {
+  let job: any = null;
+  return {
+    NOTION_SYNC_JOB_KEY: 'notion_sync_job_test',
+    async getJob() {
+      return job;
+    },
+    async setJob(next: any) {
+      job = next;
+      return true;
+    },
+    isRunningJob(value: any) {
+      return Boolean(value && value.status === 'running');
+    },
+    async abortRunningJobIfFromOtherInstance() {
+      return job;
+    },
+  };
+}
+
+beforeEach(async () => {
+  // @ts-expect-error test global
+  globalThis.indexedDB = indexedDB;
+  // @ts-expect-error test global
+  globalThis.IDBKeyRange = IDBKeyRange;
+  await closeDbCaches();
+  await deleteDb();
+
+  const chromeMock = mockChromeStorage({ notion_parent_page_id: 'parent-page' });
+  // @ts-expect-error test global
+  globalThis.chrome = chromeMock;
+  // @ts-expect-error test global
+  globalThis.browser = undefined;
+});
+
+afterEach(async () => {
+  await closeDbCaches();
+  await deleteDb();
+});
+
+describe('backup -> Notion sync continuity', () => {
+  it('keeps an already-synced chat at no_changes after a real ZIP transfer', async () => {
+    const dbA = await openDb();
+    const txA = dbA.transaction(['conversations', 'messages', 'sync_mappings'], 'readwrite');
+    const conversationIdA = await reqToPromise<number>(
+      txA.objectStore('conversations').add({
+        sourceType: 'chat',
+        source: 'chatgpt',
+        conversationKey: 'chat-round-trip',
+        title: 'Already synced chat',
+        url: 'https://chatgpt.com/c/chat-round-trip',
+        notionPageId: 'page-chat',
+        notionPageUrl: 'https://www.notion.so/workspace/page-chat',
+        notionWorkspaceSlug: 'workspace',
+        warningFlags: [],
+        lastCapturedAt: 100,
+      }) as any,
+    );
+    await reqToPromise(
+      txA.objectStore('messages').add({
+        conversationId: conversationIdA,
+        messageKey: 'm1',
+        role: 'user',
+        contentText: 'hello',
+        contentMarkdown: 'hello',
+        sequence: 1,
+        updatedAt: 100,
+      }) as any,
+    );
+    await reqToPromise(
+      txA.objectStore('messages').add({
+        conversationId: conversationIdA,
+        messageKey: 'm2',
+        role: 'assistant',
+        contentText: 'world',
+        contentMarkdown: 'world',
+        sequence: 2,
+        updatedAt: 200,
+      }) as any,
+    );
+    await reqToPromise(
+      txA.objectStore('sync_mappings').add({
+        source: 'chatgpt',
+        conversationKey: 'chat-round-trip',
+        notionPageId: 'page-chat',
+        notionPageUrl: 'https://www.notion.so/workspace/page-chat',
+        notionWorkspaceSlug: 'workspace',
+        lastSyncedMessageKey: 'm2',
+        lastSyncedSequence: 2,
+        lastSyncedAt: 1_000,
+        lastSyncedMessageUpdatedAt: 200,
+        notionSections: {
+          conversations: { headingBlockId: 'heading-conversations' },
+        },
+        notionSectionCursors: {
+          conversations: {
+            lastSyncedMessageKey: 'm2',
+            lastSyncedSequence: 2,
+            lastSyncedMessageUpdatedAt: 200,
+          },
+        },
+        updatedAt: 1_001,
+      }) as any,
+    );
+    await txDone(txA);
+    dbA.close();
+
+    await transferCurrentDbToEmptyDb();
+
+    const conversationIdB = await getOnlyConversationId();
+    const imported = await backgroundStorage.getSyncMappingByConversation(conversationIdB);
+    expect(imported?.mapping).toMatchObject({
+      notionPageId: 'page-chat',
+      notionSections: { conversations: { headingBlockId: 'heading-conversations' } },
+      notionSectionCursors: {
+        conversations: {
+          lastSyncedMessageKey: 'm2',
+          lastSyncedSequence: 2,
+          lastSyncedMessageUpdatedAt: 200,
+        },
+      },
+    });
+
+    const kind = conversationKinds.pick(imported?.conversation);
+    expect(kind?.id).toBe('chat');
+    const desiredProperties = kind!.notion.pageSpec.buildUpdateProperties(imported!.conversation);
+    const calls = {
+      getPage: 0,
+      createPage: 0,
+      updatePage: 0,
+      appendChildren: 0,
+      clearPageChildren: 0,
+      messagesToBlocks: 0,
+    };
+
+    const orchestrator = createNotionSyncOrchestrator({
+      tokenStore: {
+        async getToken() {
+          return { accessToken: 'test-token' };
+        },
+      },
+      storage: backgroundStorage,
+      conversationKinds,
+      notionApi: {},
+      notionFilesApi: {},
+      dbManager: {
+        async ensureDatabase() {
+          return { databaseId: 'db-chat' };
+        },
+      },
+      syncService: {
+        async getPage() {
+          calls.getPage += 1;
+          return {
+            id: 'page-chat',
+            url: 'https://www.notion.so/workspace/page-chat',
+            properties: desiredProperties,
+          };
+        },
+        async createPageInDatabase() {
+          calls.createPage += 1;
+          return { id: 'unexpected-created-page' };
+        },
+        async updatePageProperties() {
+          calls.updatePage += 1;
+          return {};
+        },
+        async clearPageChildren() {
+          calls.clearPageChildren += 1;
+          return {};
+        },
+        async appendChildren() {
+          calls.appendChildren += 1;
+          return { results: [] };
+        },
+        messagesToBlocks() {
+          calls.messagesToBlocks += 1;
+          return [];
+        },
+        isPageUsableForDatabase(_page: unknown, databaseId?: string) {
+          return databaseId === 'db-chat';
+        },
+        pageBelongsToDatabase(_page: unknown, databaseId: string) {
+          return databaseId === 'db-chat';
+        },
+        hasExternalImageBlocks() {
+          return false;
+        },
+        async upgradeImageBlocksToFileUploads(_accessToken: string, blocks: any[]) {
+          return blocks;
+        },
+      },
+      jobStore: createMemoryJobStore(),
+    });
+
+    const result = await orchestrator.syncConversations({
+      instanceId: 'integration-test',
+      conversationIds: [conversationIdB],
+    });
+
+    expect(result).toMatchObject({
+      provider: 'notion',
+      okCount: 1,
+      failCount: 0,
+    });
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]).toMatchObject({
+      conversationId: conversationIdB,
+      ok: true,
+      mode: 'no_changes',
+      appended: 0,
+    });
+    expect(calls).toEqual({
+      getPage: 1,
+      createPage: 0,
+      updatePage: 0,
+      appendChildren: 0,
+      clearPageChildren: 0,
+      messagesToBlocks: 0,
+    });
+
+    const afterSync = await backgroundStorage.getSyncMappingByConversation(conversationIdB);
+    expect(afterSync?.mapping?.notionSections).toMatchObject({
+      conversations: { headingBlockId: 'heading-conversations' },
+    });
+    expect(afterSync?.mapping?.notionSectionCursors).toMatchObject({
+      conversations: {
+        lastSyncedMessageKey: 'm2',
+        lastSyncedSequence: 2,
+        lastSyncedMessageUpdatedAt: 200,
+      },
+    });
+  });
+});

--- a/tests/storage/conversations-idb.test.ts
+++ b/tests/storage/conversations-idb.test.ts
@@ -11,7 +11,10 @@ import {
   getConversationListBootstrap,
   getMessagesByConversationId,
   getMessagesTailByConversationId,
+  getSyncMappingByConversation,
   mergeConversationsByIds,
+  patchSyncMapping,
+  setSyncCursor,
   syncConversationMessages,
   upsertConversation,
 } from '@services/conversations/data/storage-idb';
@@ -721,6 +724,105 @@ describe('conversations storage-idb', () => {
     expect(windowResult.messages).toHaveLength(200);
     expect(windowResult.messages[0]?.sequence).toBe(101);
     expect(windowResult.messages[199]?.sequence).toBe(300);
+  });
+
+  it('patches mapping nested state through one writer and keeps mapping identity stable', async () => {
+    const convo = await upsertConversation({
+      sourceType: 'chat',
+      source: 'debug',
+      conversationKey: 'mapping-patch',
+      title: 'Mapping patch',
+      notionPageId: 'page-1',
+      lastCapturedAt: 1,
+    });
+    const conversationId = Number(convo.id);
+
+    const db = await openDb();
+    const seedTx = db.transaction(['sync_mappings'], 'readwrite');
+    const mappingId = await reqToPromise<number>(
+      seedTx.objectStore('sync_mappings').add({
+        source: 'debug',
+        conversationKey: 'mapping-patch',
+        notionPageId: 'page-1',
+        notionSections: {
+          conversations: { headingBlockId: 'h-old', stable: true },
+          comments: { headingBlockId: 'h-comments' },
+        },
+        notionSectionCursors: {
+          conversations: { lastSyncedMessageKey: 'm1', lastSyncedSequence: 1 },
+        },
+        notionSectionDigests: {
+          article: { digest: 'd-old', lastSyncedAt: 10 },
+        },
+        updatedAt: 10,
+      }) as any,
+    );
+    await txDone(seedTx);
+    db.close();
+
+    await patchSyncMapping(conversationId, {
+      notionSections: { conversations: { headingBlockId: 'h-new' } },
+      notionSectionCursors: { conversations: { lastSyncedSequence: 2 } },
+      notionSectionDigests: { comments: { digest: 'd-comments', lastSyncedAt: 20 } },
+      feishuDocId: 'doc-1',
+      feishuLastContentHash: 'hash-1',
+    });
+
+    const afterPatch = await getSyncMappingByConversation(conversationId);
+    expect(afterPatch?.mapping).toMatchObject({
+      id: mappingId,
+      source: 'debug',
+      conversationKey: 'mapping-patch',
+      notionPageId: 'page-1',
+      notionSections: {
+        conversations: { headingBlockId: 'h-new', stable: true },
+        comments: { headingBlockId: 'h-comments' },
+      },
+      notionSectionCursors: {
+        conversations: { lastSyncedMessageKey: 'm1', lastSyncedSequence: 2 },
+      },
+      notionSectionDigests: {
+        article: { digest: 'd-old', lastSyncedAt: 10 },
+        comments: { digest: 'd-comments', lastSyncedAt: 20 },
+      },
+      feishuDocId: 'doc-1',
+      feishuLastContentHash: 'hash-1',
+    });
+    expect(afterPatch?.conversation.feishuDocId).toBe('doc-1');
+
+    const beforeCursorUpdatedAt = Number(afterPatch?.mapping?.updatedAt) || 0;
+    await setSyncCursor(conversationId, {
+      lastSyncedMessageKey: 'm2',
+      lastSyncedSequence: null,
+      lastSyncedAt: null,
+      lastSyncedMessageUpdatedAt: null,
+      notionSectionCursors: {
+        conversations: { lastSyncedMessageKey: 'm2', lastSyncedSequence: 2 },
+      },
+    });
+
+    const afterCursor = await getSyncMappingByConversation(conversationId);
+    expect(afterCursor?.mapping).toMatchObject({
+      id: mappingId,
+      source: 'debug',
+      conversationKey: 'mapping-patch',
+      lastSyncedMessageKey: 'm2',
+      lastSyncedSequence: null,
+      lastSyncedMessageUpdatedAt: null,
+      notionSections: {
+        conversations: { headingBlockId: 'h-new', stable: true },
+        comments: { headingBlockId: 'h-comments' },
+      },
+      notionSectionCursors: {
+        conversations: { lastSyncedMessageKey: 'm2', lastSyncedSequence: 2 },
+      },
+      notionSectionDigests: {
+        article: { digest: 'd-old', lastSyncedAt: 10 },
+        comments: { digest: 'd-comments', lastSyncedAt: 20 },
+      },
+    });
+    expect(Number(afterCursor?.mapping?.lastSyncedAt)).toBeGreaterThan(0);
+    expect(Number(afterCursor?.mapping?.updatedAt)).toBeGreaterThanOrEqual(beforeCursorUpdatedAt);
   });
 
   it('deletes conversations, messages, and sync mappings', async () => {

--- a/tests/storage/conversations-idb.test.ts
+++ b/tests/storage/conversations-idb.test.ts
@@ -939,6 +939,44 @@ describe('conversations storage-idb', () => {
     expect(after?.mapping?.notionSectionCursors).toBeUndefined();
   });
 
+  it('resets stale Feishu hash when the destination doc changes and mirrors explicit clears', async () => {
+    const convo = await upsertConversation({
+      sourceType: 'chat',
+      source: 'debug',
+      conversationKey: 'feishu-doc-switch',
+      title: 'Feishu doc switch',
+      feishuDocId: 'doc-old',
+      lastCapturedAt: 1,
+    });
+    const conversationId = Number(convo.id);
+
+    await patchSyncMapping(conversationId, {
+      feishuDocId: 'doc-old',
+      feishuLastContentHash: 'hash-old',
+      notionPageId: 'page-1',
+      unknownMetadata: 'keep-me',
+    });
+    const before = await getSyncMappingByConversation(conversationId);
+    const mappingId = Number(before?.mapping?.id);
+
+    await patchSyncMapping(conversationId, { feishuDocId: 'doc-new' });
+    const changed = await getSyncMappingByConversation(conversationId);
+    expect(changed?.mapping).toMatchObject({
+      id: mappingId,
+      feishuDocId: 'doc-new',
+      notionPageId: 'page-1',
+      unknownMetadata: 'keep-me',
+    });
+    expect(changed?.mapping?.feishuLastContentHash).toBeUndefined();
+    expect(changed?.conversation?.feishuDocId).toBe('doc-new');
+
+    await patchSyncMapping(conversationId, { feishuDocId: '' });
+    const cleared = await getSyncMappingByConversation(conversationId);
+    expect(cleared?.mapping?.feishuDocId).toBe('');
+    expect(cleared?.mapping?.feishuLastContentHash).toBeUndefined();
+    expect(cleared?.conversation?.feishuDocId).toBe('');
+  });
+
   it('deletes conversations, messages, and sync mappings', async () => {
     const convo = await upsertConversation({
       sourceType: 'chat',

--- a/tests/storage/conversations-idb.test.ts
+++ b/tests/storage/conversations-idb.test.ts
@@ -886,6 +886,18 @@ describe('conversations storage-idb', () => {
         source: 'article',
         conversationKey: 'article_https://example.com/post',
         notionPageId: 'page_old',
+        notionPageUrl: 'https://notion.so/page_old',
+        notionWorkspaceSlug: 'legacy-ws',
+        lastSyncedMessageKey: 'article_body',
+        lastSyncedSequence: 1,
+        lastSyncedAt: 10,
+        lastSyncedMessageUpdatedAt: 9,
+        notionSections: { article: { headingBlockId: 'h-article' }, comments: { headingBlockId: 'h-comments' } },
+        notionSectionCursors: { conversations: { lastSyncedMessageKey: 'article_body', lastSyncedSequence: 1 } },
+        notionSectionDigests: { article: { digest: 'd-article', lastSyncedAt: 10 } },
+        feishuDocId: 'doc-old',
+        feishuLastContentHash: 'hash-old',
+        futureMetadata: { keep: true },
         updatedAt: 1,
       }),
     );
@@ -926,6 +938,15 @@ describe('conversations storage-idb', () => {
       source: 'web',
       conversationKey: 'article:https://example.com/post',
       notionPageId: 'page_old',
+      notionPageUrl: 'https://notion.so/page_old',
+      notionWorkspaceSlug: 'legacy-ws',
+      lastSyncedMessageKey: 'article_body',
+      notionSections: { article: { headingBlockId: 'h-article' }, comments: { headingBlockId: 'h-comments' } },
+      notionSectionCursors: { conversations: { lastSyncedMessageKey: 'article_body', lastSyncedSequence: 1 } },
+      notionSectionDigests: { article: { digest: 'd-article', lastSyncedAt: 10 } },
+      feishuDocId: 'doc-old',
+      feishuLastContentHash: 'hash-old',
+      futureMetadata: { keep: true },
     });
   });
 
@@ -968,7 +989,14 @@ describe('conversations storage-idb', () => {
         source: 'web',
         conversationKey: removeKey,
         notionPageId: 'page_remove',
+        notionPageUrl: 'https://notion.so/page_remove',
         lastSyncedMessageKey: 'x',
+        lastSyncedSequence: 2,
+        notionSections: { conversations: { headingBlockId: 'h-remove' } },
+        notionSectionCursors: { conversations: { lastSyncedMessageKey: 'x', lastSyncedSequence: 2 } },
+        feishuDocId: 'doc-remove',
+        feishuLastContentHash: 'hash-remove',
+        legacyOnly: true,
         updatedAt: 1,
       }),
     );
@@ -1004,7 +1032,103 @@ describe('conversations storage-idb', () => {
       source: 'web',
       conversationKey: keepKey,
       notionPageId: 'page_remove',
+      notionPageUrl: 'https://notion.so/page_remove',
       lastSyncedMessageKey: 'x',
+      lastSyncedSequence: 2,
+      notionSections: { conversations: { headingBlockId: 'h-remove' } },
+      feishuDocId: 'doc-remove',
+      feishuLastContentHash: 'hash-remove',
+      legacyOnly: true,
+    });
+  });
+
+  it('keeps canonical provider targets atomic when merging conversations with conflicting mappings', async () => {
+    const keep = await upsertConversation({
+      sourceType: 'article',
+      source: 'web',
+      conversationKey: 'keep-conflict',
+      title: 'keep',
+      url: 'https://example.com/keep',
+      notionPageId: '',
+      feishuDocId: '',
+      lastCapturedAt: 10,
+    });
+    const remove = await upsertConversation({
+      sourceType: 'article',
+      source: 'web',
+      conversationKey: 'remove-conflict',
+      title: 'remove',
+      url: 'https://example.com/remove',
+      notionPageId: 'page-remove-conversation',
+      feishuDocId: 'doc-remove-conversation',
+      lastCapturedAt: 20,
+    });
+    const keepId = Number(keep.id);
+    const removeId = Number(remove.id);
+    const keepKey = String(keep.conversationKey || '');
+    const removeKey = String(remove.conversationKey || '');
+
+    const db = await openDb();
+    const tx = db.transaction(['sync_mappings'], 'readwrite');
+    const store = tx.objectStore('sync_mappings');
+    await reqToPromise(
+      store.add({
+        source: 'web',
+        conversationKey: keepKey,
+        notionPageId: 'page-keep',
+        notionPageUrl: 'https://notion.so/page-keep',
+        lastSyncedMessageKey: 'keep-m1',
+        lastSyncedSequence: 1,
+        notionSections: { conversations: { headingBlockId: 'h-keep' } },
+        notionSectionCursors: { conversations: { lastSyncedMessageKey: 'keep-m1', lastSyncedSequence: 1 } },
+        feishuDocId: 'doc-keep',
+        feishuLastContentHash: 'hash-keep',
+        sharedMetadata: 'target',
+        updatedAt: 10,
+      }),
+    );
+    await reqToPromise(
+      store.add({
+        source: 'web',
+        conversationKey: removeKey,
+        notionPageId: 'page-remove',
+        notionPageUrl: 'https://notion.so/page-remove',
+        lastSyncedMessageKey: 'remove-m9',
+        lastSyncedSequence: 9,
+        notionSections: { conversations: { headingBlockId: 'h-remove' } },
+        notionSectionCursors: { conversations: { lastSyncedMessageKey: 'remove-m9', lastSyncedSequence: 9 } },
+        feishuDocId: 'doc-remove',
+        feishuLastContentHash: 'hash-remove',
+        sharedMetadata: 'legacy',
+        legacyOnly: true,
+        updatedAt: 99,
+      }),
+    );
+    await txDone(tx);
+    db.close();
+
+    await mergeConversationsByIds({ keepConversationId: keepId, removeConversationId: removeId });
+
+    const reopened = await openDb();
+    const verifyTx = reopened.transaction(['sync_mappings'], 'readonly');
+    const mappings = await reqToPromise<any[]>(verifyTx.objectStore('sync_mappings').getAll());
+    await txDone(verifyTx);
+    reopened.close();
+
+    expect(mappings).toHaveLength(1);
+    expect(mappings[0]).toMatchObject({
+      source: 'web',
+      conversationKey: keepKey,
+      notionPageId: 'page-keep',
+      notionPageUrl: 'https://notion.so/page-keep',
+      lastSyncedMessageKey: 'keep-m1',
+      lastSyncedSequence: 1,
+      notionSections: { conversations: { headingBlockId: 'h-keep' } },
+      notionSectionCursors: { conversations: { lastSyncedMessageKey: 'keep-m1', lastSyncedSequence: 1 } },
+      feishuDocId: 'doc-keep',
+      feishuLastContentHash: 'hash-keep',
+      sharedMetadata: 'target',
+      legacyOnly: true,
     });
   });
 

--- a/tests/storage/conversations-idb.test.ts
+++ b/tests/storage/conversations-idb.test.ts
@@ -14,6 +14,7 @@ import {
   getSyncMappingByConversation,
   mergeConversationsByIds,
   patchSyncMapping,
+  setConversationNotionPageId,
   setSyncCursor,
   syncConversationMessages,
   upsertConversation,
@@ -823,6 +824,119 @@ describe('conversations storage-idb', () => {
     });
     expect(Number(afterCursor?.mapping?.lastSyncedAt)).toBeGreaterThan(0);
     expect(Number(afterCursor?.mapping?.updatedAt)).toBeGreaterThanOrEqual(beforeCursorUpdatedAt);
+  });
+
+  it('resets stale Notion continuity when the destination page changes and keeps the same mapping identity', async () => {
+    const convo = await upsertConversation({
+      sourceType: 'chat',
+      source: 'debug',
+      conversationKey: 'page-switch',
+      title: 'Page switch',
+      notionPageId: 'page-old',
+      lastCapturedAt: 1,
+    });
+    const conversationId = Number(convo.id);
+
+    await patchSyncMapping(conversationId, {
+      notionPageId: 'page-old',
+      notionPageUrl: 'https://notion.so/page-old',
+      notionWorkspaceSlug: 'old-workspace',
+      lastSyncedMessageKey: 'm5',
+      lastSyncedSequence: 5,
+      lastSyncedAt: 50,
+      lastSyncedMessageUpdatedAt: 55,
+      notionSections: { conversations: { headingBlockId: 'h-old' } },
+      notionSectionCursors: { conversations: { lastSyncedMessageKey: 'm5', lastSyncedSequence: 5 } },
+      notionSectionDigests: { article: { digest: 'd-old' } },
+      feishuDocId: 'doc-1',
+      unknownMetadata: 'keep-me',
+    });
+    const before = await getSyncMappingByConversation(conversationId);
+    const mappingId = Number(before?.mapping?.id);
+
+    await setConversationNotionPageId(conversationId, 'page-old', {
+      notionPageUrl: 'https://notion.so/page-old-refreshed',
+      notionWorkspaceSlug: 'old-workspace-refreshed',
+    });
+    const samePage = await getSyncMappingByConversation(conversationId);
+    expect(samePage?.mapping).toMatchObject({
+      id: mappingId,
+      notionPageId: 'page-old',
+      notionPageUrl: 'https://notion.so/page-old-refreshed',
+      notionWorkspaceSlug: 'old-workspace-refreshed',
+      lastSyncedMessageKey: 'm5',
+      lastSyncedSequence: 5,
+      notionSections: { conversations: { headingBlockId: 'h-old' } },
+    });
+
+    await setConversationNotionPageId(conversationId, 'page-new', {
+      notionPageUrl: 'https://notion.so/page-new',
+      notionWorkspaceSlug: 'new-workspace',
+    });
+
+    const after = await getSyncMappingByConversation(conversationId);
+    expect(after?.mapping).toMatchObject({
+      id: mappingId,
+      source: 'debug',
+      conversationKey: 'page-switch',
+      notionPageId: 'page-new',
+      notionPageUrl: 'https://notion.so/page-new',
+      notionWorkspaceSlug: 'new-workspace',
+      feishuDocId: 'doc-1',
+      unknownMetadata: 'keep-me',
+    });
+    expect(after?.mapping?.lastSyncedMessageKey).toBeUndefined();
+    expect(after?.mapping?.lastSyncedSequence).toBeUndefined();
+    expect(after?.mapping?.lastSyncedAt).toBeUndefined();
+    expect(after?.mapping?.lastSyncedMessageUpdatedAt).toBeUndefined();
+    expect(after?.mapping?.notionSections).toBeUndefined();
+    expect(after?.mapping?.notionSectionCursors).toBeUndefined();
+    expect(after?.mapping?.notionSectionDigests).toBeUndefined();
+    expect(after?.conversation).toMatchObject({
+      notionPageId: 'page-new',
+      notionPageUrl: 'https://notion.so/page-new',
+      notionWorkspaceSlug: 'new-workspace',
+    });
+  });
+
+  it('uses the conversation Notion mirror as the current target when an old mapping is missing notionPageId', async () => {
+    const convo = await upsertConversation({
+      sourceType: 'chat',
+      source: 'debug',
+      conversationKey: 'page-switch-missing-mapping-page',
+      title: 'Page switch legacy state',
+      notionPageId: 'page-old',
+      lastCapturedAt: 1,
+    });
+    const conversationId = Number(convo.id);
+
+    const db = await openDb();
+    const tx = db.transaction(['sync_mappings'], 'readwrite');
+    await reqToPromise(
+      tx.objectStore('sync_mappings').add({
+        source: 'debug',
+        conversationKey: 'page-switch-missing-mapping-page',
+        lastSyncedMessageKey: 'm5',
+        lastSyncedSequence: 5,
+        notionSections: { conversations: { headingBlockId: 'h-old' } },
+        notionSectionCursors: { conversations: { lastSyncedMessageKey: 'm5', lastSyncedSequence: 5 } },
+        unknownMetadata: 'keep-me',
+      }),
+    );
+    await txDone(tx);
+    db.close();
+
+    await setConversationNotionPageId(conversationId, 'page-new');
+
+    const after = await getSyncMappingByConversation(conversationId);
+    expect(after?.mapping).toMatchObject({
+      notionPageId: 'page-new',
+      unknownMetadata: 'keep-me',
+    });
+    expect(after?.mapping?.lastSyncedMessageKey).toBeUndefined();
+    expect(after?.mapping?.lastSyncedSequence).toBeUndefined();
+    expect(after?.mapping?.notionSections).toBeUndefined();
+    expect(after?.mapping?.notionSectionCursors).toBeUndefined();
   });
 
   it('deletes conversations, messages, and sync mappings', async () => {

--- a/tests/storage/schema-migration.test.ts
+++ b/tests/storage/schema-migration.test.ts
@@ -160,6 +160,99 @@ describe('storage schema migration (v2 NotionAI thread id)', () => {
     expect(String(remaining.url)).toBe(`https://app.notion.com/chat?t=${threadId}&wfv=chat`);
   });
 
+  it('merges legacy mapping metadata into an existing stable mapping without mixing provider targets', async () => {
+    const threadId = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const stableKey = `notionai_t_${threadId}`;
+    const legacyKey = 'notionai_legacy_conflict';
+
+    const db1 = await openV1Db();
+    const t1 = db1.transaction(['conversations', 'sync_mappings'], 'readwrite');
+    const convStore = t1.objectStore('conversations');
+    const mapStore = t1.objectStore('sync_mappings');
+
+    await reqToPromise(
+      convStore.add({
+        sourceType: 'chat',
+        source: 'notionai',
+        conversationKey: stableKey,
+        title: 'stable',
+        url: `https://app.notion.com/chat?t=${threadId}&wfv=chat`,
+        notionPageId: 'page-target',
+        warningFlags: [],
+        lastCapturedAt: 20,
+      }),
+    );
+    await reqToPromise(
+      convStore.add({
+        sourceType: 'chat',
+        source: 'notionai',
+        conversationKey: legacyKey,
+        title: 'legacy',
+        url: `https://app.notion.com/SomePage-0123456789abcdef0123456789abcdef?t=${threadId}`,
+        notionPageId: 'page-legacy',
+        warningFlags: [],
+        lastCapturedAt: 10,
+      }),
+    );
+    await reqToPromise(
+      mapStore.add({
+        source: 'notionai',
+        conversationKey: stableKey,
+        notionPageId: 'page-target',
+        notionPageUrl: 'https://notion.so/page-target',
+        lastSyncedMessageKey: 'target-m1',
+        lastSyncedSequence: 1,
+        notionSections: { conversations: { headingBlockId: 'h-target' } },
+        notionSectionCursors: { conversations: { lastSyncedMessageKey: 'target-m1', lastSyncedSequence: 1 } },
+        feishuDocId: 'doc-target',
+        feishuLastContentHash: 'hash-target',
+        sharedMetadata: 'target',
+        updatedAt: 20,
+      }),
+    );
+    await reqToPromise(
+      mapStore.add({
+        source: 'notionai',
+        conversationKey: legacyKey,
+        notionPageId: 'page-legacy',
+        notionPageUrl: 'https://notion.so/page-legacy',
+        lastSyncedMessageKey: 'legacy-m9',
+        lastSyncedSequence: 9,
+        notionSections: { conversations: { headingBlockId: 'h-legacy' } },
+        notionSectionCursors: { conversations: { lastSyncedMessageKey: 'legacy-m9', lastSyncedSequence: 9 } },
+        feishuDocId: 'doc-legacy',
+        feishuLastContentHash: 'hash-legacy',
+        sharedMetadata: 'legacy',
+        legacyOnly: true,
+        updatedAt: 99,
+      }),
+    );
+    await txDone(t1);
+    db1.close();
+
+    const db2 = await openDb();
+    const t2 = db2.transaction(['sync_mappings'], 'readonly');
+    const maps = await reqToPromise<any[]>(t2.objectStore('sync_mappings').getAll());
+    await txDone(t2);
+    db2.close();
+
+    expect(maps).toHaveLength(1);
+    expect(maps[0]).toMatchObject({
+      source: 'notionai',
+      conversationKey: stableKey,
+      notionPageId: 'page-target',
+      notionPageUrl: 'https://notion.so/page-target',
+      lastSyncedMessageKey: 'target-m1',
+      lastSyncedSequence: 1,
+      notionSections: { conversations: { headingBlockId: 'h-target' } },
+      notionSectionCursors: { conversations: { lastSyncedMessageKey: 'target-m1', lastSyncedSequence: 1 } },
+      feishuDocId: 'doc-target',
+      feishuLastContentHash: 'hash-target',
+      sharedMetadata: 'target',
+      legacyOnly: true,
+    });
+  });
+
   it('migrates keep conversation mapping when conversationKey is rewritten to stableKey', async () => {
     const threadId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
     const stableKey = `notionai_t_${threadId}`;
@@ -336,6 +429,16 @@ describe('storage schema migration (v4 legacy article rows)', () => {
         source: 'article',
         conversationKey: 'article_https://example.com/post',
         notionPageId: 'page_old',
+        notionPageUrl: 'https://notion.so/page_old',
+        notionWorkspaceSlug: 'legacy-ws',
+        lastSyncedMessageKey: 'article_body',
+        lastSyncedSequence: 1,
+        lastSyncedAt: 10,
+        notionSections: { article: { headingBlockId: 'h-article' }, comments: { headingBlockId: 'h-comments' } },
+        notionSectionDigests: { article: { digest: 'digest-old', lastSyncedAt: 10 } },
+        feishuDocId: 'doc-old',
+        feishuLastContentHash: 'hash-old',
+        futureMetadata: { keep: true },
         updatedAt: 10,
       }),
     );
@@ -369,6 +472,15 @@ describe('storage schema migration (v4 legacy article rows)', () => {
       source: 'web',
       conversationKey: 'article:https://example.com/post',
       notionPageId: 'page_old',
+      notionPageUrl: 'https://notion.so/page_old',
+      notionWorkspaceSlug: 'legacy-ws',
+      lastSyncedMessageKey: 'article_body',
+      lastSyncedSequence: 1,
+      notionSections: { article: { headingBlockId: 'h-article' }, comments: { headingBlockId: 'h-comments' } },
+      notionSectionDigests: { article: { digest: 'digest-old', lastSyncedAt: 10 } },
+      feishuDocId: 'doc-old',
+      feishuLastContentHash: 'hash-old',
+      futureMetadata: { keep: true },
     });
   });
 
@@ -415,10 +527,35 @@ describe('storage schema migration (v4 legacy article rows)', () => {
     );
     await reqToPromise(
       mapStore.add({
+        source: 'web',
+        conversationKey: 'article:https://example.com/post',
+        notionPageId: 'page_target',
+        notionPageUrl: 'https://notion.so/page_target',
+        lastSyncedMessageKey: 'target-body',
+        lastSyncedSequence: 1,
+        notionSections: { article: { headingBlockId: 'h-target' } },
+        notionSectionDigests: { article: { digest: 'target-digest', lastSyncedAt: 20 } },
+        feishuDocId: 'doc-target',
+        feishuLastContentHash: 'hash-target',
+        sharedMetadata: 'target',
+        updatedAt: 20,
+      }),
+    );
+    await reqToPromise(
+      mapStore.add({
         source: 'article',
         conversationKey: 'article_https://example.com/post',
         notionPageId: 'page_old',
-        updatedAt: 10,
+        notionPageUrl: 'https://notion.so/page_old',
+        lastSyncedMessageKey: 'legacy-body',
+        lastSyncedSequence: 9,
+        notionSections: { article: { headingBlockId: 'h-legacy' } },
+        notionSectionDigests: { article: { digest: 'legacy-digest', lastSyncedAt: 99 } },
+        feishuDocId: 'doc-legacy',
+        feishuLastContentHash: 'hash-legacy',
+        sharedMetadata: 'legacy',
+        legacyOnly: true,
+        updatedAt: 99,
       }),
     );
     await txDone(t1);
@@ -449,7 +586,16 @@ describe('storage schema migration (v4 legacy article rows)', () => {
     expect(maps[0]).toMatchObject({
       source: 'web',
       conversationKey: 'article:https://example.com/post',
-      notionPageId: 'page_old',
+      notionPageId: 'page_target',
+      notionPageUrl: 'https://notion.so/page_target',
+      lastSyncedMessageKey: 'target-body',
+      lastSyncedSequence: 1,
+      notionSections: { article: { headingBlockId: 'h-target' } },
+      notionSectionDigests: { article: { digest: 'target-digest', lastSyncedAt: 20 } },
+      feishuDocId: 'doc-target',
+      feishuLastContentHash: 'hash-target',
+      sharedMetadata: 'target',
+      legacyOnly: true,
     });
   });
 });

--- a/tests/storage/sync-mapping-record.test.ts
+++ b/tests/storage/sync-mapping-record.test.ts
@@ -102,11 +102,15 @@ describe('sync mapping persistence record', () => {
       heading: 'h-missing',
       digest: 'd-missing',
     });
+    const incomingNull = { ...incomingMissing, lastSyncedAt: null };
+    const incomingEmpty = { ...incomingMissing, lastSyncedAt: '' };
 
     expect(mergeSyncMappingForImport(local, incomingEqual).lastSyncedMessageKey).toBe('incoming-equal');
     const missingMerged = mergeSyncMappingForImport(local, incomingMissing);
     expect(missingMerged.lastSyncedMessageKey).toBe('incoming-missing');
     expect(missingMerged.notionSections).toEqual({ conversations: { headingBlockId: 'h-missing' } });
+    expect(mergeSyncMappingForImport(local, incomingNull).lastSyncedMessageKey).toBe('incoming-missing');
+    expect(mergeSyncMappingForImport(local, incomingEmpty).lastSyncedMessageKey).toBe('incoming-missing');
   });
 
   it('different Notion pages keep the complete local provider state', () => {

--- a/tests/storage/sync-mapping-record.test.ts
+++ b/tests/storage/sync-mapping-record.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  mergeSyncMappingForIdentityMove,
   mergeSyncMappingForImport,
   mergeSyncMappingPatch,
   stripSyncMappingLocalId,
@@ -92,6 +93,110 @@ describe('sync mapping persistence record', () => {
     expect(merged).toMatchObject(existing);
     expect(existing).toEqual(existingBefore);
     expect(patch).toEqual(patchBefore);
+  });
+
+  it('moves a legacy mapping wholesale when the canonical target does not exist', () => {
+    const legacy = {
+      id: 11,
+      source: 'article',
+      conversationKey: 'legacy-key',
+      ...notionState({ pageId: 'page-legacy', syncedAt: 50, key: 'm5', sequence: 5, heading: 'h5', digest: 'd5' }),
+      feishuDocId: 'doc-legacy',
+      feishuLastContentHash: 'hash-legacy',
+      unknownLegacy: { keep: true },
+    };
+
+    const moved = mergeSyncMappingForIdentityMove(null, legacy, {
+      source: 'web',
+      conversationKey: 'article:https://example.com/a',
+    });
+
+    expect(moved).toMatchObject({
+      id: 11,
+      source: 'web',
+      conversationKey: 'article:https://example.com/a',
+      notionPageId: 'page-legacy',
+      notionSections: { conversations: { headingBlockId: 'h5' } },
+      feishuDocId: 'doc-legacy',
+      feishuLastContentHash: 'hash-legacy',
+      unknownLegacy: { keep: true },
+    });
+  });
+
+  it('keeps target provider groups while filling unknown metadata from legacy', () => {
+    const target = {
+      id: 20,
+      source: 'web',
+      conversationKey: 'canonical',
+      ...notionState({ pageId: 'page-target', syncedAt: 10, key: 'target', sequence: 1, heading: 'h-target', digest: 'd-target' }),
+      feishuDocId: 'doc-target',
+      feishuLastContentHash: 'hash-target',
+      shared: 'target',
+    };
+    const legacy = {
+      id: 21,
+      ...notionState({ pageId: 'page-legacy', syncedAt: 999, key: 'legacy', sequence: 9, heading: 'h-legacy', digest: 'd-legacy' }),
+      feishuDocId: 'doc-legacy',
+      feishuLastContentHash: 'hash-legacy',
+      shared: 'legacy',
+      legacyOnly: true,
+    };
+
+    const merged = mergeSyncMappingForIdentityMove(target, legacy, {
+      source: 'web',
+      conversationKey: 'canonical',
+      fallbackNotionPageId: 'page-fallback',
+    });
+
+    expect(merged).toMatchObject({
+      id: 20,
+      notionPageId: 'page-target',
+      lastSyncedMessageKey: 'target',
+      notionSections: { conversations: { headingBlockId: 'h-target' } },
+      feishuDocId: 'doc-target',
+      feishuLastContentHash: 'hash-target',
+      shared: 'target',
+      legacyOnly: true,
+    });
+  });
+
+  it('adopts legacy provider groups only when the target lacks that provider target', () => {
+    const target = { id: 30, source: 'web', conversationKey: 'canonical', targetOnly: true };
+    const legacy = {
+      id: 31,
+      ...notionState({ pageId: 'page-legacy', syncedAt: 50, key: 'legacy', sequence: 5, heading: 'h-legacy', digest: 'd-legacy' }),
+      feishuDocId: 'doc-legacy',
+      feishuLastContentHash: 'hash-legacy',
+    };
+
+    const merged = mergeSyncMappingForIdentityMove(target, legacy, {
+      source: 'web',
+      conversationKey: 'canonical',
+    });
+
+    expect(merged).toMatchObject({
+      id: 30,
+      notionPageId: 'page-legacy',
+      lastSyncedMessageKey: 'legacy',
+      notionSections: { conversations: { headingBlockId: 'h-legacy' } },
+      feishuDocId: 'doc-legacy',
+      feishuLastContentHash: 'hash-legacy',
+      targetOnly: true,
+    });
+  });
+
+  it('uses fallback Notion page only after provider-state selection leaves the page empty', () => {
+    const merged = mergeSyncMappingForIdentityMove(
+      { id: 40, lastSyncedMessageKey: 'target-orphan' },
+      null,
+      { source: 'web', conversationKey: 'canonical', fallbackNotionPageId: 'page-fallback' },
+    );
+
+    expect(merged).toMatchObject({
+      id: 40,
+      notionPageId: 'page-fallback',
+      lastSyncedMessageKey: 'target-orphan',
+    });
   });
 
   it('strips only the browser-local id without mutating the source', () => {

--- a/tests/storage/sync-mapping-record.test.ts
+++ b/tests/storage/sync-mapping-record.test.ts
@@ -74,6 +74,64 @@ describe('sync mapping persistence record', () => {
     expect(merged.notionSectionDigests).toEqual(existing.notionSectionDigests);
   });
 
+  it('keeps Notion continuity when notionPageId stays the same', () => {
+    const existing = {
+      id: 7,
+      ...notionState({ pageId: 'page-1', syncedAt: 50, key: 'm5', sequence: 5, heading: 'h-old', digest: 'd-old' }),
+    };
+
+    const merged = mergeSyncMappingPatch(existing, {
+      notionPageId: 'page-1',
+      notionPageUrl: 'https://notion.so/page-1-updated',
+      notionSections: { conversations: { headingBlockId: 'h-new' } },
+    });
+
+    expect(merged).toMatchObject({
+      id: 7,
+      notionPageId: 'page-1',
+      notionPageUrl: 'https://notion.so/page-1-updated',
+      lastSyncedMessageKey: 'm5',
+      lastSyncedSequence: 5,
+      notionSections: { conversations: { headingBlockId: 'h-new' } },
+      notionSectionCursors: { conversations: { lastSyncedMessageKey: 'm5', lastSyncedSequence: 5 } },
+      notionSectionDigests: { article: { digest: 'd-old', lastSyncedAt: 50 } },
+    });
+  });
+
+  it('resets the whole Notion continuity group when notionPageId changes', () => {
+    const existing = {
+      id: 7,
+      source: 'chatgpt',
+      conversationKey: 'c1',
+      ...notionState({ pageId: 'page-old', syncedAt: 50, key: 'm5', sequence: 5, heading: 'h-old', digest: 'd-old' }),
+      feishuDocId: 'doc-1',
+      unknownMetadata: 'keep-me',
+    };
+
+    const merged = mergeSyncMappingPatch(existing, {
+      notionPageId: 'page-new',
+      notionPageUrl: 'https://notion.so/page-new',
+    });
+
+    expect(merged).toMatchObject({
+      id: 7,
+      source: 'chatgpt',
+      conversationKey: 'c1',
+      notionPageId: 'page-new',
+      notionPageUrl: 'https://notion.so/page-new',
+      feishuDocId: 'doc-1',
+      unknownMetadata: 'keep-me',
+    });
+    expect(merged.notionWorkspaceSlug).toBeUndefined();
+    expect(merged.lastSyncedMessageKey).toBeUndefined();
+    expect(merged.lastSyncedSequence).toBeUndefined();
+    expect(merged.lastSyncedAt).toBeUndefined();
+    expect(merged.lastSyncedMessageUpdatedAt).toBeUndefined();
+    expect(merged.notionSections).toBeUndefined();
+    expect(merged.notionSectionCursors).toBeUndefined();
+    expect(merged.notionSectionDigests).toBeUndefined();
+  });
+
   it('ignores invalid Notion nested field patches and does not mutate inputs', () => {
     const existing = {
       notionSections: { conversations: { headingBlockId: 'h1' } },

--- a/tests/storage/sync-mapping-record.test.ts
+++ b/tests/storage/sync-mapping-record.test.ts
@@ -132,6 +132,30 @@ describe('sync mapping persistence record', () => {
     expect(merged.notionSectionDigests).toBeUndefined();
   });
 
+  it('resets the whole Feishu continuity group when feishuDocId changes', () => {
+    const existing = {
+      id: 7,
+      source: 'chatgpt',
+      conversationKey: 'c1',
+      feishuDocId: 'doc-old',
+      feishuLastContentHash: 'hash-old',
+      notionPageId: 'page-1',
+      unknownMetadata: 'keep-me',
+    };
+
+    const merged = mergeSyncMappingPatch(existing, { feishuDocId: 'doc-new' });
+
+    expect(merged).toMatchObject({
+      id: 7,
+      source: 'chatgpt',
+      conversationKey: 'c1',
+      feishuDocId: 'doc-new',
+      notionPageId: 'page-1',
+      unknownMetadata: 'keep-me',
+    });
+    expect(merged.feishuLastContentHash).toBeUndefined();
+  });
+
   it('ignores invalid Notion nested field patches and does not mutate inputs', () => {
     const existing = {
       notionSections: { conversations: { headingBlockId: 'h1' } },

--- a/tests/storage/sync-mapping-record.test.ts
+++ b/tests/storage/sync-mapping-record.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+
+import { mergeSyncMappingForImport, stripSyncMappingLocalId } from '@platform/idb/sync-mapping-record';
+
+function notionState(input: {
+  pageId: string;
+  syncedAt?: number;
+  key: string;
+  sequence: number;
+  heading: string;
+  digest: string;
+}) {
+  return {
+    notionPageId: input.pageId,
+    notionPageUrl: `https://notion.so/${input.pageId}`,
+    notionWorkspaceSlug: `ws-${input.pageId}`,
+    lastSyncedMessageKey: input.key,
+    lastSyncedSequence: input.sequence,
+    ...(input.syncedAt == null ? {} : { lastSyncedAt: input.syncedAt }),
+    lastSyncedMessageUpdatedAt: input.sequence * 10,
+    notionSections: { conversations: { headingBlockId: input.heading } },
+    notionSectionCursors: {
+      conversations: {
+        lastSyncedMessageKey: input.key,
+        lastSyncedSequence: input.sequence,
+        lastSyncedMessageUpdatedAt: input.sequence * 10,
+      },
+    },
+    notionSectionDigests: { article: { digest: input.digest, lastSyncedAt: input.syncedAt ?? 0 } },
+  };
+}
+
+describe('sync mapping persistence record', () => {
+  it('strips only the browser-local id without mutating the source', () => {
+    const source = { id: 7, source: 'chatgpt', conversationKey: 'c1', nested: { value: 1 } };
+    const stripped = stripSyncMappingLocalId(source);
+
+    expect(stripped).toEqual({ source: 'chatgpt', conversationKey: 'c1', nested: { value: 1 } });
+    expect(source.id).toBe(7);
+  });
+
+  it('fresh import preserves complete provider continuity and unknown metadata', () => {
+    const incoming = {
+      id: 99,
+      source: 'chatgpt',
+      conversationKey: 'c1',
+      ...notionState({ pageId: 'page-a', syncedAt: 100, key: 'm2', sequence: 2, heading: 'h-a', digest: 'd-a' }),
+      feishuDocId: 'doc-a',
+      feishuLastContentHash: 'hash-a',
+      futureProviderMetadata: { opaque: true },
+      updatedAt: 200,
+    };
+
+    const merged = mergeSyncMappingForImport(null, incoming);
+
+    expect(merged).toMatchObject({
+      notionPageId: 'page-a',
+      notionSections: { conversations: { headingBlockId: 'h-a' } },
+      notionSectionCursors: { conversations: { lastSyncedMessageKey: 'm2', lastSyncedSequence: 2 } },
+      notionSectionDigests: { article: { digest: 'd-a' } },
+      feishuDocId: 'doc-a',
+      feishuLastContentHash: 'hash-a',
+      futureProviderMetadata: { opaque: true },
+    });
+    expect(merged.id).toBeUndefined();
+  });
+
+  it('same Notion page uses the later lastSyncedAt as one complete snapshot', () => {
+    const local = {
+      ...notionState({ pageId: 'page-a', syncedAt: 300, key: 'local', sequence: 3, heading: 'h-local', digest: 'd-local' }),
+      updatedAt: 1,
+    };
+    const incoming = {
+      ...notionState({ pageId: 'page-a', syncedAt: 200, key: 'incoming', sequence: 9, heading: 'h-in', digest: 'd-in' }),
+      updatedAt: 999,
+    };
+
+    const merged = mergeSyncMappingForImport(local, incoming);
+
+    expect(merged.notionPageId).toBe('page-a');
+    expect(merged.lastSyncedMessageKey).toBe('local');
+    expect(merged.lastSyncedSequence).toBe(3);
+    expect(merged.notionSections).toEqual({ conversations: { headingBlockId: 'h-local' } });
+    expect(merged.notionSectionDigests).toEqual({ article: { digest: 'd-local', lastSyncedAt: 300 } });
+    expect(merged.updatedAt).toBe(999);
+  });
+
+  it('same Notion page uses incoming as the stable tie-break when time is equal or missing', () => {
+    const local = notionState({ pageId: 'page-a', syncedAt: 100, key: 'local', sequence: 1, heading: 'h-local', digest: 'd-local' });
+    const incomingEqual = notionState({
+      pageId: 'page-a',
+      syncedAt: 100,
+      key: 'incoming-equal',
+      sequence: 2,
+      heading: 'h-equal',
+      digest: 'd-equal',
+    });
+    const incomingMissing = notionState({
+      pageId: 'page-a',
+      key: 'incoming-missing',
+      sequence: 3,
+      heading: 'h-missing',
+      digest: 'd-missing',
+    });
+
+    expect(mergeSyncMappingForImport(local, incomingEqual).lastSyncedMessageKey).toBe('incoming-equal');
+    const missingMerged = mergeSyncMappingForImport(local, incomingMissing);
+    expect(missingMerged.lastSyncedMessageKey).toBe('incoming-missing');
+    expect(missingMerged.notionSections).toEqual({ conversations: { headingBlockId: 'h-missing' } });
+  });
+
+  it('different Notion pages keep the complete local provider state', () => {
+    const local = notionState({ pageId: 'page-local', syncedAt: 100, key: 'local', sequence: 1, heading: 'h-local', digest: 'd-local' });
+    const incoming = notionState({
+      pageId: 'page-incoming',
+      syncedAt: 999,
+      key: 'incoming',
+      sequence: 9,
+      heading: 'h-incoming',
+      digest: 'd-incoming',
+    });
+
+    const merged = mergeSyncMappingForImport(local, incoming);
+
+    expect(merged.notionPageId).toBe('page-local');
+    expect(merged.lastSyncedMessageKey).toBe('local');
+    expect(merged.lastSyncedSequence).toBe(1);
+    expect(merged.notionSections).toEqual({ conversations: { headingBlockId: 'h-local' } });
+    expect(merged.notionSectionCursors).toEqual(local.notionSectionCursors);
+    expect(merged.notionSectionDigests).toEqual(local.notionSectionDigests);
+  });
+
+  it('keeps Feishu doc/hash atomic across same and different targets', () => {
+    const local = { feishuDocId: 'doc-local', feishuLastContentHash: 'hash-local' };
+
+    expect(
+      mergeSyncMappingForImport(local, { feishuDocId: 'doc-local', feishuLastContentHash: 'hash-incoming' }),
+    ).toMatchObject({ feishuDocId: 'doc-local', feishuLastContentHash: 'hash-incoming' });
+
+    expect(
+      mergeSyncMappingForImport(local, { feishuDocId: 'doc-other', feishuLastContentHash: 'hash-other' }),
+    ).toMatchObject({ feishuDocId: 'doc-local', feishuLastContentHash: 'hash-local' });
+
+    expect(
+      mergeSyncMappingForImport({}, { feishuDocId: 'doc-incoming', feishuLastContentHash: 'hash-incoming' }),
+    ).toMatchObject({ feishuDocId: 'doc-incoming', feishuLastContentHash: 'hash-incoming' });
+  });
+
+  it('keeps local unknown metadata and only fills missing unknown keys from incoming', () => {
+    const merged = mergeSyncMappingForImport(
+      { custom: 'local', localOnly: 1 },
+      { custom: 'incoming', incomingOnly: 2 },
+    );
+
+    expect(merged.custom).toBe('local');
+    expect(merged.localOnly).toBe(1);
+    expect(merged.incomingOnly).toBe(2);
+  });
+
+  it('does not mutate either input while replacing provider groups', () => {
+    const local = {
+      id: 1,
+      ...notionState({ pageId: 'page-a', syncedAt: 10, key: 'local', sequence: 1, heading: 'h-local', digest: 'd-local' }),
+    };
+    const incoming = {
+      id: 2,
+      ...notionState({ pageId: 'page-a', syncedAt: 20, key: 'incoming', sequence: 2, heading: 'h-in', digest: 'd-in' }),
+    };
+    const localBefore = structuredClone(local);
+    const incomingBefore = structuredClone(incoming);
+
+    mergeSyncMappingForImport(local, incoming);
+
+    expect(local).toEqual(localBefore);
+    expect(incoming).toEqual(incomingBefore);
+  });
+});

--- a/tests/storage/sync-mapping-record.test.ts
+++ b/tests/storage/sync-mapping-record.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { mergeSyncMappingForImport, stripSyncMappingLocalId } from '@platform/idb/sync-mapping-record';
+import {
+  mergeSyncMappingForImport,
+  mergeSyncMappingPatch,
+  stripSyncMappingLocalId,
+} from '@platform/idb/sync-mapping-record';
 
 function notionState(input: {
   pageId: string;
@@ -31,6 +35,65 @@ function notionState(input: {
 }
 
 describe('sync mapping persistence record', () => {
+  it('merges only explicitly provided valid Notion nested sections', () => {
+    const existing = {
+      id: 7,
+      notionSections: {
+        conversations: { headingBlockId: 'h-old', stable: true },
+        comments: { headingBlockId: 'h-comments' },
+      },
+      notionSectionCursors: {
+        conversations: { lastSyncedMessageKey: 'm1', lastSyncedSequence: 1 },
+      },
+      notionSectionDigests: {
+        article: { digest: 'old', lastSyncedAt: 1 },
+      },
+    };
+    const patch = {
+      id: 999,
+      notionSections: {
+        conversations: { headingBlockId: 'h-new' },
+      },
+      notionSectionCursors: {
+        conversations: { lastSyncedSequence: 2 },
+        invalid: null,
+      },
+    };
+
+    const merged = mergeSyncMappingPatch(existing, patch);
+
+    expect(merged.id).toBe(7);
+    expect(merged.notionSections).toEqual({
+      conversations: { headingBlockId: 'h-new', stable: true },
+      comments: { headingBlockId: 'h-comments' },
+    });
+    expect(merged.notionSectionCursors).toEqual({
+      conversations: { lastSyncedMessageKey: 'm1', lastSyncedSequence: 2 },
+    });
+    expect(merged.notionSectionDigests).toEqual(existing.notionSectionDigests);
+  });
+
+  it('ignores invalid Notion nested field patches and does not mutate inputs', () => {
+    const existing = {
+      notionSections: { conversations: { headingBlockId: 'h1' } },
+      notionSectionCursors: { conversations: { lastSyncedMessageKey: 'm1' } },
+      notionSectionDigests: { article: { digest: 'd1' } },
+    };
+    const patch = {
+      notionSections: null,
+      notionSectionCursors: ['bad'],
+      notionSectionDigests: 'bad',
+    };
+    const existingBefore = structuredClone(existing);
+    const patchBefore = structuredClone(patch);
+
+    const merged = mergeSyncMappingPatch(existing, patch);
+
+    expect(merged).toMatchObject(existing);
+    expect(existing).toEqual(existingBefore);
+    expect(patch).toEqual(patchBefore);
+  });
+
   it('strips only the browser-local id without mutating the source', () => {
     const source = { id: 7, source: 'chatgpt', conversationKey: 'c1', nested: { value: 1 } };
     const stripped = stripSyncMappingLocalId(source);

--- a/tests/storage/sync-mapping-record.test.ts
+++ b/tests/storage/sync-mapping-record.test.ts
@@ -210,14 +210,28 @@ describe('sync mapping persistence record', () => {
       id: 20,
       source: 'web',
       conversationKey: 'canonical',
-      ...notionState({ pageId: 'page-target', syncedAt: 10, key: 'target', sequence: 1, heading: 'h-target', digest: 'd-target' }),
+      ...notionState({
+        pageId: 'page-target',
+        syncedAt: 10,
+        key: 'target',
+        sequence: 1,
+        heading: 'h-target',
+        digest: 'd-target',
+      }),
       feishuDocId: 'doc-target',
       feishuLastContentHash: 'hash-target',
       shared: 'target',
     };
     const legacy = {
       id: 21,
-      ...notionState({ pageId: 'page-legacy', syncedAt: 999, key: 'legacy', sequence: 9, heading: 'h-legacy', digest: 'd-legacy' }),
+      ...notionState({
+        pageId: 'page-legacy',
+        syncedAt: 999,
+        key: 'legacy',
+        sequence: 9,
+        heading: 'h-legacy',
+        digest: 'd-legacy',
+      }),
       feishuDocId: 'doc-legacy',
       feishuLastContentHash: 'hash-legacy',
       shared: 'legacy',
@@ -246,7 +260,14 @@ describe('sync mapping persistence record', () => {
     const target = { id: 30, source: 'web', conversationKey: 'canonical', targetOnly: true };
     const legacy = {
       id: 31,
-      ...notionState({ pageId: 'page-legacy', syncedAt: 50, key: 'legacy', sequence: 5, heading: 'h-legacy', digest: 'd-legacy' }),
+      ...notionState({
+        pageId: 'page-legacy',
+        syncedAt: 50,
+        key: 'legacy',
+        sequence: 5,
+        heading: 'h-legacy',
+        digest: 'd-legacy',
+      }),
       feishuDocId: 'doc-legacy',
       feishuLastContentHash: 'hash-legacy',
     };
@@ -268,11 +289,11 @@ describe('sync mapping persistence record', () => {
   });
 
   it('uses fallback Notion page only after provider-state selection leaves the page empty', () => {
-    const merged = mergeSyncMappingForIdentityMove(
-      { id: 40, lastSyncedMessageKey: 'target-orphan' },
-      null,
-      { source: 'web', conversationKey: 'canonical', fallbackNotionPageId: 'page-fallback' },
-    );
+    const merged = mergeSyncMappingForIdentityMove({ id: 40, lastSyncedMessageKey: 'target-orphan' }, null, {
+      source: 'web',
+      conversationKey: 'canonical',
+      fallbackNotionPageId: 'page-fallback',
+    });
 
     expect(merged).toMatchObject({
       id: 40,
@@ -317,11 +338,25 @@ describe('sync mapping persistence record', () => {
 
   it('same Notion page uses the later lastSyncedAt as one complete snapshot', () => {
     const local = {
-      ...notionState({ pageId: 'page-a', syncedAt: 300, key: 'local', sequence: 3, heading: 'h-local', digest: 'd-local' }),
+      ...notionState({
+        pageId: 'page-a',
+        syncedAt: 300,
+        key: 'local',
+        sequence: 3,
+        heading: 'h-local',
+        digest: 'd-local',
+      }),
       updatedAt: 1,
     };
     const incoming = {
-      ...notionState({ pageId: 'page-a', syncedAt: 200, key: 'incoming', sequence: 9, heading: 'h-in', digest: 'd-in' }),
+      ...notionState({
+        pageId: 'page-a',
+        syncedAt: 200,
+        key: 'incoming',
+        sequence: 9,
+        heading: 'h-in',
+        digest: 'd-in',
+      }),
       updatedAt: 999,
     };
 
@@ -336,7 +371,14 @@ describe('sync mapping persistence record', () => {
   });
 
   it('same Notion page uses incoming as the stable tie-break when time is equal or missing', () => {
-    const local = notionState({ pageId: 'page-a', syncedAt: 100, key: 'local', sequence: 1, heading: 'h-local', digest: 'd-local' });
+    const local = notionState({
+      pageId: 'page-a',
+      syncedAt: 100,
+      key: 'local',
+      sequence: 1,
+      heading: 'h-local',
+      digest: 'd-local',
+    });
     const incomingEqual = notionState({
       pageId: 'page-a',
       syncedAt: 100,
@@ -364,7 +406,14 @@ describe('sync mapping persistence record', () => {
   });
 
   it('different Notion pages keep the complete local provider state', () => {
-    const local = notionState({ pageId: 'page-local', syncedAt: 100, key: 'local', sequence: 1, heading: 'h-local', digest: 'd-local' });
+    const local = notionState({
+      pageId: 'page-local',
+      syncedAt: 100,
+      key: 'local',
+      sequence: 1,
+      heading: 'h-local',
+      digest: 'd-local',
+    });
     const incoming = notionState({
       pageId: 'page-incoming',
       syncedAt: 999,
@@ -414,7 +463,14 @@ describe('sync mapping persistence record', () => {
   it('does not mutate either input while replacing provider groups', () => {
     const local = {
       id: 1,
-      ...notionState({ pageId: 'page-a', syncedAt: 10, key: 'local', sequence: 1, heading: 'h-local', digest: 'd-local' }),
+      ...notionState({
+        pageId: 'page-a',
+        syncedAt: 10,
+        key: 'local',
+        sequence: 1,
+        heading: 'h-local',
+        digest: 'd-local',
+      }),
     };
     const incoming = {
       id: 2,

--- a/tests/sync/notion-article-comments.test.ts
+++ b/tests/sync/notion-article-comments.test.ts
@@ -168,6 +168,42 @@ describe('notion article comments blocks', () => {
     expect(renderer.computeNotionCommentsDigest(comments)).toBe(d1);
   });
 
+  it('keeps digest stable when local database ids are remapped but thread content is unchanged', async () => {
+    const renderer = await loadNotionCommentsRenderer();
+    const source = [
+      {
+        id: 41,
+        parentId: null,
+        conversationId: 10,
+        canonicalUrl: 'https://example.com',
+        authorName: 'A',
+        quoteText: 'Quoted',
+        commentText: 'Root',
+        locator: null,
+        createdAt: 100,
+        updatedAt: 100,
+      },
+      {
+        id: 57,
+        parentId: 41,
+        conversationId: 10,
+        canonicalUrl: 'https://example.com',
+        authorName: 'B',
+        quoteText: '',
+        commentText: 'Reply',
+        locator: null,
+        createdAt: 110,
+        updatedAt: 110,
+      },
+    ];
+    const restored = [
+      { ...source[0], id: 1 },
+      { ...source[1], id: 2, parentId: 1 },
+    ];
+
+    expect(renderer.computeNotionCommentsDigest(restored)).toBe(renderer.computeNotionCommentsDigest(source));
+  });
+
   it('counts root threads even when a root has no quote', async () => {
     const renderer = await loadNotionCommentsRenderer();
     const result = renderer.buildNotionCommentsBlocks([

--- a/tests/sync/notion-article-comments.test.ts
+++ b/tests/sync/notion-article-comments.test.ts
@@ -204,6 +204,36 @@ describe('notion article comments blocks', () => {
     expect(renderer.computeNotionCommentsDigest(restored)).toBe(renderer.computeNotionCommentsDigest(source));
   });
 
+  it('keeps digest stable when equal-time roots differ only by reply creation time across id remaps', async () => {
+    const renderer = await loadNotionCommentsRenderer();
+    const comment = (id: number, parentId: number | null, createdAt: number, updatedAt: number) => ({
+      id,
+      parentId,
+      conversationId: 10,
+      canonicalUrl: 'https://example.com',
+      authorName: 'A',
+      quoteText: '',
+      commentText: parentId == null ? 'same-root' : 'same-reply',
+      locator: null,
+      createdAt,
+      updatedAt,
+    });
+    const source = [
+      comment(41, null, 100, 200),
+      comment(57, null, 100, 200),
+      comment(80, 41, 110, 300),
+      comment(70, 57, 120, 300),
+    ];
+    const restored = [
+      comment(3, null, 100, 200),
+      comment(1, null, 100, 200),
+      comment(4, 3, 110, 300),
+      comment(2, 1, 120, 300),
+    ];
+
+    expect(renderer.computeNotionCommentsDigest(restored)).toBe(renderer.computeNotionCommentsDigest(source));
+  });
+
   it('counts root threads even when a root has no quote', async () => {
     const renderer = await loadNotionCommentsRenderer();
     const result = renderer.buildNotionCommentsBlocks([

--- a/tests/unit/comment-thread-graph.test.ts
+++ b/tests/unit/comment-thread-graph.test.ts
@@ -20,6 +20,35 @@ describe('comment thread graph', () => {
     expect(graph.threads.map((t) => t.root.id)).toEqual([4, 1]);
     expect(graph.threads[1].replies.map((r) => r.id)).toEqual([3, 2]);
   });
+  it('keeps equal-time thread and reply order stable across local id remaps', () => {
+    const sourceRootA = { ...item(41, null, 100), commentText: 'same-root' };
+    const sourceRootB = { ...item(57, null, 100), commentText: 'same-root' };
+    const sourceReplyA = { ...item(80, 41, 110), commentText: 'reply-z' };
+    const sourceReplyB = { ...item(70, 57, 110), commentText: 'reply-a' };
+    const sourceReplyA2 = { ...item(81, 41, 110), commentText: 'reply-a' };
+    const restoredRootA = { ...sourceRootA, id: 2 };
+    const restoredRootB = { ...sourceRootB, id: 1 };
+    const restoredReplyA = { ...sourceReplyA, id: 3, parentId: 2 };
+    const restoredReplyB = { ...sourceReplyB, id: 4, parentId: 1 };
+    const restoredReplyA2 = { ...sourceReplyA2, id: 5, parentId: 2 };
+
+    const source = normalizeCommentThreadGraph([sourceRootA, sourceRootB, sourceReplyA, sourceReplyB, sourceReplyA2]);
+    const restored = normalizeCommentThreadGraph([
+      restoredRootA,
+      restoredRootB,
+      restoredReplyA,
+      restoredReplyB,
+      restoredReplyA2,
+    ]);
+
+    const project = (graph: ReturnType<typeof normalizeCommentThreadGraph>) =>
+      graph.threads.map((thread) => ({
+        root: thread.root.commentText,
+        replies: thread.replies.map((reply) => reply.commentText),
+      }));
+    expect(project(restored)).toEqual(project(source));
+  });
+
   it('classifies duplicates, orphans and cycles deterministically', () => {
     const graph = normalizeCommentThreadGraph([item(1, 2), item(2, 1), item(3, 999), item(3, null)]);
     expect(graph.duplicateIds).toEqual([3]);

--- a/tests/unit/notion-managed-sections-toggle-heading.test.ts
+++ b/tests/unit/notion-managed-sections-toggle-heading.test.ts
@@ -71,5 +71,8 @@ describe('notion managed sections', () => {
     expect(res.discoveredBy).toBe('scan');
     expect(appendChildren).toHaveBeenCalledTimes(0);
     expect(patchSyncMapping).toHaveBeenCalledTimes(1);
+    expect(patchSyncMapping).toHaveBeenCalledWith(1, {
+      notionSections: { conversations: { headingBlockId: 'b1' } },
+    });
   });
 });


### PR DESCRIPTION
## 背景

备份恢复到新浏览器/新数据库后，Notion / 飞书同步状态可能因 mapping 合并、conversation identity migration、IndexedDB upgrade 或评论本地 ID 重映射而失去连续性，导致已同步内容被重复创建、追加或重建。

## 修改

- 建立 canonical `sync-mapping-record`，统一 backup import、runtime patch/cursor、identity migration 与 schema upgrade 的同步映射语义。
- Notion 与 Feishu continuity state 按 provider target 整组选择/切换，避免 page/doc 与旧 cursor、digest、hash 混合。
- ZIP v2 与 legacy JSON import 共用同一 mapping upsert 和 conversation mirror 路径。
- 删除旧的 field-by-field / nested mapping merge、独立 cursor transaction 与 dead `clearSyncCursor` 路径。
- 增加真实 ZIP export → 删除 DB → import → production storage → Notion sync 集成回归，验证 chat/article/comments 恢复后保持 `no_changes`。
- 修复 comments digest / thread ordering 对本地自增 ID 的依赖，并把 `createdAt` 纳入稳定语义排序，保证跨库 ID remap 后投影与 digest 不漂移。

## 审计中额外修复

- 修复 `lastSyncedAt = null/空字符串` 被误判为有效 0。
- 修复切换 Notion page / Feishu doc 时旧 continuity state 未原子清除。
- 修复 comments digest 依赖本地 ID。
- 修复同时间评论线程在跨库 ID 重映射后仍可能因 reply `createdAt` 缺失于 tie-key 而翻转顺序。

## 验证

- P1 targeted: 36/36 PASS
- P2 targeted: 57/57 PASS
- P3 targeted: 60/60 PASS
- `npm run gate:ci`: PASS
- `npm run build`: PASS
- `npm run gate`: PASS
- 全仓：234 test files / 1167 tests PASS
- TypeScript / ESLint / Prettier: PASS
- 旧 symbols `mergeSyncMappingRecord` / `mergeMappingRecord` / `mergeNestedRecord` / `mergeNotionSectionAnchorsPatch` / `clearSyncCursor` / `stripLocalMapping` 已无生产残留。
- 依赖边界扫描通过。