### PR TITLE
fix:左侧会话列表灰色边缘

### DIFF
--- a/src/ui/conversations/ConversationListPane.tsx
+++ b/src/ui/conversations/ConversationListPane.tsx
@@ -620,7 +620,7 @@ export function ConversationListPane({
     <div className="tw-flex tw-min-h-0 tw-flex-1 tw-flex-col">
       <div
         ref={scrollRef}
-        className="route-scroll webclipper-detail-route-scroll tw-relative tw-min-h-0 tw-flex-1 tw-overflow-auto tw-overflow-x-hidden"
+        className="route-scroll tw-relative tw-min-h-0 tw-flex-1 tw-overflow-auto tw-overflow-x-hidden"
         onScroll={() => onListScrollTopChange?.(scrollRef.current?.scrollTop || 0)}
       >
         <div className="tw-grid tw-gap-2 tw-p-3">

--- a/src/ui/conversations/ConversationListPane.tsx
+++ b/src/ui/conversations/ConversationListPane.tsx
@@ -620,7 +620,7 @@ export function ConversationListPane({
     <div className="tw-flex tw-min-h-0 tw-flex-1 tw-flex-col">
       <div
         ref={scrollRef}
-        className="route-scroll tw-relative tw-min-h-0 tw-flex-1 tw-overflow-auto tw-overflow-x-hidden"
+        className="route-scroll webclipper-detail-route-scroll tw-relative tw-min-h-0 tw-flex-1 tw-overflow-auto tw-overflow-x-hidden"
         onScroll={() => onListScrollTopChange?.(scrollRef.current?.scrollTop || 0)}
       >
         <div className="tw-grid tw-gap-2 tw-p-3">

--- a/src/ui/conversations/ConversationsScene.tsx
+++ b/src/ui/conversations/ConversationsScene.tsx
@@ -16,7 +16,6 @@ import { ConversationListPane } from '@ui/conversations/ConversationListPane';
 import { ArticleCommentsSection } from '@ui/conversations/ArticleCommentsSection';
 import { useConversationsApp } from '@viewmodels/conversations/conversations-context';
 import { consumePendingOpenConversation } from '@ui/conversations/pending-open';
-import { columnDividerRightClassName } from '@ui/shared/column-styles';
 import { CapturedListPaneShell } from '@ui/shared/CapturedListPaneShell';
 import { conversationKinds } from '@services/protocols/conversation-kinds';
 
@@ -206,12 +205,7 @@ export function ConversationsScene({
   return (
     <div className={wideContainerClassName}>
       {wideHideList ? null : (
-        <aside
-          className={[
-            'tw-flex tw-min-h-0 tw-w-[min(360px,40%)] tw-min-w-[320px] tw-flex-col tw-bg-[var(--bg-primary)]',
-            columnDividerRightClassName(),
-          ].join(' ')}
-        >
+        <aside className="tw-flex tw-min-h-0 tw-w-[min(360px,40%)] tw-min-w-[320px] tw-flex-col tw-bg-[var(--bg-primary)]">
           {list}
         </aside>
       )}

--- a/src/ui/shared/column-styles.ts
+++ b/src/ui/shared/column-styles.ts
@@ -1,7 +1,0 @@
-export function columnDividerRightClassName(): string {
-  return 'tw-border-r tw-border-solid tw-border-[var(--border)]';
-}
-
-export function columnDividerLeftClassName(): string {
-  return 'tw-border-l tw-border-solid tw-border-[var(--border)]';
-}


### PR DESCRIPTION
# 左侧会话列表灰色边缘

## 问题

独立 App 标签页的左侧会话列表右边出现一条细长灰线；Chrome 与 Zen 均可复现，Popup 正常。

## 排查结论

- 这不是列表背景未覆盖，也不是滚动条：运行时盒模型命中左栏 `<aside>`，其背景为 `rgb(250, 251, 252)`。
- 灰线来自该元素的 `tw-border-r tw-border-[var(--border)]`；`--border` 在 light 主题下为灰色。
- 隐藏列表滚动条无法影响该边框，已回退这项错误改动。

## 解决

移除会话场景左栏的右边框，并删除仅为该边框存在、已无消费者的 `column-styles.ts`。

## 验证

- `npm run compile`
- 关联会话场景与列表分页用例（10 项）
- `npm run build`
