### PR TITLE
修复消息连接生命周期问题并优化后台初始化流程

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,6 +12,13 @@
 | OAuth Connect 无响应 | client id、redirect URI、pending state、Worker endpoint 和浏览器日志。 |
 | article 只有文本没有图片 | 图片设置、anti-hotlink rule、referer 与下载 warning；文本成功仍是成功。 |
 | 视频提示没有字幕 | 先在页面开启并等待字幕请求加载，再 capture。 |
+| `Could not establish connection` / `Receiving end does not exist` | 先按发送方向区分生命周期：In Page 已出现后的 content → background 首击失败应检查 MV3 background listener 是否被异步初始化挡住；background → content 则先判断 content script 是否尚未注入/初始化。不要把它和 `Extension context invalidated` 混为一类，也不要用通用 retry 掩盖 background cold-start。 |
+
+### 连接错误的方向性判断
+
+- **content → background**：In Page 按钮已经存在、worker 冷启动后第一次点击失败而第二次立即成功，优先检查 background `runtime.onMessage` 是否在任何 `await` 之后才注册。background receiver 应 listener-first，不能靠 retry、keep-alive 或扩大 timeout 修复。
+- **background → content**：页面刚导航时 content script 可能尚未有 receiver；这不等价于 background cold-start。content entrypoint 自身的异步初始化窗口也要单独检查，不能反向套用 content → background 的结论。
+- **`Extension context invalidated`**：extension reload/update 后旧页面脚本属于旧 context 生命周期，继续走现有 invalidated-context 处理；不要归入 receiving-end retry。
 
 ## 评论精确定位
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,13 +12,15 @@
 | OAuth Connect 无响应 | client id、redirect URI、pending state、Worker endpoint 和浏览器日志。 |
 | article 只有文本没有图片 | 图片设置、anti-hotlink rule、referer 与下载 warning；文本成功仍是成功。 |
 | 视频提示没有字幕 | 先在页面开启并等待字幕请求加载，再 capture。 |
-| `Could not establish connection` / `Receiving end does not exist` | 先按发送方向区分生命周期：In Page 已出现后的 content → background 首击失败应检查 MV3 background listener 是否被异步初始化挡住；background → content 则先判断 content script 是否尚未注入/初始化。不要把它和 `Extension context invalidated` 混为一类，也不要用通用 retry 掩盖 background cold-start。 |
+| `Could not establish connection` / `Receiving end does not exist` | 先按发送方向和生命周期分类：content → background 冷启动、background → content 尚未注入、port 已建立后关闭、旧 context 失效是不同问题。不要用通用 retry 掩盖 background cold-start，也不要把 `message port closed` 或 `Extension context invalidated` 当成 missing receiver。 |
 
-### 连接错误的方向性判断
+### 连接错误的五类生命周期
 
-- **content → background**：In Page 按钮已经存在、worker 冷启动后第一次点击失败而第二次立即成功，优先检查 background `runtime.onMessage` 是否在任何 `await` 之后才注册。background receiver 应 listener-first，不能靠 retry、keep-alive 或扩大 timeout 修复。
-- **background → content**：页面刚导航时 content script 可能尚未有 receiver；这不等价于 background cold-start。content entrypoint 自身的异步初始化窗口也要单独检查，不能反向套用 content → background 的结论。
-- **`Extension context invalidated`**：extension reload/update 后旧页面脚本属于旧 context 生命周期，继续走现有 invalidated-context 处理；不要归入 receiving-end retry。
+- **content → background / background cold-start**：In Page 按钮已经存在、worker 冷启动后第一次点击失败而第二次立即成功，优先检查 background `runtime.onMessage` 是否在任何 `await` 之后才注册。background receiver 应 listener-first，不能靠 retry、keep-alive 或扩大 timeout 修复。
+- **background → content / 人为初始化窗口**：content entrypoint 已执行但仍被 locale await 挡住 listener 的窗口已经消除；Current Page / comments / video 只在 handler 内等语言，article extract 不等语言。
+- **background → content / 尚未注入**：页面刚导航、content script 根本还没注入时，仍可能没有 receiver。这是真实平台窗口，不等价于 background cold-start；现有 article navigation 的一次 missing-receiver retry 只属于该 caller。
+- **message port closed**：listener/port 已经建立后又因导航、reload 或 teardown 关闭。这不是“从未有 receiver”，不得借用 missing-receiver retry 隐藏。
+- **`Extension context invalidated`**：extension reload/update 后旧页面脚本属于旧 context 生命周期，继续走现有 invalidated-context 处理；不要归入 receiving-end retry。content → background 不增加 retry。
 
 ## 评论精确定位
 

--- a/src/collectors/web/article-fetch.ts
+++ b/src/collectors/web/article-fetch.ts
@@ -133,11 +133,10 @@ async function ensureReadability(tabId: number) {
   }
 }
 
-function isNoReceiverError(error: unknown): boolean {
+function isMissingContentReceiverError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error || '');
-  return /receiving end does not exist|could not establish connection|no receiving end|message port closed/i.test(
-    message,
-  );
+  // port closed means a receiver existed and then tore down; do not hide it behind missing-receiver retry
+  return /receiving end does not exist|no receiving end/i.test(message);
 }
 
 async function extractArticleOnTab(tabId: number, includeXiaohongshuComments: boolean) {
@@ -155,7 +154,7 @@ async function extractArticleOnTab(tabId: number, includeXiaohongshuComments: bo
     response = await tabsSendMessage(tabId, payload);
   } catch (error) {
     // Content scripts may not be ready right after navigation; retry once to reduce flaky "no receiver" failures.
-    if (isNoReceiverError(error)) {
+    if (isMissingContentReceiverError(error)) {
       await sleep(CONTENT_MESSAGE_RETRY_DELAY_MS);
       response = await tabsSendMessage(tabId, payload);
     } else {

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -35,8 +35,8 @@ async function openAboutSectionAfterInstall(): Promise<void> {
   await openOrFocusExtensionAppTab({ route: '/settings?section=aboutme' });
 }
 
-export default defineBackground(async () => {
-  await initializeLocale();
+export default defineBackground(() => {
+  const localeReady = initializeLocale();
   const services = createBackgroundServices({ getInstanceId: getBackgroundInstanceId });
 
   const router = createBackgroundRouter({
@@ -68,7 +68,7 @@ export default defineBackground(async () => {
     getInstanceId: getBackgroundInstanceId,
     testObsidianConnection: (input) => services.obsidianSyncOrchestrator.testConnection(input),
   });
-  registerUiMessageHandlers(router);
+  registerUiMessageHandlers(router, { localeReady });
   registerSyncHandlers(router, {
     getInstanceId: getBackgroundInstanceId,
     notionSyncOrchestrator: services.notionSyncOrchestrator,
@@ -76,14 +76,24 @@ export default defineBackground(async () => {
     feishuSyncOrchestrator: services.feishuSyncOrchestrator,
   });
 
-  // Keep legacy "start" side-effects that are not message handlers.
+  router.start();
+
   try {
-    ensureDefaultNotionOAuthClientId().catch(() => {});
-    ensureDefaultFeishuOAuthClientId().catch(() => {});
-    ensureDefaultFeishuOAuthProxyUrl().catch(() => {});
     setupNotionOAuthNavigationListener();
+  } catch (_e) {
+    // optional listener registration must not block sibling listeners
+  }
+  try {
     setupFeishuOAuthNavigationListener();
-    registerClipperContextMenu();
+  } catch (_e) {
+    // optional listener registration must not block sibling listeners
+  }
+  try {
+    registerClipperContextMenu({ localeReady });
+  } catch (_e) {
+    // optional listener registration must not block sibling listeners
+  }
+  try {
     onInstalled((details) => {
       ensureDefaultNotionOAuthClientId().catch(() => {});
       ensureDefaultFeishuOAuthClientId().catch(() => {});
@@ -93,8 +103,19 @@ export default defineBackground(async () => {
       openAboutSectionAfterInstall().catch(() => {});
     });
   } catch (_e) {
-    // ignore
+    // optional listener registration must not block sibling listeners
   }
+  try {
+    onAlarm((alarm) => {
+      void services.autoSync.handleAlarm(String(alarm?.name || ''));
+    });
+  } catch (_e) {
+    // optional listener registration must not block sibling listeners
+  }
+
+  void ensureDefaultNotionOAuthClientId().catch(() => {});
+  void ensureDefaultFeishuOAuthClientId().catch(() => {});
+  void ensureDefaultFeishuOAuthProxyUrl().catch(() => {});
 
   try {
     const id = getBackgroundInstanceId();
@@ -102,15 +123,7 @@ export default defineBackground(async () => {
     obsidianSyncJobStore.abortRunningJobIfFromOtherInstance(id, { forceAbort: true }).catch(() => {});
     feishuSyncJobStore.abortRunningJobIfFromOtherInstance(id, { forceAbort: true }).catch(() => {});
   } catch (_e) {
-    // ignore
-  }
-
-  try {
-    onAlarm((alarm) => {
-      void services.autoSync.handleAlarm(String(alarm?.name || ''));
-    });
-  } catch (_e) {
-    // ignore
+    // ignore best-effort startup recovery failures
   }
 
   // Best-effort flush for any overdue auto-sync queue items. This complements
@@ -120,8 +133,6 @@ export default defineBackground(async () => {
     void services.autoSync.obsidianScheduler.flush();
     void services.autoSync.feishuScheduler.flush();
   } catch (_e) {
-    // ignore
+    // ignore best-effort startup flush failures
   }
-
-  router.start();
 });

--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -25,7 +25,7 @@ export default defineContentScript({
   // This avoids browser-specific dynamic content-script registration support gaps.
   matches: ['http://*/*', 'https://*/*'],
   async main() {
-    await initializeLocale();
+    const localeReady = initializeLocale();
     const runtime = createRuntimeClient();
     const env = createCollectorEnv({ window, document, location, normalize: normalizeApi });
     const collectorsRegistry = createCollectorsRegistry();
@@ -35,8 +35,12 @@ export default defineContentScript({
       collectorsRegistry,
     });
 
-    registerCurrentPageCaptureContentHandlers(currentPageCapture, { inpageTip: inpageTipApi });
+    registerCurrentPageCaptureContentHandlers(currentPageCapture, {
+      inpageTip: inpageTipApi,
+      localeReady,
+    });
     registerInpageCommentsPanelContentHandlers(runtime, {
+      localeReady,
       createPanelApi: (rt) => getInpageCommentsPanelApi(rt),
       domSource: createInpageCommentsDomSource({
         window,
@@ -47,8 +51,10 @@ export default defineContentScript({
     registerWebArticleExtractContentHandlers();
     registerVideoTranscriptCaptureContentHandlers(createVideoTranscriptCaptureService({ runtime }), {
       inpageTip: inpageTipApi,
+      localeReady,
     });
 
+    await localeReady.catch(() => undefined);
     const itemMentionController = createItemMentionController({ runtime, ui: inpageItemMentionApi });
     const controller = createContentController({
       runtime,

--- a/src/platform/context-menus/clipper-context-menu.ts
+++ b/src/platform/context-menus/clipper-context-menu.ts
@@ -231,9 +231,7 @@ export function registerClipperContextMenu(options: ContextMenuRegistrationOptio
   if (!api) return;
 
   const localeReady = options.localeReady || Promise.resolve();
-  void localeReady
-    .catch(() => undefined)
-    .then(() => createOrRefreshMenus(api));
+  void localeReady.catch(() => undefined).then(() => createOrRefreshMenus(api));
 
   try {
     api.onClicked?.addListener?.((info: any, _tab: any) => {

--- a/src/platform/context-menus/clipper-context-menu.ts
+++ b/src/platform/context-menus/clipper-context-menu.ts
@@ -219,14 +219,21 @@ async function updateCheckedStates(api: any, state: { mode: InpageDisplayMode; a
 let registered = false;
 let removeStorageListener: (() => void) | null = null;
 
-export function registerClipperContextMenu(): void {
+type ContextMenuRegistrationOptions = {
+  localeReady?: Promise<unknown>;
+};
+
+export function registerClipperContextMenu(options: ContextMenuRegistrationOptions = {}): void {
   if (registered) return;
   registered = true;
 
   const api = getMenusApi();
   if (!api) return;
 
-  void createOrRefreshMenus(api);
+  const localeReady = options.localeReady || Promise.resolve();
+  void localeReady
+    .catch(() => undefined)
+    .then(() => createOrRefreshMenus(api));
 
   try {
     api.onClicked?.addListener?.((info: any, _tab: any) => {
@@ -269,12 +276,16 @@ export function registerClipperContextMenu(): void {
   try {
     api.onShown?.addListener?.((info: any, tab: any) => {
       if (!info) return;
-      void refreshSaveMenuTitle(api, tab || null);
-      try {
-        api.refresh?.();
-      } catch (_e) {
-        // ignore
-      }
+      void localeReady
+        .catch(() => undefined)
+        .then(() => refreshSaveMenuTitle(api, tab || null))
+        .then(() => {
+          try {
+            api.refresh?.();
+          } catch (_e) {
+            // ignore
+          }
+        });
     });
   } catch (_e) {
     // ignore

--- a/src/platform/messaging/ui-background-handlers.ts
+++ b/src/platform/messaging/ui-background-handlers.ts
@@ -12,7 +12,15 @@ type AnyRouter = {
   register: (type: string, handler: (msg: any, sender?: any) => Promise<any> | any) => void;
 };
 
-export function registerUiMessageHandlers(router: AnyRouter) {
+type UiMessageHandlersOptions = {
+  localeReady?: Promise<unknown>;
+};
+
+export function registerUiMessageHandlers(router: AnyRouter, options: UiMessageHandlersOptions = {}) {
+  const localeReady = options.localeReady || Promise.resolve();
+  const waitLocale = async () => {
+    await localeReady.catch(() => undefined);
+  };
   router.register(UI_MESSAGE_TYPES.OPEN_CURRENT_TAB_INPAGE_COMMENTS_PANEL, async (msg: any, sender: any) => {
     const explicitTabId = Number((msg as any)?.tabId);
     const senderTabId = Number(sender?.tab?.id);
@@ -62,6 +70,7 @@ export function registerUiMessageHandlers(router: AnyRouter) {
   });
 
   router.register(UI_MESSAGE_TYPES.GET_ACTIVE_TAB_CAPTURE_STATE, async () => {
+    await waitLocale();
     const activeTab = await getActiveTab();
     if (!activeTab.ok) return router.ok(activeTab.state);
 
@@ -72,6 +81,7 @@ export function registerUiMessageHandlers(router: AnyRouter) {
   });
 
   router.register(UI_MESSAGE_TYPES.CAPTURE_ACTIVE_TAB_CURRENT_PAGE, async () => {
+    await waitLocale();
     const activeTab = await getActiveTab();
     if (!activeTab.ok) {
       return router.err(activeTab.state.reason || t('currentPageCannotBeCaptured'), {

--- a/src/services/bootstrap/current-page-capture-content-handlers.ts
+++ b/src/services/bootstrap/current-page-capture-content-handlers.ts
@@ -6,19 +6,25 @@ type InpageTipApi = {
   showSaveTip?: (text: unknown, options?: { kind?: 'default' | 'error' }) => void;
 };
 
+type LocaleReadyOptions = {
+  localeReady?: Promise<unknown>;
+};
+
 export function registerCurrentPageCaptureContentHandlers(
   service: CurrentPageCaptureService,
-  options?: { inpageTip?: InpageTipApi | null },
+  options?: { inpageTip?: InpageTipApi | null } & LocaleReadyOptions,
 ) {
   const runtime = (globalThis as any).chrome?.runtime ?? (globalThis as any).browser?.runtime;
   const onMessage = runtime?.onMessage;
   if (!onMessage?.addListener) return () => {};
 
+  const localeReady = options?.localeReady ?? Promise.resolve();
   const listener = (msg: any, _sender: any, sendResponse: (value: ApiResponse<any>) => void) => {
     if (!msg || typeof msg.type !== 'string') return undefined;
 
     if (msg.type === CURRENT_PAGE_MESSAGE_TYPES.GET_CAPTURE_STATE) {
-      Promise.resolve()
+      Promise.resolve(localeReady)
+        .catch(() => undefined)
         .then(() => service.getCurrentPageCaptureState())
         .then((data) => sendResponse(ok(data)))
         .catch((error) => sendResponse(err((error as any)?.message ?? error)));
@@ -32,7 +38,8 @@ export function registerCurrentPageCaptureContentHandlers(
       const inpageTip = options?.inpageTip;
       const showTip = source === 'contextmenu' && typeof inpageTip?.showSaveTip === 'function';
 
-      Promise.resolve()
+      Promise.resolve(localeReady)
+        .catch(() => undefined)
         .then(() =>
           service.captureCurrentPage(
             showTip

--- a/src/services/bootstrap/inpage-comments-panel-content-handlers.ts
+++ b/src/services/bootstrap/inpage-comments-panel-content-handlers.ts
@@ -22,6 +22,7 @@ export type InpageCommentsPanelController = {
 };
 
 export type InpageCommentsPanelDeps = {
+  localeReady?: Promise<unknown>;
   domSource: InpageCommentsDomSource;
   // Injected from the entrypoint (UI layer) so that `services` never imports `ui`
   // directly, preserving the one-way layering rule in AGENTS.md.
@@ -88,12 +89,13 @@ export function registerInpageCommentsPanelContentHandlers(
     if (!msg || typeof msg.type !== 'string') return undefined;
     if (msg.type !== CONTENT_MESSAGE_TYPES.OPEN_INPAGE_COMMENTS_PANEL) return undefined;
 
-    void controller
-      .open({
+    void Promise.resolve(deps.localeReady)
+      .catch(() => undefined)
+      .then(() => controller.open({
         tabId: normalizePositiveInt(msg?.payload?.tabId) || null,
         focusComposer: true,
         ensureArticle: true,
-      })
+      }))
       .finally(() => {
         sendResponse?.({ ok: true });
       });

--- a/src/services/bootstrap/inpage-comments-panel-content-handlers.ts
+++ b/src/services/bootstrap/inpage-comments-panel-content-handlers.ts
@@ -91,11 +91,13 @@ export function registerInpageCommentsPanelContentHandlers(
 
     void Promise.resolve(deps.localeReady)
       .catch(() => undefined)
-      .then(() => controller.open({
-        tabId: normalizePositiveInt(msg?.payload?.tabId) || null,
-        focusComposer: true,
-        ensureArticle: true,
-      }))
+      .then(() =>
+        controller.open({
+          tabId: normalizePositiveInt(msg?.payload?.tabId) || null,
+          focusComposer: true,
+          ensureArticle: true,
+        }),
+      )
       .finally(() => {
         sendResponse?.({ ok: true });
       });

--- a/src/services/bootstrap/video-transcript-capture-content-handlers.ts
+++ b/src/services/bootstrap/video-transcript-capture-content-handlers.ts
@@ -37,11 +37,12 @@ export function registerVideoTranscriptCaptureContentHandlers(
     const inpageTip = options?.inpageTip;
     const showTip = source === 'contextmenu' && typeof inpageTip?.showSaveTip === 'function';
 
-    if (showTip) inpageTip?.showSaveTip?.(t('fetchingDots'), { kind: 'default' });
-
     Promise.resolve(localeReady)
       .catch(() => undefined)
-      .then(() => service.captureVideoTranscript())
+      .then(() => {
+        if (showTip) inpageTip?.showSaveTip?.(t('fetchingDots'), { kind: 'default' });
+        return service.captureVideoTranscript();
+      })
       .then((data) => {
         if (showTip) {
           if (data?.subtitleStatus === 'empty') {

--- a/src/services/bootstrap/video-transcript-capture-content-handlers.ts
+++ b/src/services/bootstrap/video-transcript-capture-content-handlers.ts
@@ -8,6 +8,10 @@ type InpageTipApi = {
   showSaveTip?: (text: unknown, options?: { kind?: 'default' | 'error' }) => void;
 };
 
+type LocaleReadyOptions = {
+  localeReady?: Promise<unknown>;
+};
+
 function toErrorMessage(error: unknown, fallback: string): string {
   const msg = error instanceof Error ? error.message : String(error ?? '');
   const text = String(msg || '').trim();
@@ -16,12 +20,13 @@ function toErrorMessage(error: unknown, fallback: string): string {
 
 export function registerVideoTranscriptCaptureContentHandlers(
   service: VideoTranscriptCaptureService,
-  options?: { inpageTip?: InpageTipApi | null },
+  options?: { inpageTip?: InpageTipApi | null } & LocaleReadyOptions,
 ) {
   const runtime = (globalThis as any).chrome?.runtime ?? (globalThis as any).browser?.runtime;
   const onMessage = runtime?.onMessage;
   if (!onMessage?.addListener) return () => {};
 
+  const localeReady = options?.localeReady ?? Promise.resolve();
   const listener = (msg: any, _sender: any, sendResponse: (value: ApiResponse<any>) => void) => {
     if (!msg || typeof msg.type !== 'string') return undefined;
     if (msg.type !== CONTENT_MESSAGE_TYPES.CAPTURE_VIDEO_TRANSCRIPT) return undefined;
@@ -34,7 +39,8 @@ export function registerVideoTranscriptCaptureContentHandlers(
 
     if (showTip) inpageTip?.showSaveTip?.(t('fetchingDots'), { kind: 'default' });
 
-    Promise.resolve()
+    Promise.resolve(localeReady)
+      .catch(() => undefined)
       .then(() => service.captureVideoTranscript())
       .then((data) => {
         if (showTip) {

--- a/tests/smoke/article-fetch-service.test.ts
+++ b/tests/smoke/article-fetch-service.test.ts
@@ -730,6 +730,37 @@ describe('article-fetch-service', () => {
     vi.useRealTimers();
   });
 
+  it('does not treat a closed message port as a missing content receiver', async () => {
+    storageMocks.hasConversation.mockResolvedValue(false);
+    settingsMocks.storageGet.mockResolvedValue({ web_article_cache_images_enabled: false });
+
+    const runtime = { lastError: null as any };
+    const executeScript = vi.fn((details: any, cb: (results: any[]) => void) =>
+      cb(Array.isArray(details?.files) ? [{}] : []),
+    );
+    const sendMessage = vi.fn((_tabId: number, _msg: any, cb: (res: any) => void) => {
+      runtime.lastError = { message: 'The message port closed before a response was received.' };
+      cb(null);
+      runtime.lastError = null;
+    });
+
+    // @ts-expect-error test global
+    globalThis.chrome = {
+      runtime,
+      tabs: {
+        query: (_query: any, cb: (tabs: any[]) => void) =>
+          cb([{ id: 88, url: 'https://example.com/closed', title: 'T' }]),
+        sendMessage,
+      },
+      scripting: { executeScript },
+    };
+
+    const service = await loadArticleFetchService();
+    const pending = service.fetchActiveTabArticle();
+    await expect(pending).rejects.toThrow(/message port closed/i);
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+  });
+
   it('continues capture when readability injection fails', async () => {
     const upsertConversation = vi.fn(async (payload: any) => ({ id: 61, ...payload }));
     const syncConversationMessages = vi.fn(async () => ({ upserted: 1, deleted: 0 }));

--- a/tests/smoke/background-entrypoint-cold-start.test.ts
+++ b/tests/smoke/background-entrypoint-cold-start.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  initializeLocale: vi.fn(),
+  createBackgroundServices: vi.fn(),
+  registerConversationHandlers: vi.fn(),
+  registerSyncHandlers: vi.fn(),
+  registerWebArticleHandlers: vi.fn(),
+  registerChatgptDeepResearchHandlers: vi.fn(),
+  registerUiMessageHandlers: vi.fn(),
+  registerArticleCommentsHandlers: vi.fn(),
+  registerItemMentionHandlers: vi.fn(),
+  registerChatWithBackgroundHandlers: vi.fn(),
+  registerNotionSettingsHandlers: vi.fn(),
+  registerObsidianSettingsHandlers: vi.fn(),
+  registerFeishuSettingsHandlers: vi.fn(),
+  setupNotionOAuthNavigationListener: vi.fn(),
+  setupFeishuOAuthNavigationListener: vi.fn(),
+  ensureDefaultNotionOAuthClientId: vi.fn(),
+  ensureDefaultFeishuOAuthClientId: vi.fn(),
+  ensureDefaultFeishuOAuthProxyUrl: vi.fn(),
+  registerClipperContextMenu: vi.fn(),
+  onInstalled: vi.fn(),
+  onAlarm: vi.fn(),
+  openOrFocusExtensionAppTab: vi.fn(),
+  obsidianAbort: vi.fn(),
+  feishuAbort: vi.fn(),
+}));
+
+vi.mock('@i18n', () => ({ initializeLocale: mocks.initializeLocale }));
+vi.mock('@services/bootstrap/background-services.ts', () => ({
+  createBackgroundServices: mocks.createBackgroundServices,
+}));
+vi.mock('@services/conversations/background/handlers', () => ({
+  registerConversationHandlers: mocks.registerConversationHandlers,
+}));
+vi.mock('@services/sync/background-handlers', () => ({ registerSyncHandlers: mocks.registerSyncHandlers }));
+vi.mock('@collectors/web/article-fetch-background-handlers', () => ({
+  registerWebArticleHandlers: mocks.registerWebArticleHandlers,
+}));
+vi.mock('@collectors/chatgpt/chatgpt-deep-research-background-handlers', () => ({
+  registerChatgptDeepResearchHandlers: mocks.registerChatgptDeepResearchHandlers,
+}));
+vi.mock('@platform/messaging/ui-background-handlers', () => ({
+  registerUiMessageHandlers: mocks.registerUiMessageHandlers,
+}));
+vi.mock('@services/comments/background/handlers', () => ({
+  registerArticleCommentsHandlers: mocks.registerArticleCommentsHandlers,
+}));
+vi.mock('@services/integrations/item-mention/background-handlers', () => ({
+  registerItemMentionHandlers: mocks.registerItemMentionHandlers,
+}));
+vi.mock('@services/integrations/chatwith/chatwith-background-handlers', () => ({
+  registerChatWithBackgroundHandlers: mocks.registerChatWithBackgroundHandlers,
+}));
+vi.mock('@services/sync/notion/settings-background-handlers', () => ({
+  registerNotionSettingsHandlers: mocks.registerNotionSettingsHandlers,
+}));
+vi.mock('@services/sync/obsidian/settings-background-handlers', () => ({
+  registerObsidianSettingsHandlers: mocks.registerObsidianSettingsHandlers,
+}));
+vi.mock('@services/sync/feishu/settings-background-handlers', () => ({
+  registerFeishuSettingsHandlers: mocks.registerFeishuSettingsHandlers,
+}));
+vi.mock('@services/sync/notion/auth/oauth', () => ({
+  ensureDefaultNotionOAuthClientId: mocks.ensureDefaultNotionOAuthClientId,
+  setupNotionOAuthNavigationListener: mocks.setupNotionOAuthNavigationListener,
+}));
+vi.mock('@services/sync/feishu/auth/oauth', () => ({
+  ensureDefaultFeishuOAuthClientId: mocks.ensureDefaultFeishuOAuthClientId,
+  ensureDefaultFeishuOAuthProxyUrl: mocks.ensureDefaultFeishuOAuthProxyUrl,
+  setupFeishuOAuthNavigationListener: mocks.setupFeishuOAuthNavigationListener,
+}));
+vi.mock('@services/sync/obsidian/obsidian-sync-job-store.ts', () => ({
+  default: { abortRunningJobIfFromOtherInstance: mocks.obsidianAbort },
+}));
+vi.mock('@services/sync/feishu/feishu-sync-job-store.ts', () => ({
+  default: { abortRunningJobIfFromOtherInstance: mocks.feishuAbort },
+}));
+vi.mock('@platform/runtime/runtime', () => ({ onInstalled: mocks.onInstalled }));
+vi.mock('@platform/webext/extension-app', () => ({ openOrFocusExtensionAppTab: mocks.openOrFocusExtensionAppTab }));
+vi.mock('@platform/context-menus/clipper-context-menu', () => ({
+  registerClipperContextMenu: mocks.registerClipperContextMenu,
+}));
+vi.mock('@platform/alarms/alarms', () => ({ onAlarm: mocks.onAlarm }));
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function createServices() {
+  return {
+    autoSync: {
+      onConversationChanged: vi.fn(),
+      handleAlarm: vi.fn(),
+      notionScheduler: { flush: vi.fn().mockResolvedValue(undefined) },
+      obsidianScheduler: { flush: vi.fn().mockResolvedValue(undefined) },
+      feishuScheduler: { flush: vi.fn().mockResolvedValue(undefined) },
+    },
+    notionSyncJobStore: { abortRunningJobIfFromOtherInstance: vi.fn().mockResolvedValue(undefined) },
+    conversationKinds: {},
+    notionSyncOrchestrator: {},
+    obsidianSyncOrchestrator: { testConnection: vi.fn() },
+    feishuSyncOrchestrator: {},
+  };
+}
+
+async function flushMicrotasks() {
+  for (let i = 0; i < 6; i += 1) await Promise.resolve();
+}
+
+async function loadBackground() {
+  let callback: (() => unknown) | null = null;
+  vi.stubGlobal('defineBackground', (next: () => unknown) => {
+    callback = next;
+    return next;
+  });
+  await import('../../src/entrypoints/background.ts');
+  if (!callback) throw new Error('background callback was not registered');
+  return callback;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  mocks.ensureDefaultNotionOAuthClientId.mockResolvedValue(undefined);
+  mocks.ensureDefaultFeishuOAuthClientId.mockResolvedValue(undefined);
+  mocks.ensureDefaultFeishuOAuthProxyUrl.mockResolvedValue(undefined);
+  mocks.obsidianAbort.mockResolvedValue(undefined);
+  mocks.feishuAbort.mockResolvedValue(undefined);
+  mocks.createBackgroundServices.mockReturnValue(createServices());
+  // @ts-expect-error test global cleanup
+  delete globalThis.browser;
+  // @ts-expect-error test global cleanup
+  delete globalThis.chrome;
+});
+
+describe('background entrypoint cold start', () => {
+  it('registers runtime and browser listeners before locale readiness settles', async () => {
+    const locale = deferred<void>();
+    mocks.initializeLocale.mockReturnValue(locale.promise);
+
+    let runtimeMessageListener: ((msg: any, sender: any, sendResponse: any) => boolean) | null = null;
+    const onMessageAddListener = vi.fn((listener: any) => {
+      runtimeMessageListener = listener;
+    });
+    const onConnectAddListener = vi.fn();
+    // @ts-expect-error test global
+    globalThis.chrome = {
+      runtime: {
+        onMessage: { addListener: onMessageAddListener },
+        onConnect: { addListener: onConnectAddListener },
+      },
+    };
+
+    const callback = await loadBackground();
+    expect(callback()).toBeUndefined();
+
+    expect(onMessageAddListener).toHaveBeenCalledTimes(1);
+    expect(onConnectAddListener).toHaveBeenCalledTimes(1);
+    expect(mocks.setupNotionOAuthNavigationListener).toHaveBeenCalledTimes(1);
+    expect(mocks.setupFeishuOAuthNavigationListener).toHaveBeenCalledTimes(1);
+    expect(mocks.registerClipperContextMenu).toHaveBeenCalledTimes(1);
+    expect(mocks.onInstalled).toHaveBeenCalledTimes(1);
+    expect(mocks.onAlarm).toHaveBeenCalledTimes(1);
+    expect(mocks.registerUiMessageHandlers.mock.calls[0]?.[1]?.localeReady).toBe(locale.promise);
+    expect(mocks.registerClipperContextMenu.mock.calls[0]?.[0]?.localeReady).toBe(locale.promise);
+
+    const sendResponse = vi.fn();
+    expect(runtimeMessageListener).not.toBeNull();
+    expect(runtimeMessageListener?.({ type: 'cold-start-probe' }, null, sendResponse)).toBe(true);
+    await flushMicrotasks();
+    expect(sendResponse).toHaveBeenCalledWith({
+      ok: false,
+      data: null,
+      error: { message: 'unknown message type: cold-start-probe', extra: null },
+    });
+  });
+
+  it('isolates optional listener registration failures from sibling listeners', async () => {
+    const locale = deferred<void>();
+    mocks.initializeLocale.mockReturnValue(locale.promise);
+    mocks.setupNotionOAuthNavigationListener.mockImplementationOnce(() => {
+      throw new Error('notion listener failed');
+    });
+
+    const onMessageAddListener = vi.fn();
+    const onConnectAddListener = vi.fn();
+    // @ts-expect-error test global
+    globalThis.chrome = {
+      runtime: {
+        onMessage: { addListener: onMessageAddListener },
+        onConnect: { addListener: onConnectAddListener },
+      },
+    };
+
+    const callback = await loadBackground();
+    expect(() => callback()).not.toThrow();
+
+    expect(onMessageAddListener).toHaveBeenCalledTimes(1);
+    expect(mocks.setupFeishuOAuthNavigationListener).toHaveBeenCalledTimes(1);
+    expect(mocks.registerClipperContextMenu).toHaveBeenCalledTimes(1);
+    expect(mocks.onInstalled).toHaveBeenCalledTimes(1);
+    expect(mocks.onAlarm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/smoke/clipper-context-menu-save-title.test.ts
+++ b/tests/smoke/clipper-context-menu-save-title.test.ts
@@ -11,7 +11,22 @@ import {
   unregisterClipperContextMenu,
 } from '../../src/platform/context-menus/clipper-context-menu';
 
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushMicrotasks() {
+  for (let i = 0; i < 12; i += 1) await Promise.resolve();
+}
+
 function createMenusApi() {
+  const onClickedListeners: Array<(info: any, tab: any) => void> = [];
   const onShownListeners: Array<(info: any, tab: any) => void> = [];
 
   const api = {
@@ -19,11 +34,18 @@ function createMenusApi() {
     update: vi.fn(),
     removeAll: vi.fn((cb: any) => cb?.()),
     refresh: vi.fn(),
-    onClicked: { addListener: vi.fn() },
+    onClicked: {
+      addListener: vi.fn((cb: any) => {
+        onClickedListeners.push(cb);
+      }),
+    },
     onShown: {
       addListener: vi.fn((cb: any) => {
         onShownListeners.push(cb);
       }),
+    },
+    __emitClicked: (menuItemId: string) => {
+      for (const cb of onClickedListeners) cb({ menuItemId }, null);
     },
     __emitShown: (tab: any) => {
       for (const cb of onShownListeners) cb({ menuIds: ['syncnos_clipper_root'] }, tab);
@@ -67,10 +89,84 @@ describe('clipper context menu save title', () => {
     registerClipperContextMenu();
     menusApi.__emitShown({ id: 7, url: 'https://chatgpt.com/c/123' });
 
-    await new Promise((r) => setTimeout(r, 0));
+    await flushMicrotasks();
 
     expect(menusApi.update).toHaveBeenCalledWith('syncnos_clipper_save_current_page', {
       title: 'Save current AI chat',
     });
+  });
+
+  it('registers listeners synchronously while localized menu work waits for locale readiness', async () => {
+    const menusApi = createMenusApi();
+    const locale = deferred<void>();
+    const storageSet = vi.fn((_value: any, cb: any) => cb?.());
+    const removeStorageListener = vi.fn();
+
+    // @ts-expect-error test global
+    globalThis.chrome = {
+      contextMenus: menusApi,
+      tabs: {
+        query: vi.fn((_query: any, cb: any) => cb([{ id: 7, url: 'https://chatgpt.com/c/123' }])),
+      },
+      storage: {
+        local: {
+          get: vi.fn((_keys: any, cb: any) => cb({})),
+          set: storageSet,
+        },
+        onChanged: {
+          addListener: vi.fn(),
+          removeListener: removeStorageListener,
+        },
+      },
+    };
+
+    registerClipperContextMenu({ localeReady: locale.promise });
+
+    expect(menusApi.onClicked.addListener).toHaveBeenCalledTimes(1);
+    expect(menusApi.onShown.addListener).toHaveBeenCalledTimes(1);
+    expect(menusApi.create).not.toHaveBeenCalled();
+
+    menusApi.__emitClicked('syncnos_clipper_mode_off');
+    expect(storageSet).toHaveBeenCalledWith({ inpage_display_mode: 'off' }, expect.any(Function));
+
+    menusApi.__emitShown({ id: 7, url: 'https://chatgpt.com/c/123' });
+    await flushMicrotasks();
+    expect(tabsSendMessage).not.toHaveBeenCalled();
+
+    locale.resolve();
+    await flushMicrotasks();
+
+    expect(menusApi.create).toHaveBeenCalled();
+    expect(tabsSendMessage).toHaveBeenCalled();
+    expect(menusApi.refresh).toHaveBeenCalled();
+
+    unregisterClipperContextMenu();
+    expect(removeStorageListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back after locale readiness rejects instead of permanently blocking menus', async () => {
+    const menusApi = createMenusApi();
+    const locale = deferred<void>();
+
+    // @ts-expect-error test global
+    globalThis.chrome = {
+      contextMenus: menusApi,
+      storage: {
+        local: {
+          get: vi.fn((_keys: any, cb: any) => cb({})),
+          set: vi.fn((_value: any, cb: any) => cb?.()),
+        },
+        onChanged: {
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+        },
+      },
+    };
+
+    registerClipperContextMenu({ localeReady: locale.promise });
+    locale.reject(new Error('locale failed'));
+    await flushMicrotasks();
+
+    expect(menusApi.create).toHaveBeenCalled();
   });
 });

--- a/tests/smoke/content-entrypoint-listener-readiness.test.ts
+++ b/tests/smoke/content-entrypoint-listener-readiness.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  initializeLocale: vi.fn(),
+  startContentBootstrap: vi.fn(),
+  createContentController: vi.fn(),
+  createItemMentionController: vi.fn(),
+  createRuntimeClient: vi.fn(() => ({})),
+  createCollectorEnv: vi.fn(() => ({})),
+  createCollectorsRegistry: vi.fn(() => ({})),
+  registerAllCollectors: vi.fn(),
+  createCurrentPageCaptureService: vi.fn(() => ({})),
+  createVideoTranscriptCaptureService: vi.fn(() => ({})),
+  createInpageCommentsDomSource: vi.fn(() => ({
+    resolveComposerSelection: () => ({ selectionText: '', locator: null }),
+    isTopFrame: () => true,
+    readPageUrl: () => 'https://example.com/',
+  })),
+  getInpageCommentsPanelApi: vi.fn(() => ({
+    attachHost: () => ({ dispose: () => {} }),
+  })),
+}));
+
+vi.mock('@i18n', () => ({ initializeLocale: mocks.initializeLocale }));
+vi.mock('@services/bootstrap/content.ts', () => ({ startContentBootstrap: mocks.startContentBootstrap }));
+vi.mock('@services/bootstrap/content-controller.ts', () => ({
+  createContentController: mocks.createContentController,
+}));
+vi.mock('@services/integrations/item-mention/content/mention-controller', () => ({
+  createItemMentionController: mocks.createItemMentionController,
+}));
+vi.mock('@platform/runtime/client.ts', () => ({ createRuntimeClient: mocks.createRuntimeClient }));
+vi.mock('@collectors/collector-env.ts', () => ({ createCollectorEnv: mocks.createCollectorEnv }));
+vi.mock('@collectors/registry.ts', () => ({ createCollectorsRegistry: mocks.createCollectorsRegistry }));
+vi.mock('@collectors/register-all.ts', () => ({ registerAllCollectors: mocks.registerAllCollectors }));
+vi.mock('@services/bootstrap/current-page-capture.ts', () => ({
+  createCurrentPageCaptureService: mocks.createCurrentPageCaptureService,
+}));
+vi.mock('@services/bootstrap/video-transcript-capture', () => ({
+  createVideoTranscriptCaptureService: mocks.createVideoTranscriptCaptureService,
+}));
+vi.mock('@ui/inpage/inpage-comments-panel-shadow.ts', () => ({
+  createInpageCommentsDomSource: mocks.createInpageCommentsDomSource,
+  getInpageCommentsPanelApi: mocks.getInpageCommentsPanelApi,
+}));
+vi.mock('@ui/inpage/inpage-button-shadow.ts', () => ({ inpageButtonApi: {} }));
+vi.mock('@ui/inpage/inpage-item-mention-shadow.ts', () => ({ inpageItemMentionApi: {} }));
+vi.mock('@ui/inpage/inpage-tip-shadow.ts', () => ({ inpageTipApi: {} }));
+vi.mock('@collectors/runtime-observer.ts', () => ({ default: {} }));
+vi.mock('@services/conversations/content/incremental-updater.ts', () => ({ default: {} }));
+vi.mock('@services/shared/normalize.ts', () => ({ default: {} }));
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushMicrotasks() {
+  for (let i = 0; i < 8; i += 1) await Promise.resolve();
+}
+
+async function loadContentMain() {
+  let main: (() => Promise<void> | void) | null = null;
+  vi.stubGlobal('defineContentScript', (config: { main: () => Promise<void> | void }) => {
+    main = config.main;
+    return config;
+  });
+  await import('../../src/entrypoints/content.ts');
+  if (!main) throw new Error('content main was not registered');
+  return main;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  mocks.createContentController.mockReturnValue({});
+  mocks.createItemMentionController.mockReturnValue({});
+  vi.stubGlobal('window', {} as Window);
+  vi.stubGlobal('document', {} as Document);
+  vi.stubGlobal('location', { hostname: 'example.com' } as Location);
+  // @ts-expect-error test global cleanup
+  delete globalThis.browser;
+  // @ts-expect-error test global cleanup
+  delete globalThis.chrome;
+});
+
+describe('content entrypoint listener readiness', () => {
+  it('registers content message listeners before locale readiness settles', async () => {
+    const locale = deferred<void>();
+    mocks.initializeLocale.mockReturnValue(locale.promise);
+
+    const addListener = vi.fn();
+    // @ts-expect-error test global
+    globalThis.chrome = {
+      runtime: {
+        onMessage: {
+          addListener,
+          removeListener: vi.fn(),
+        },
+      },
+    };
+
+    const main = await loadContentMain();
+    const started = Promise.resolve(main());
+    await flushMicrotasks();
+
+    expect(addListener).toHaveBeenCalledTimes(4);
+    expect(mocks.startContentBootstrap).not.toHaveBeenCalled();
+    expect(mocks.createContentController).not.toHaveBeenCalled();
+
+    locale.resolve();
+    await started;
+    expect(mocks.startContentBootstrap).toHaveBeenCalledTimes(1);
+    expect(mocks.createContentController).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/smoke/content-message-locale-readiness.test.ts
+++ b/tests/smoke/content-message-locale-readiness.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const openPanel = vi.hoisted(() => vi.fn(async () => {}));
+const extractWebArticleFromCurrentPage = vi.hoisted(() => vi.fn(async () => ({ title: 'Article' })));
+
+vi.mock('@services/comments/sidebar/article-comments-sidebar-controller', () => ({
+  createArticleCommentsSidebarController: () => ({
+    open: openPanel,
+    dispose: vi.fn(),
+  }),
+}));
+
+vi.mock('@collectors/web/article-extract/engine', () => ({
+  extractWebArticleFromCurrentPage,
+}));
+
+import { CONTENT_MESSAGE_TYPES } from '../../src/platform/messaging/message-contracts';
+import { registerInpageCommentsPanelContentHandlers } from '../../src/services/bootstrap/inpage-comments-panel-content-handlers';
+import { registerVideoTranscriptCaptureContentHandlers } from '../../src/services/bootstrap/video-transcript-capture-content-handlers';
+import { registerWebArticleExtractContentHandlers } from '../../src/services/bootstrap/web-article-extract-content-handlers';
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function waitFor(predicate: () => boolean) {
+  for (let i = 0; i < 20; i += 1) {
+    if (predicate()) return;
+    await Promise.resolve();
+  }
+}
+
+function installRuntime() {
+  const listeners: Array<(msg: any, sender: any, sendResponse: any) => unknown> = [];
+  const addListener = vi.fn((listener: any) => {
+    listeners.push(listener);
+  });
+  // @ts-expect-error test global
+  globalThis.chrome = {
+    runtime: {
+      onMessage: {
+        addListener,
+        removeListener: vi.fn(),
+      },
+    },
+  };
+  return {
+    addListener,
+    emit(msg: any) {
+      let response: any = null;
+      let returned: unknown;
+      for (const listener of listeners) {
+        const next = listener(msg, {}, (value: any) => {
+          response = value;
+        });
+        if (next !== undefined) returned = next;
+      }
+      return { returned, getResponse: () => response };
+    },
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  // @ts-expect-error test global cleanup
+  delete globalThis.chrome;
+});
+
+describe('content message locale readiness', () => {
+  it('keeps video listener registered while localized tip work waits for locale', async () => {
+    const locale = deferred<void>();
+    const runtime = installRuntime();
+    const captureVideoTranscript = vi.fn(async () => ({ title: 'Talk', isNew: true, subtitleStatus: 'ok' }));
+    const showSaveTip = vi.fn();
+
+    registerVideoTranscriptCaptureContentHandlers(
+      { captureVideoTranscript } as any,
+      { inpageTip: { showSaveTip }, localeReady: locale.promise },
+    );
+
+    expect(runtime.addListener).toHaveBeenCalledTimes(1);
+    const pending = runtime.emit({
+      type: CONTENT_MESSAGE_TYPES.CAPTURE_VIDEO_TRANSCRIPT,
+      payload: { source: 'contextmenu' },
+    });
+    expect(pending.returned).toBe(true);
+    for (let i = 0; i < 8; i += 1) await Promise.resolve();
+    expect(captureVideoTranscript).not.toHaveBeenCalled();
+    expect(showSaveTip).not.toHaveBeenCalled();
+
+    locale.resolve();
+    await waitFor(() => pending.getResponse()?.ok === true);
+    expect(captureVideoTranscript).toHaveBeenCalledTimes(1);
+    expect(showSaveTip).toHaveBeenCalledWith('Fetching...', { kind: 'default' });
+    expect(pending.getResponse()?.ok).toBe(true);
+  });
+
+  it('continues video capture after locale readiness rejects', async () => {
+    const locale = deferred<void>();
+    const runtime = installRuntime();
+    const captureVideoTranscript = vi.fn(async () => ({ title: 'Talk', isNew: false, subtitleStatus: 'empty' }));
+    const showSaveTip = vi.fn();
+
+    registerVideoTranscriptCaptureContentHandlers(
+      { captureVideoTranscript } as any,
+      { inpageTip: { showSaveTip }, localeReady: locale.promise },
+    );
+
+    const pending = runtime.emit({
+      type: CONTENT_MESSAGE_TYPES.CAPTURE_VIDEO_TRANSCRIPT,
+      payload: { source: 'contextmenu' },
+    });
+    locale.reject(new Error('locale failed'));
+    await waitFor(() => pending.getResponse()?.ok === true);
+
+    expect(captureVideoTranscript).toHaveBeenCalledTimes(1);
+    expect(showSaveTip).toHaveBeenCalledWith('Fetching...', { kind: 'default' });
+    expect(showSaveTip).toHaveBeenCalledWith('No subtitles detected (not saved).', { kind: 'default' });
+    expect(pending.getResponse()?.ok).toBe(true);
+  });
+
+  it('keeps comments listener registered while panel open waits for locale', async () => {
+    const locale = deferred<void>();
+    const runtime = installRuntime();
+
+    registerInpageCommentsPanelContentHandlers(null, {
+      localeReady: locale.promise,
+      createPanelApi: () => ({ attachHost: () => ({ dispose: () => {} }) }),
+      domSource: {
+        resolveComposerSelection: () => ({ selectionText: '', locator: null }),
+        isTopFrame: () => true,
+        readPageUrl: () => 'https://example.com/article',
+      },
+    });
+
+    expect(runtime.addListener).toHaveBeenCalledTimes(1);
+    const pending = runtime.emit({
+      type: CONTENT_MESSAGE_TYPES.OPEN_INPAGE_COMMENTS_PANEL,
+      payload: { tabId: 7 },
+    });
+    expect(pending.returned).toBe(true);
+    for (let i = 0; i < 8; i += 1) await Promise.resolve();
+    expect(openPanel).not.toHaveBeenCalled();
+
+    locale.resolve();
+    await waitFor(() => pending.getResponse()?.ok === true);
+    expect(openPanel).toHaveBeenCalledTimes(1);
+    expect(pending.getResponse()).toEqual({ ok: true });
+  });
+
+  it('does not gate article extraction on locale readiness', async () => {
+    const locale = deferred<void>();
+    const runtime = installRuntime();
+
+    registerWebArticleExtractContentHandlers();
+    expect(runtime.addListener).toHaveBeenCalledTimes(1);
+
+    const pending = runtime.emit({
+      type: CONTENT_MESSAGE_TYPES.EXTRACT_WEB_ARTICLE,
+      payload: {},
+    });
+    expect(pending.returned).toBe(true);
+    await waitFor(() => pending.getResponse()?.ok === true);
+
+    expect(extractWebArticleFromCurrentPage).toHaveBeenCalledTimes(1);
+    expect(pending.getResponse()?.ok).toBe(true);
+    expect(locale.promise).toBeInstanceOf(Promise);
+  });
+});

--- a/tests/smoke/content-message-locale-readiness.test.ts
+++ b/tests/smoke/content-message-locale-readiness.test.ts
@@ -79,10 +79,10 @@ describe('content message locale readiness', () => {
     const captureVideoTranscript = vi.fn(async () => ({ title: 'Talk', isNew: true, subtitleStatus: 'ok' }));
     const showSaveTip = vi.fn();
 
-    registerVideoTranscriptCaptureContentHandlers(
-      { captureVideoTranscript } as any,
-      { inpageTip: { showSaveTip }, localeReady: locale.promise },
-    );
+    registerVideoTranscriptCaptureContentHandlers({ captureVideoTranscript } as any, {
+      inpageTip: { showSaveTip },
+      localeReady: locale.promise,
+    });
 
     expect(runtime.addListener).toHaveBeenCalledTimes(1);
     const pending = runtime.emit({
@@ -107,10 +107,10 @@ describe('content message locale readiness', () => {
     const captureVideoTranscript = vi.fn(async () => ({ title: 'Talk', isNew: false, subtitleStatus: 'empty' }));
     const showSaveTip = vi.fn();
 
-    registerVideoTranscriptCaptureContentHandlers(
-      { captureVideoTranscript } as any,
-      { inpageTip: { showSaveTip }, localeReady: locale.promise },
-    );
+    registerVideoTranscriptCaptureContentHandlers({ captureVideoTranscript } as any, {
+      inpageTip: { showSaveTip },
+      localeReady: locale.promise,
+    });
 
     const pending = runtime.emit({
       type: CONTENT_MESSAGE_TYPES.CAPTURE_VIDEO_TRANSCRIPT,

--- a/tests/smoke/current-page-capture-content-handlers.test.ts
+++ b/tests/smoke/current-page-capture-content-handlers.test.ts
@@ -2,6 +2,23 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { registerCurrentPageCaptureContentHandlers } from '@services/bootstrap/current-page-capture-content-handlers';
 
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function waitFor(predicate: () => boolean) {
+  for (let i = 0; i < 20; i += 1) {
+    if (predicate()) return;
+    await Promise.resolve();
+  }
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
   // @ts-expect-error test global cleanup
@@ -61,5 +78,88 @@ describe('current-page-capture content handlers', () => {
     expect(showSaveTip).toHaveBeenCalledWith('Saved: Hello', { kind: 'default' });
     expect(response?.ok).toBe(true);
     expect(response?.data).toEqual({ title: 'Hello' });
+  });
+
+  it('registers capture listeners immediately and waits for locale before service work', async () => {
+    const locale = deferred<void>();
+    let registeredListener: any = null;
+    const addListener = vi.fn((listener: any) => {
+      registeredListener = listener;
+    });
+
+    // @ts-expect-error test global
+    globalThis.chrome = {
+      runtime: {
+        onMessage: {
+          addListener,
+          removeListener: vi.fn(),
+        },
+      },
+    };
+
+    const getCurrentPageCaptureState = vi.fn(async () => ({ available: true }));
+    const captureCurrentPage = vi.fn(async () => ({ title: 'Hello' }));
+
+    registerCurrentPageCaptureContentHandlers(
+      {
+        getCurrentPageCaptureState,
+        captureCurrentPage,
+      } as any,
+      { localeReady: locale.promise },
+    );
+
+    expect(addListener).toHaveBeenCalledTimes(1);
+
+    let stateResponse: any = null;
+    expect(
+      registeredListener?.({ type: 'getCurrentPageCaptureState' }, {}, (value: any) => {
+        stateResponse = value;
+      }),
+    ).toBe(true);
+    for (let i = 0; i < 8; i += 1) await Promise.resolve();
+    expect(getCurrentPageCaptureState).not.toHaveBeenCalled();
+
+    locale.resolve();
+    await waitFor(() => stateResponse?.ok === true);
+    expect(getCurrentPageCaptureState).toHaveBeenCalledTimes(1);
+    expect(stateResponse?.ok).toBe(true);
+    expect(stateResponse?.data).toEqual({ available: true });
+  });
+
+  it('continues current-page work after locale readiness rejects', async () => {
+    const locale = deferred<void>();
+    let registeredListener: any = null;
+
+    // @ts-expect-error test global
+    globalThis.chrome = {
+      runtime: {
+        onMessage: {
+          addListener: vi.fn((listener: any) => {
+            registeredListener = listener;
+          }),
+          removeListener: vi.fn(),
+        },
+      },
+    };
+
+    const captureCurrentPage = vi.fn(async () => ({ title: 'Fallback' }));
+    registerCurrentPageCaptureContentHandlers(
+      {
+        getCurrentPageCaptureState: vi.fn(),
+        captureCurrentPage,
+      } as any,
+      { localeReady: locale.promise },
+    );
+
+    let response: any = null;
+    registeredListener?.({ type: 'captureCurrentPage', payload: { source: 'popup' } }, {}, (value: any) => {
+      response = value;
+    });
+    locale.reject(new Error('locale failed'));
+    await waitFor(() => response?.ok === true);
+
+    expect(captureCurrentPage).toHaveBeenCalledTimes(1);
+    expect(response?.ok).toBe(true);
+    expect(response?.data).toEqual({ title: 'Fallback' });
   });
 });

--- a/tests/smoke/ui-background-handlers-locale-readiness.test.ts
+++ b/tests/smoke/ui-background-handlers-locale-readiness.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/platform/webext/tabs', () => ({
+  tabsQuery: vi.fn(),
+  tabsSendMessage: vi.fn(),
+}));
+
+import { UI_MESSAGE_TYPES } from '../../src/platform/messaging/message-contracts';
+import { tabsQuery, tabsSendMessage } from '../../src/platform/webext/tabs';
+import { registerUiMessageHandlers } from '../../src/platform/messaging/ui-background-handlers';
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function createRouter() {
+  const handlers = new Map<string, (msg?: any, sender?: any) => Promise<any> | any>();
+  return {
+    handlers,
+    router: {
+      ok: (data: unknown) => ({ ok: true, data, error: null }),
+      err: (message: string, extra?: unknown) => ({ ok: false, data: null, error: { message, extra: extra ?? null } }),
+      register: vi.fn((type: string, handler: (msg?: any, sender?: any) => Promise<any> | any) => {
+        handlers.set(type, handler);
+      }),
+    },
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  // @ts-expect-error test global cleanup
+  delete globalThis.chrome;
+});
+
+describe('UI background handler locale readiness', () => {
+  it('registers every UI message synchronously while current-page work waits for locale', async () => {
+    const locale = deferred<void>();
+    const { router, handlers } = createRouter();
+    vi.mocked(tabsQuery).mockResolvedValue([{ id: 7, url: 'https://example.com/' }] as any);
+    vi.mocked(tabsSendMessage).mockResolvedValue({ ok: true, data: { available: true }, error: null } as any);
+
+    registerUiMessageHandlers(router, { localeReady: locale.promise });
+
+    expect([...handlers.keys()].sort()).toEqual(Object.values(UI_MESSAGE_TYPES).sort());
+
+    const responsePromise = handlers.get(UI_MESSAGE_TYPES.GET_ACTIVE_TAB_CAPTURE_STATE)?.();
+    await flushMicrotasks();
+    expect(tabsQuery).not.toHaveBeenCalled();
+    expect(tabsSendMessage).not.toHaveBeenCalled();
+
+    locale.resolve();
+    await expect(responsePromise).resolves.toEqual({ ok: true, data: { available: true }, error: null });
+    expect(tabsQuery).toHaveBeenCalledTimes(1);
+    expect(tabsSendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues current-page handling after locale readiness rejects', async () => {
+    const locale = deferred<void>();
+    const { router, handlers } = createRouter();
+    vi.mocked(tabsQuery).mockResolvedValue([{ id: 7, url: 'https://example.com/' }] as any);
+    vi.mocked(tabsSendMessage).mockResolvedValue({ ok: true, data: { captured: true }, error: null } as any);
+
+    registerUiMessageHandlers(router, { localeReady: locale.promise });
+    const responsePromise = handlers.get(UI_MESSAGE_TYPES.CAPTURE_ACTIVE_TAB_CURRENT_PAGE)?.();
+
+    locale.reject(new Error('locale failed'));
+    await expect(responsePromise).resolves.toEqual({ ok: true, data: { captured: true }, error: null });
+    expect(tabsQuery).toHaveBeenCalledTimes(1);
+    expect(tabsSendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not gate popup or comments handlers on locale readiness', async () => {
+    const locale = deferred<void>();
+    const { router, handlers } = createRouter();
+    const openPopup = vi.fn().mockResolvedValue(undefined);
+    // @ts-expect-error test global
+    globalThis.chrome = { action: { openPopup } };
+    vi.mocked(tabsSendMessage).mockResolvedValue(null as any);
+
+    registerUiMessageHandlers(router, { localeReady: locale.promise });
+
+    await expect(handlers.get(UI_MESSAGE_TYPES.OPEN_EXTENSION_POPUP)?.()).resolves.toEqual({
+      ok: true,
+      data: { opened: true },
+      error: null,
+    });
+    await expect(
+      handlers.get(UI_MESSAGE_TYPES.OPEN_CURRENT_TAB_INPAGE_COMMENTS_PANEL)?.({ tabId: 7 }, null),
+    ).resolves.toEqual({ ok: true, data: { opened: true }, error: null });
+
+    expect(openPopup).toHaveBeenCalledTimes(1);
+    expect(tabsSendMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -60,7 +60,7 @@ const resolveManifest: UserManifestFn = (env) => {
 
   return {
     name: isSafari ? '__MSG_name__' : '__MSG_extName__',
-    version: '1.9.4',
+    version: '1.9.5',
     description: isSafari ? '__MSG_description__' : '__MSG_extDescription__',
     default_locale: 'en',
     permissions,


### PR DESCRIPTION
## 变更说明

修复扩展消息通信中的生命周期问题，避免因 listener 注册时机、content script 注入时机等原因导致偶发连接失败。

## 主要改动

- 区分不同类型的连接错误：
  - content → background 冷启动导致的接收端缺失
  - background → content 尚未注入
  - message port 已建立后关闭
  - extension context 失效
- 收窄 `receiving end does not exist` 重试范围，避免使用 retry 掩盖真实生命周期问题。
- 调整 background 初始化流程：
  - 提前注册 message handlers
  - 避免等待 locale 初始化阻塞消息监听
  - 优化启动阶段的可选 listener 注册和异常隔离
- 调整 content script 初始化流程：
  - listener 优先注册
  - locale 初始化改为异步等待，不阻塞消息接收
- 优化 context menu、页面捕获、评论面板等模块对 locale 初始化的依赖处理。

## 目的

提升扩展消息通信稳定性，减少页面首次打开、导航刷新、background cold start 等场景下的偶发失败。