### PR TITLE
Refine detail header actions and Notion dark mode support

### DIFF
--- a/src/services/integrations/detail-header-actions.ts
+++ b/src/services/integrations/detail-header-actions.ts
@@ -2,6 +2,11 @@ import type { Conversation, ConversationDetail } from '@services/conversations/d
 import { t } from '@i18n';
 import { writeTextToClipboard } from '@services/shared/clipboard';
 import { formatConversationMarkdownForExternalOutput } from '@services/integrations/chatwith/chatwith-settings';
+import {
+  prioritizeDetailHeaderCopyLinkActions,
+  readLastDetailHeaderCopyLinkActionId,
+  rememberDetailHeaderCopyLinkAction,
+} from '@services/integrations/detail-header-copy-link-preference';
 import { launchObsidianApp } from '@services/sync/obsidian/obsidian-app-launch';
 import type { DetailHeaderAction, DetailHeaderActionPort } from '@services/integrations/detail-header-action-types';
 import { openExternalUrl } from '@services/integrations/open-external-url';
@@ -77,7 +82,7 @@ function buildDetailUtilityActions({
   ];
 }
 
-function buildCopyLinkActions(openActions: DetailHeaderAction[]): DetailHeaderAction[] {
+async function buildCopyLinkActions(openActions: DetailHeaderAction[]): Promise<DetailHeaderAction[]> {
   const copyTargets = {
     notion: { id: 'copy-notion-link', label: t('detailHeaderCopyNotionLink') },
     feishu: { id: 'copy-feishu-link', label: t('detailHeaderCopyFeishuLink') },
@@ -106,7 +111,14 @@ function buildCopyLinkActions(openActions: DetailHeaderAction[]): DetailHeaderAc
     });
   }
 
-  return actions;
+  const preferredActionId = await readLastDetailHeaderCopyLinkActionId();
+  return prioritizeDetailHeaderCopyLinkActions(actions, preferredActionId).map((action) => ({
+    ...action,
+    onTrigger: async () => {
+      await rememberDetailHeaderCopyLinkAction(action.id);
+      await action.onTrigger();
+    },
+  }));
 }
 
 export async function resolveDetailHeaderActions({
@@ -115,9 +127,6 @@ export async function resolveDetailHeaderActions({
   port = defaultDetailHeaderActionPort,
 }: ResolveDetailHeaderActionsInput): Promise<DetailHeaderAction[]> {
   const openActions = await resolveOpenInDetailHeaderActions({ conversation, port });
-  return [
-    ...openActions,
-    ...buildCopyLinkActions(openActions),
-    ...buildDetailUtilityActions({ conversation, detail, port }),
-  ];
+  const copyActions = await buildCopyLinkActions(openActions);
+  return [...openActions, ...copyActions, ...buildDetailUtilityActions({ conversation, detail, port })];
 }

--- a/src/services/integrations/detail-header-copy-link-preference.ts
+++ b/src/services/integrations/detail-header-copy-link-preference.ts
@@ -1,0 +1,36 @@
+import type { DetailHeaderAction } from '@services/integrations/detail-header-action-types';
+import { storageGet, storageSet } from '@services/shared/storage';
+
+export const DETAIL_HEADER_COPY_LINK_ACTION_STORAGE_KEY = 'webclipper_detail_header_last_copy_link_action_v1';
+
+function normalizeActionId(value: unknown): string {
+  return String(value || '').trim();
+}
+
+export async function readLastDetailHeaderCopyLinkActionId(): Promise<string> {
+  try {
+    const values = await storageGet([DETAIL_HEADER_COPY_LINK_ACTION_STORAGE_KEY]);
+    return normalizeActionId(values?.[DETAIL_HEADER_COPY_LINK_ACTION_STORAGE_KEY]);
+  } catch (_error) {
+    return '';
+  }
+}
+
+export async function rememberDetailHeaderCopyLinkAction(actionId: string): Promise<void> {
+  const normalizedActionId = normalizeActionId(actionId);
+  if (!normalizedActionId) return;
+  try {
+    await storageSet({ [DETAIL_HEADER_COPY_LINK_ACTION_STORAGE_KEY]: normalizedActionId });
+  } catch (_error) {
+    // 记忆失败不应阻断用户已选择的复制操作。
+  }
+}
+
+export function prioritizeDetailHeaderCopyLinkActions(
+  actions: DetailHeaderAction[],
+  preferredActionId: string,
+): DetailHeaderAction[] {
+  const preferredIndex = actions.findIndex((action) => action.id === preferredActionId);
+  if (preferredIndex <= 0) return actions;
+  return [actions[preferredIndex]!, ...actions.slice(0, preferredIndex), ...actions.slice(preferredIndex + 1)];
+}

--- a/src/ui/conversations/ConversationDetailPane.tsx
+++ b/src/ui/conversations/ConversationDetailPane.tsx
@@ -63,6 +63,7 @@ export function ConversationDetailPane({
   const openActions = safeActions.filter((action) => action.slot === 'open');
   const copyActions = safeActions.filter((action) => action.slot === 'copy');
   const toolActions = safeActions.filter((action) => action.slot === 'tools');
+  const moreActions = [...openActions, ...toolActions];
   const copyActionScopeKey = JSON.stringify([
     Number((selected as any)?.id ?? activeId) || 0,
     copyActions.map((action) => [action.id, String(action.href || '')]),
@@ -183,7 +184,7 @@ export function ConversationDetailPane({
       ? `${wordCountLabel} ${Math.max(0, Math.floor(wordCount)).toLocaleString()}`
       : '';
   const hasReaderMoreMenuContent = readerFeatures.textLayout || readerFeatures.theme || readerFeatures.narration;
-  const hasMoreMenuContent = Boolean(wordCountText) || toolActions.length > 0 || hasReaderMoreMenuContent;
+  const hasMoreMenuContent = Boolean(wordCountText) || moreActions.length > 0 || hasReaderMoreMenuContent;
   const moreMenuPanelClassName = 'tw-w-[214px] tw-max-w-[min(214px,calc(100vw-28px))] tw-text-[var(--text-primary)]';
   const closeMoreMenu = useCallback(() => {
     setMoreMenuOpen(false);
@@ -396,15 +397,6 @@ export function ConversationDetailPane({
           </div>
           <div className="tw-flex tw-shrink-0 tw-items-center tw-justify-end tw-gap-2 tw-whitespace-nowrap">
             <DetailHeaderActionBar
-              actions={openActions}
-              buttonClassName={headerIconButtonClass}
-              menuTriggerLabel={t('detailHeaderOpenInMenuLabel')}
-              menuTriggerAriaLabel={t('detailHeaderOpenInMenuAria')}
-              menuAriaLabel={t('detailHeaderOpenInMenuAria')}
-              className="tw-order-1"
-            />
-
-            <DetailHeaderActionBar
               key={copyActionScopeKey}
               actions={copyActions}
               buttonClassName={headerIconButtonClass}
@@ -412,7 +404,7 @@ export function ConversationDetailPane({
               menuTriggerLabel={t('detailHeaderCopyLinkMenuLabel')}
               menuTriggerAriaLabel={t('detailHeaderCopyLinkMenuAria')}
               menuAriaLabel={t('detailHeaderCopyLinkMenuAria')}
-              className="tw-order-2"
+              className="tw-order-1"
             />
 
             {canOpenCommentsSidebar ? (
@@ -421,7 +413,7 @@ export function ConversationDetailPane({
                 onClick={() => {
                   onTriggerCommentsSidebar?.();
                 }}
-                className={[headerButtonClassName(), 'tw-order-3'].join(' ')}
+                className={[headerButtonClassName(), 'tw-order-2'].join(' ')}
                 aria-label={commentsSidebarLabel}
                 {...tooltipAttrs(commentsSidebarLabel)}
                 aria-pressed={commentsSidebarOpen ? 'true' : 'false'}
@@ -449,7 +441,7 @@ export function ConversationDetailPane({
                 align="end"
                 panelMinWidth={214}
                 panelClassName={moreMenuPanelClassName}
-                className="tw-order-4"
+                className="tw-order-3"
                 trigger={(triggerProps) => (
                   <button
                     {...triggerProps}
@@ -472,7 +464,7 @@ export function ConversationDetailPane({
                       />
                     ) : null}
 
-                    {toolActions.length ? (
+                    {moreActions.length ? (
                       <div
                         className={[
                           hasReaderMoreMenuContent ? 'tw-border-t tw-border-[var(--border)] tw-pt-1' : '',
@@ -482,7 +474,7 @@ export function ConversationDetailPane({
                           .join(' ')}
                       >
                         <DetailHeaderActionBar
-                          actions={toolActions}
+                          actions={moreActions}
                           buttonClassName={buttonMenuItemClassName()}
                           inlineMenuItems
                           closeMenuOnActionTrigger={closeMoreMenu}
@@ -494,7 +486,7 @@ export function ConversationDetailPane({
                     {wordCountText ? (
                       <div
                         className={[
-                          hasReaderMoreMenuContent || toolActions.length
+                          hasReaderMoreMenuContent || moreActions.length
                             ? 'tw-border-t tw-border-[var(--border)] tw-pt-1'
                             : '',
                           'tw-px-2 tw-py-1 tw-text-[11px] tw-font-semibold tw-text-[var(--text-secondary)]',

--- a/src/ui/conversations/ConversationDetailPane.tsx
+++ b/src/ui/conversations/ConversationDetailPane.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, Link, MoreHorizontal } from 'lucide-react';
+import { ChevronLeft, MoreHorizontal } from 'lucide-react';
 
 import { ChatDetailView } from '@ui/conversations/views/ChatDetailView';
 import { ArticleReaderView } from '@ui/conversations/views/ArticleReaderView';
@@ -400,7 +400,6 @@ export function ConversationDetailPane({
               key={copyActionScopeKey}
               actions={copyActions}
               buttonClassName={headerIconButtonClass}
-              triggerIcon={<Link size={16} strokeWidth={2} aria-hidden="true" />}
               menuTriggerLabel={t('detailHeaderCopyLinkMenuLabel')}
               menuTriggerAriaLabel={t('detailHeaderCopyLinkMenuAria')}
               menuAriaLabel={t('detailHeaderCopyLinkMenuAria')}

--- a/src/ui/conversations/DetailHeaderActionBar.tsx
+++ b/src/ui/conversations/DetailHeaderActionBar.tsx
@@ -25,7 +25,7 @@ const PROVIDER_LOGO_SRC: Record<string, string> = {
   feishu: '/icons/feishu.svg',
 };
 
-function providerLogo(action: DetailHeaderAction, className = 'tw-h-4 tw-w-4 tw-shrink-0 tw-object-contain') {
+function providerLogo(action: DetailHeaderAction) {
   const src = PROVIDER_LOGO_SRC[action.provider];
   if (!src) return null;
   return (
@@ -33,7 +33,7 @@ function providerLogo(action: DetailHeaderAction, className = 'tw-h-4 tw-w-4 tw-
       src={src}
       alt=""
       aria-hidden="true"
-      className={className}
+      className="tw-h-4 tw-w-4 tw-shrink-0 tw-object-contain"
       data-provider-logo={action.provider}
     />
   );
@@ -103,20 +103,6 @@ export function DetailHeaderActionBar({
     return <ImageDown size={16} strokeWidth={2} aria-hidden="true" />;
   };
 
-  const renderPrimaryIcon = (action: DetailHeaderAction, icon: ReactNode) => {
-    const badge = triggerIcon ? providerLogo(action, 'tw-h-[8px] tw-w-[8px] tw-object-contain') : null;
-    return (
-      <span className="tw-relative tw-inline-flex tw-items-center tw-justify-center">
-        {icon}
-        {badge ? (
-          <span className="tw-absolute tw-bottom-0 tw-right-0 tw-flex tw-h-3 tw-w-3 tw-items-center tw-justify-center tw-rounded-[var(--radius-inline)] tw-border tw-border-[var(--border)] tw-bg-[var(--bg-card)]">
-            {badge}
-          </span>
-        ) : null}
-      </span>
-    );
-  };
-
   if (inlineMenuItems) {
     return (
       <div className={['tw-flex tw-flex-col tw-gap-1', className || ''].join(' ').trim()}>
@@ -173,7 +159,7 @@ export function DetailHeaderActionBar({
           aria-disabled={action.disabled ? 'true' : undefined}
           disabled={busy || !!action.disabled}
         >
-          {renderPrimaryIcon(action, resolvedTriggerIcon)}
+          <span className="tw-inline-flex tw-items-center tw-justify-center">{resolvedTriggerIcon}</span>
         </button>
         {status}
       </div>
@@ -205,7 +191,7 @@ export function DetailHeaderActionBar({
           aria-disabled={primaryAction.disabled ? 'true' : undefined}
           disabled={busy || !!primaryAction.disabled}
         >
-          {renderPrimaryIcon(primaryAction, resolvedTriggerIcon)}
+          <span className="tw-inline-flex tw-items-center tw-justify-center">{resolvedTriggerIcon}</span>
         </button>
         <MenuPopover
           open={menuOpen}

--- a/src/ui/conversations/DetailHeaderActionBar.tsx
+++ b/src/ui/conversations/DetailHeaderActionBar.tsx
@@ -25,7 +25,7 @@ const PROVIDER_LOGO_SRC: Record<string, string> = {
   feishu: '/icons/feishu.svg',
 };
 
-function providerLogo(action: DetailHeaderAction) {
+function providerLogo(action: DetailHeaderAction, className = 'tw-h-4 tw-w-4 tw-shrink-0 tw-object-contain') {
   const src = PROVIDER_LOGO_SRC[action.provider];
   if (!src) return null;
   return (
@@ -33,7 +33,7 @@ function providerLogo(action: DetailHeaderAction) {
       src={src}
       alt=""
       aria-hidden="true"
-      className="tw-h-4 tw-w-4 tw-shrink-0 tw-object-contain"
+      className={className}
       data-provider-logo={action.provider}
     />
   );
@@ -103,6 +103,20 @@ export function DetailHeaderActionBar({
     return <ImageDown size={16} strokeWidth={2} aria-hidden="true" />;
   };
 
+  const renderPrimaryIcon = (action: DetailHeaderAction, icon: ReactNode) => {
+    const badge = triggerIcon ? providerLogo(action, 'tw-h-[8px] tw-w-[8px] tw-object-contain') : null;
+    return (
+      <span className="tw-relative tw-inline-flex tw-items-center tw-justify-center">
+        {icon}
+        {badge ? (
+          <span className="tw-absolute tw-bottom-0 tw-right-0 tw-flex tw-h-3 tw-w-3 tw-items-center tw-justify-center tw-rounded-[var(--radius-inline)] tw-border tw-border-[var(--border)] tw-bg-[var(--bg-card)]">
+            {badge}
+          </span>
+        ) : null}
+      </span>
+    );
+  };
+
   if (inlineMenuItems) {
     return (
       <div className={['tw-flex tw-flex-col tw-gap-1', className || ''].join(' ').trim()}>
@@ -159,7 +173,7 @@ export function DetailHeaderActionBar({
           aria-disabled={action.disabled ? 'true' : undefined}
           disabled={busy || !!action.disabled}
         >
-          <span className="tw-inline-flex tw-items-center tw-justify-center">{resolvedTriggerIcon}</span>
+          {renderPrimaryIcon(action, resolvedTriggerIcon)}
         </button>
         {status}
       </div>
@@ -191,7 +205,7 @@ export function DetailHeaderActionBar({
           aria-disabled={primaryAction.disabled ? 'true' : undefined}
           disabled={busy || !!primaryAction.disabled}
         >
-          <span className="tw-inline-flex tw-items-center tw-justify-center">{resolvedTriggerIcon}</span>
+          {renderPrimaryIcon(primaryAction, resolvedTriggerIcon)}
         </button>
         <MenuPopover
           open={menuOpen}

--- a/src/ui/conversations/DetailHeaderActionBar.tsx
+++ b/src/ui/conversations/DetailHeaderActionBar.tsx
@@ -52,6 +52,7 @@ export function DetailHeaderActionBar({
 }: DetailHeaderActionBarProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [primaryActionId, setPrimaryActionId] = useState('');
   const [labelOverride, setLabelOverride] = useState<string>('');
   const labelResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -60,6 +61,7 @@ export function DetailHeaderActionBar({
     if (labelResetTimerRef.current != null) globalThis.clearTimeout(labelResetTimerRef.current);
     labelResetTimerRef.current = null;
     setLabelOverride('');
+    setPrimaryActionId(action.id);
     setBusy(true);
     try {
       await action.onTrigger();
@@ -93,6 +95,8 @@ export function DetailHeaderActionBar({
   if (!actions.length) return null;
 
   const resolveInlineActionIcon = (action: DetailHeaderAction) => {
+    const logo = providerLogo(action);
+    if (logo) return logo;
     if (action.kind === 'copy-text') return <Copy size={16} strokeWidth={2} aria-hidden="true" />;
     if (action.provider === 'source' && action.kind === 'external-link')
       return <ExternalLink size={16} strokeWidth={2} aria-hidden="true" />;
@@ -162,7 +166,10 @@ export function DetailHeaderActionBar({
     );
   }
 
-  const resolvedTriggerIcon = triggerIcon || <ExternalLink size={16} strokeWidth={2} aria-hidden="true" />;
+  const primaryAction = actions.find((action) => action.id === primaryActionId) || actions[0]!;
+  const resolvedTriggerIcon = triggerIcon || providerLogo(primaryAction) || (
+    <ExternalLink size={16} strokeWidth={2} aria-hidden="true" />
+  );
   const resolvedMenuTriggerLabel = String(menuTriggerLabel || '').trim() || 'Open in...';
   const resolvedMenuTriggerAriaLabel = String(menuTriggerAriaLabel || '').trim() || 'Open destinations';
   const resolvedMenuAriaLabel = String(menuAriaLabel || '').trim() || resolvedMenuTriggerAriaLabel;
@@ -170,54 +177,69 @@ export function DetailHeaderActionBar({
 
   return (
     <div className={['tw-relative tw-flex tw-items-center tw-gap-2', className || ''].join(' ').trim()}>
-      <MenuPopover
-        open={menuOpen}
-        onOpenChange={setMenuOpen}
-        disabled={busy}
-        ariaLabel={resolvedMenuAriaLabel}
-        side="bottom"
-        align="end"
-        panelMinWidth={170}
-        trigger={(triggerProps) => (
-          <button
-            {...triggerProps}
-            {...tooltipAttrs(resolvedMenuTriggerLabel)}
-            aria-label={resolvedMenuTriggerAriaLabel}
-            className={buttonClassName}
-          >
-            <span className="tw-inline-flex tw-items-center tw-justify-center tw-gap-0.5">
-              {resolvedTriggerIcon}
+      <div className="detail-header-split-button">
+        <button
+          key={primaryAction.id}
+          type="button"
+          {...tooltipAttrs(primaryAction.label)}
+          onClick={() => {
+            void handleTrigger(primaryAction);
+            closeMenuOnActionTrigger?.();
+          }}
+          className={buttonClassName}
+          aria-label={primaryAction.label}
+          aria-disabled={primaryAction.disabled ? 'true' : undefined}
+          disabled={busy || !!primaryAction.disabled}
+        >
+          <span className="tw-inline-flex tw-items-center tw-justify-center">{resolvedTriggerIcon}</span>
+        </button>
+        <MenuPopover
+          open={menuOpen}
+          onOpenChange={setMenuOpen}
+          disabled={busy}
+          ariaLabel={resolvedMenuAriaLabel}
+          side="bottom"
+          align="end"
+          panelMinWidth={170}
+          className="detail-header-split-button__menu"
+          trigger={(triggerProps) => (
+            <button
+              {...triggerProps}
+              {...tooltipAttrs(resolvedMenuTriggerLabel)}
+              aria-label={resolvedMenuTriggerAriaLabel}
+              className={buttonClassName}
+            >
               <span
                 className="tw-w-[10px] tw-text-center tw-text-[10px] tw-font-black tw-leading-none tw-text-[var(--text-secondary)]"
                 aria-hidden="true"
               >
                 ▾
               </span>
-            </span>
-          </button>
-        )}
-      >
-        {actions.map((action) => (
-          <button
-            key={action.id}
-            className={menuButtonClass}
-            type="button"
-            role="menuitem"
-            onClick={() => {
-              void handleTrigger(action);
-              setMenuOpen(false);
-              closeMenuOnActionTrigger?.();
-            }}
-            aria-disabled={action.disabled ? 'true' : undefined}
-            disabled={busy || !!action.disabled}
-          >
-            <span className="tw-inline-flex tw-items-center tw-gap-1.5">
-              {providerLogo(action)}
-              <span className="tw-whitespace-normal tw-break-words">{action.label}</span>
-            </span>
-          </button>
-        ))}
-      </MenuPopover>
+            </button>
+          )}
+        >
+          {actions.map((action) => (
+            <button
+              key={action.id}
+              className={menuButtonClass}
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                void handleTrigger(action);
+                setMenuOpen(false);
+                closeMenuOnActionTrigger?.();
+              }}
+              aria-disabled={action.disabled ? 'true' : undefined}
+              disabled={busy || !!action.disabled}
+            >
+              <span className="tw-inline-flex tw-items-center tw-gap-1.5">
+                {providerLogo(action)}
+                <span className="tw-whitespace-normal tw-break-words">{action.label}</span>
+              </span>
+            </button>
+          ))}
+        </MenuPopover>
+      </div>
       {status}
     </div>
   );

--- a/src/ui/conversations/DetailHeaderActionBar.tsx
+++ b/src/ui/conversations/DetailHeaderActionBar.tsx
@@ -185,7 +185,15 @@ export function DetailHeaderActionBar({
             aria-label={resolvedMenuTriggerAriaLabel}
             className={buttonClassName}
           >
-            <span className="tw-inline-flex tw-items-center tw-justify-center">{resolvedTriggerIcon}</span>
+            <span className="tw-inline-flex tw-items-center tw-justify-center tw-gap-0.5">
+              {resolvedTriggerIcon}
+              <span
+                className="tw-w-[10px] tw-text-center tw-text-[10px] tw-font-black tw-leading-none tw-text-[var(--text-secondary)]"
+                aria-hidden="true"
+              >
+                ▾
+              </span>
+            </span>
           </button>
         )}
       >

--- a/src/ui/conversations/DetailHeaderActionBar.tsx
+++ b/src/ui/conversations/DetailHeaderActionBar.tsx
@@ -32,7 +32,12 @@ function providerLogo(action: DetailHeaderAction) {
       src={src}
       alt=""
       aria-hidden="true"
-      className="tw-h-4 tw-w-4 tw-shrink-0 tw-object-contain"
+      className={[
+        'tw-h-4 tw-w-4 tw-shrink-0 tw-object-contain',
+        action.provider === 'notion' ? 'webclipper-provider-logo--notion' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
       data-provider-logo={action.provider}
     />
   );

--- a/src/ui/conversations/DetailHeaderActionBar.tsx
+++ b/src/ui/conversations/DetailHeaderActionBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Copy, ExternalLink, ImageDown } from 'lucide-react';
 
 import type { DetailHeaderAction } from '@services/integrations/detail-header-actions';
@@ -12,7 +12,6 @@ export type DetailHeaderActionBarProps = {
   buttonClassName: string;
   closeMenuOnActionTrigger?: () => void;
   inlineMenuItems?: boolean;
-  triggerIcon?: ReactNode;
   menuTriggerLabel?: string;
   menuTriggerAriaLabel?: string;
   menuAriaLabel?: string;
@@ -44,7 +43,6 @@ export function DetailHeaderActionBar({
   buttonClassName,
   closeMenuOnActionTrigger,
   inlineMenuItems = false,
-  triggerIcon,
   menuTriggerLabel,
   menuTriggerAriaLabel,
   menuAriaLabel,
@@ -141,7 +139,7 @@ export function DetailHeaderActionBar({
   ) : null;
   if (actions.length === 1) {
     const action = actions[0]!;
-    const resolvedTriggerIcon = triggerIcon || providerLogo(action) || (
+    const resolvedTriggerIcon = providerLogo(action) || (
       <ExternalLink size={16} strokeWidth={2} aria-hidden="true" />
     );
     return (
@@ -167,7 +165,7 @@ export function DetailHeaderActionBar({
   }
 
   const primaryAction = actions.find((action) => action.id === primaryActionId) || actions[0]!;
-  const resolvedTriggerIcon = triggerIcon || providerLogo(primaryAction) || (
+  const resolvedTriggerIcon = providerLogo(primaryAction) || (
     <ExternalLink size={16} strokeWidth={2} aria-hidden="true" />
   );
   const resolvedMenuTriggerLabel = String(menuTriggerLabel || '').trim() || 'Open in...';

--- a/src/ui/i18n/locales/en.ts
+++ b/src/ui/i18n/locales/en.ts
@@ -508,8 +508,6 @@ export const en = {
   // DetailHeaderActionBar
   detailHeaderChatWithMenuLabel: 'Chat with...',
   detailHeaderChatWithMenuAria: 'Chat with',
-  detailHeaderOpenInMenuLabel: 'Open in...',
-  detailHeaderOpenInMenuAria: 'Open destinations',
   detailHeaderOpenInNotion: 'Open in Notion',
   detailHeaderOpenInObsidian: 'Open in Obsidian',
   detailHeaderOpenInFeishu: 'Open in Feishu',

--- a/src/ui/i18n/locales/zh.ts
+++ b/src/ui/i18n/locales/zh.ts
@@ -504,8 +504,6 @@ export const zh: { [K in TranslationKey]: string } = {
   // DetailHeaderActionBar
   detailHeaderChatWithMenuLabel: 'Chat with...',
   detailHeaderChatWithMenuAria: 'Chat with',
-  detailHeaderOpenInMenuLabel: '打开到...',
-  detailHeaderOpenInMenuAria: '打开目录',
   detailHeaderOpenInNotion: '在 Notion 中打开',
   detailHeaderOpenInObsidian: '在 Obsidian 中打开',
   detailHeaderOpenInFeishu: '在飞书中打开',

--- a/src/ui/settings/sections/NotionOAuthSection.tsx
+++ b/src/ui/settings/sections/NotionOAuthSection.tsx
@@ -75,7 +75,12 @@ export function NotionOAuthSection(props: {
   return (
     <section className={cardClassName} aria-label={t('notionOAuth')}>
       <div className="tw-flex tw-items-center tw-gap-2">
-        <img className="tw-h-5 tw-w-5 tw-shrink-0" src={notionLogoUrl} alt="" aria-hidden="true" />
+        <img
+          className="webclipper-provider-logo--notion tw-h-5 tw-w-5 tw-shrink-0"
+          src={notionLogoUrl}
+          alt=""
+          aria-hidden="true"
+        />
         <div className="tw-min-w-0 tw-flex-1 tw-text-[var(--text-primary)]">
           <span className="tw-text-base tw-font-extrabold">{t('notionOAuth')}</span>
           <span className="tw-mx-2 tw-text-[var(--text-secondary)]" aria-hidden="true">

--- a/src/ui/styles/buttons.css
+++ b/src/ui/styles/buttons.css
@@ -192,6 +192,7 @@
 }
 
 .detail-header-split-button__menu > .webclipper-btn {
+  width: 28px;
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
 }

--- a/src/ui/styles/buttons.css
+++ b/src/ui/styles/buttons.css
@@ -177,6 +177,25 @@
   color: var(--text-primary);
 }
 
+.detail-header-split-button {
+  display: inline-flex;
+  align-items: stretch;
+}
+
+.detail-header-split-button > .webclipper-btn {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.detail-header-split-button__menu {
+  margin-left: -1px;
+}
+
+.detail-header-split-button__menu > .webclipper-btn {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
 .webclipper-btn--icon-sm {
   --btn-icon-size: 32px;
 }

--- a/src/ui/styles/buttons.css
+++ b/src/ui/styles/buttons.css
@@ -197,6 +197,17 @@
   border-bottom-left-radius: 0;
 }
 
+[data-theme-mode='dark'] .webclipper-provider-logo--notion,
+[data-theme-mode='black'] .webclipper-provider-logo--notion {
+  filter: invert(1);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme-mode]) .webclipper-provider-logo--notion {
+    filter: invert(1);
+  }
+}
+
 .webclipper-btn--icon-sm {
   --btn-icon-size: 32px;
 }

--- a/tests/smoke/app-detail-header-actions.test.ts
+++ b/tests/smoke/app-detail-header-actions.test.ts
@@ -236,7 +236,6 @@ describe('ConversationDetailPane header actions', () => {
     expect(copyButton).toBeTruthy();
     expect(copyButton?.closest('.tw-order-1')).toBeTruthy();
     expect(copyButton?.querySelector('.lucide-link')).toBeTruthy();
-    expect(copyButton?.querySelector('[data-provider-logo="notion"]')?.getAttribute('src')).toBe('/icons/notion.svg');
     expect(copyButton?.querySelector('.lucide-copy')).toBeFalsy();
 
     await act(async () => {
@@ -314,8 +313,6 @@ describe('ConversationDetailPane header actions', () => {
     });
     expect(feishuCopy).toHaveBeenCalledTimes(1);
     expect(notionCopy).not.toHaveBeenCalled();
-    const selectedPrimary = document.querySelector('[aria-label="Copy Feishu link"]') as HTMLButtonElement | null;
-    expect(selectedPrimary?.querySelector('[data-provider-logo="feishu"]')?.getAttribute('src')).toBe('/icons/feishu.svg');
 
     await act(async () => {
       trigger!.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));

--- a/tests/smoke/app-detail-header-actions.test.ts
+++ b/tests/smoke/app-detail-header-actions.test.ts
@@ -236,6 +236,7 @@ describe('ConversationDetailPane header actions', () => {
     expect(copyButton).toBeTruthy();
     expect(copyButton?.closest('.tw-order-1')).toBeTruthy();
     expect(copyButton?.querySelector('.lucide-link')).toBeTruthy();
+    expect(copyButton?.querySelector('[data-provider-logo="notion"]')?.getAttribute('src')).toBe('/icons/notion.svg');
     expect(copyButton?.querySelector('.lucide-copy')).toBeFalsy();
 
     await act(async () => {
@@ -313,6 +314,8 @@ describe('ConversationDetailPane header actions', () => {
     });
     expect(feishuCopy).toHaveBeenCalledTimes(1);
     expect(notionCopy).not.toHaveBeenCalled();
+    const selectedPrimary = document.querySelector('[aria-label="Copy Feishu link"]') as HTMLButtonElement | null;
+    expect(selectedPrimary?.querySelector('[data-provider-logo="feishu"]')?.getAttribute('src')).toBe('/icons/feishu.svg');
 
     await act(async () => {
       trigger!.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));

--- a/tests/smoke/app-detail-header-actions.test.ts
+++ b/tests/smoke/app-detail-header-actions.test.ts
@@ -235,7 +235,7 @@ describe('ConversationDetailPane header actions', () => {
     expect(openButton).toBeFalsy();
     expect(copyButton).toBeTruthy();
     expect(copyButton?.closest('.tw-order-1')).toBeTruthy();
-    expect(copyButton?.querySelector('.lucide-link')).toBeTruthy();
+    expect(copyButton?.querySelector('[data-provider-logo="notion"]')?.getAttribute('src')).toBe('/icons/notion.svg');
     expect(copyButton?.querySelector('.lucide-copy')).toBeFalsy();
 
     await act(async () => {
@@ -302,7 +302,7 @@ describe('ConversationDetailPane header actions', () => {
     expect(menu).toBeTruthy();
     const items = Array.from(menu!.querySelectorAll('[role="menuitem"]')) as HTMLButtonElement[];
     expect(items.map((item) => item.textContent)).toEqual(['Copy Notion link', 'Copy Feishu link']);
-    expect(primaryButton?.querySelector('.lucide-link')).toBeTruthy();
+    expect(primaryButton?.querySelector('[data-provider-logo="notion"]')?.getAttribute('src')).toBe('/icons/notion.svg');
     expect(trigger?.textContent).toContain('▾');
     expect(items[0]?.querySelector('[data-provider-logo="notion"]')?.getAttribute('src')).toBe('/icons/notion.svg');
     expect(items[1]?.querySelector('[data-provider-logo="feishu"]')?.getAttribute('src')).toBe('/icons/feishu.svg');

--- a/tests/smoke/app-detail-header-actions.test.ts
+++ b/tests/smoke/app-detail-header-actions.test.ts
@@ -56,7 +56,6 @@ vi.mock('../../src/ui/i18n', () => ({
       noMessages: 'No messages',
       selectAConversation: 'Select a conversation',
       backButton: 'Back',
-      detailHeaderOpenInMenuAria: 'Open destinations',
       detailHeaderCopyLinkMenuLabel: 'Copy link',
       detailHeaderCopyLinkMenuAria: 'Copy destinations',
       copied: 'Copied',
@@ -175,7 +174,7 @@ describe('ConversationDetailPane header actions', () => {
     cleanupDom();
   });
 
-  it('shows Open in Notion in the app detail header when the action is available', () => {
+  it('moves Open in Notion into the More menu when the action is available', async () => {
     currentState.detailHeaderActions = [
       {
         id: 'open-in-notion',
@@ -192,6 +191,13 @@ describe('ConversationDetailPane header actions', () => {
       root!.render(createElement(ConversationDetailPane));
     });
 
+    expect(document.querySelector('[aria-label="Open in Notion"]')).toBeFalsy();
+    const moreButton = document.querySelector('[data-detail-header-more-trigger="true"]') as HTMLButtonElement | null;
+    expect(moreButton).toBeTruthy();
+    await act(async () => {
+      moreButton!.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
     expect(document.querySelector('[aria-label="Open in Notion"]')).toBeTruthy();
   });
 
@@ -226,11 +232,9 @@ describe('ConversationDetailPane header actions', () => {
 
     const openButton = document.querySelector('[aria-label="Open in Notion"]') as HTMLButtonElement | null;
     const copyButton = document.querySelector('[aria-label="Copy Notion link"]') as HTMLButtonElement | null;
-    expect(openButton).toBeTruthy();
+    expect(openButton).toBeFalsy();
     expect(copyButton).toBeTruthy();
-    expect(openButton?.closest('.tw-order-1')).toBeTruthy();
-    expect(copyButton?.closest('.tw-order-2')).toBeTruthy();
-    expect(openButton?.querySelector('[data-provider-logo="notion"]')?.getAttribute('src')).toBe('/icons/notion.svg');
+    expect(copyButton?.closest('.tw-order-1')).toBeTruthy();
     expect(copyButton?.querySelector('.lucide-link')).toBeTruthy();
     expect(copyButton?.querySelector('.lucide-copy')).toBeFalsy();
 
@@ -284,9 +288,11 @@ describe('ConversationDetailPane header actions', () => {
     });
 
     const trigger = document.querySelector('[aria-label="Copy destinations"]') as HTMLButtonElement | null;
+    const primaryButton = document.querySelector('[aria-label="Copy Notion link"]') as HTMLButtonElement | null;
     expect(trigger).toBeTruthy();
+    expect(primaryButton).toBeTruthy();
     expect(document.querySelectorAll('[aria-label="Copy destinations"][aria-haspopup="menu"]')).toHaveLength(1);
-    expect(trigger?.closest('.tw-order-2')).toBeTruthy();
+    expect(trigger?.closest('.tw-order-1')).toBeTruthy();
 
     await act(async () => {
       trigger!.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
@@ -296,7 +302,8 @@ describe('ConversationDetailPane header actions', () => {
     expect(menu).toBeTruthy();
     const items = Array.from(menu!.querySelectorAll('[role="menuitem"]')) as HTMLButtonElement[];
     expect(items.map((item) => item.textContent)).toEqual(['Copy Notion link', 'Copy Feishu link']);
-    expect(trigger?.querySelector('.lucide-link')).toBeTruthy();
+    expect(primaryButton?.querySelector('.lucide-link')).toBeTruthy();
+    expect(trigger?.textContent).toContain('▾');
     expect(items[0]?.querySelector('[data-provider-logo="notion"]')?.getAttribute('src')).toBe('/icons/notion.svg');
     expect(items[1]?.querySelector('[data-provider-logo="feishu"]')?.getAttribute('src')).toBe('/icons/feishu.svg');
 
@@ -421,7 +428,8 @@ describe('ConversationDetailPane header actions', () => {
     act(() => {
       root!.render(createElement(ConversationDetailPane));
     });
-    expect(document.querySelector('[aria-label="Open in Notion"]')).toBeTruthy();
+    expect(document.querySelector('[aria-label="Open in Notion"]')).toBeFalsy();
+    expect(document.querySelector('[data-detail-header-more-trigger="true"]')).toBeTruthy();
     expect(document.querySelector('[aria-label="Copy destinations"]')).toBeFalsy();
     expect(document.querySelector('[aria-label="Copy Notion link"]')).toBeFalsy();
   });
@@ -508,7 +516,7 @@ describe('ConversationDetailPane header actions', () => {
     expect(document.querySelector('[aria-label="Open in Notion"]')).toBeFalsy();
   });
 
-  it('shows a menu trigger in the app detail header when multiple destinations are available', () => {
+  it('shows multiple Open in destinations in the More menu', async () => {
     currentState.detailHeaderActions = [
       {
         id: 'open-in-notion',
@@ -533,8 +541,15 @@ describe('ConversationDetailPane header actions', () => {
       root!.render(createElement(ConversationDetailPane));
     });
 
-    expect(document.querySelector('[aria-label="Open destinations"]')).toBeTruthy();
-    expect(document.querySelector('[aria-label="Open in Notion"]')).toBeFalsy();
+    expect(document.querySelector('[aria-label="Open destinations"]')).toBeFalsy();
+    const moreButton = document.querySelector('[data-detail-header-more-trigger="true"]') as HTMLButtonElement | null;
+    expect(moreButton).toBeTruthy();
+    await act(async () => {
+      moreButton!.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+    expect(document.querySelector('[aria-label="Open in Notion"]')).toBeTruthy();
+    expect(document.querySelector('[aria-label="Open in Obsidian"]')).toBeTruthy();
   });
 
   it('shows Cache images for article detail when tools action is provided', async () => {
@@ -682,10 +697,10 @@ describe('ConversationDetailPane header actions', () => {
 
     const openBtn = document.querySelector('[aria-label="Comment"]') as HTMLButtonElement | null;
     expect(openBtn).toBeTruthy();
-    expect(openBtn?.className || '').toContain('tw-order-3');
+    expect(openBtn?.className || '').toContain('tw-order-2');
     const moreBtn = document.querySelector('[data-detail-header-more-trigger="true"]') as HTMLButtonElement | null;
     expect(moreBtn).toBeTruthy();
-    expect(moreBtn?.closest('.tw-order-4')).toBeTruthy();
+    expect(moreBtn?.closest('.tw-order-3')).toBeTruthy();
 
     act(() => {
       openBtn!.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));

--- a/tests/smoke/detail-header-action-menu.test.ts
+++ b/tests/smoke/detail-header-action-menu.test.ts
@@ -83,7 +83,9 @@ describe('DetailHeaderActionBar', () => {
     expect(button?.textContent).not.toContain('▾');
   });
 
-  it('renders a menu trigger when multiple destinations exist', () => {
+  it('renders a split button and promotes a selected menu action', async () => {
+    const notionTrigger = vi.fn(async () => {});
+    const obsidianTrigger = vi.fn(async () => {});
     act(() => {
       root!.render(
         createElement(DetailHeaderActionBar, {
@@ -95,7 +97,7 @@ describe('DetailHeaderActionBar', () => {
               kind: 'external-link',
               slot: 'open',
               href: 'https://app.notion.com/example',
-              onTrigger: vi.fn(async () => {}),
+              onTrigger: notionTrigger,
             },
             {
               id: 'open-in-obsidian',
@@ -103,7 +105,7 @@ describe('DetailHeaderActionBar', () => {
               provider: 'obsidian',
               kind: 'open-target',
               slot: 'open',
-              onTrigger: vi.fn(async () => {}),
+              onTrigger: obsidianTrigger,
             },
           ],
           buttonClassName,
@@ -112,9 +114,25 @@ describe('DetailHeaderActionBar', () => {
     });
 
     const trigger = document.querySelector('[aria-label="Open destinations"]') as HTMLButtonElement | null;
+    const primaryButton = document.querySelector('[aria-label="Open in Notion"]') as HTMLButtonElement | null;
     expect(trigger).toBeTruthy();
     expect(trigger?.textContent).toContain('▾');
-    expect(document.querySelector('[aria-label="Open in Notion"]')).toBeFalsy();
+    expect(primaryButton).toBeTruthy();
+    expect(trigger?.parentElement?.className || '').toContain('detail-header-split-button__menu');
+
+    await act(async () => {
+      trigger!.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+    const menuItems = Array.from(document.querySelectorAll('[role="menuitem"]')) as HTMLButtonElement[];
+    await act(async () => {
+      menuItems[1]!.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(obsidianTrigger).toHaveBeenCalledTimes(1);
+    expect(notionTrigger).not.toHaveBeenCalled();
+    expect(document.querySelector('[aria-label="Open in Obsidian"]')).toBeTruthy();
   });
 
   it('renders menu items as vertical flex buttons that can wrap text', async () => {

--- a/tests/smoke/detail-header-action-menu.test.ts
+++ b/tests/smoke/detail-header-action-menu.test.ts
@@ -80,6 +80,7 @@ describe('DetailHeaderActionBar', () => {
     expect(document.querySelector('[aria-label="Open destinations"]')).toBeFalsy();
     const logo = button?.querySelector('[data-provider-logo="notion"]') as HTMLImageElement | null;
     expect(logo?.getAttribute('src')).toBe('/icons/notion.svg');
+    expect(button?.textContent).not.toContain('▾');
   });
 
   it('renders a menu trigger when multiple destinations exist', () => {
@@ -110,7 +111,9 @@ describe('DetailHeaderActionBar', () => {
       );
     });
 
-    expect(document.querySelector('[aria-label="Open destinations"]')).toBeTruthy();
+    const trigger = document.querySelector('[aria-label="Open destinations"]') as HTMLButtonElement | null;
+    expect(trigger).toBeTruthy();
+    expect(trigger?.textContent).toContain('▾');
     expect(document.querySelector('[aria-label="Open in Notion"]')).toBeFalsy();
   });
 

--- a/tests/smoke/detail-header-action-menu.test.ts
+++ b/tests/smoke/detail-header-action-menu.test.ts
@@ -80,6 +80,7 @@ describe('DetailHeaderActionBar', () => {
     expect(document.querySelector('[aria-label="Open destinations"]')).toBeFalsy();
     const logo = button?.querySelector('[data-provider-logo="notion"]') as HTMLImageElement | null;
     expect(logo?.getAttribute('src')).toBe('/icons/notion.svg');
+    expect(logo?.className).toContain('webclipper-provider-logo--notion');
     expect(button?.textContent).not.toContain('▾');
   });
 

--- a/tests/smoke/detail-header-actions.test.ts
+++ b/tests/smoke/detail-header-actions.test.ts
@@ -5,6 +5,10 @@ const openObsidianTargetMock = vi.fn();
 const getSyncMappingByConversationMock = vi.fn();
 const writeTextToClipboardMock = vi.fn();
 const formatConversationMarkdownMock = vi.fn();
+const { storageGetMock, storageSetMock } = vi.hoisted(() => ({
+  storageGetMock: vi.fn(),
+  storageSetMock: vi.fn(),
+}));
 
 vi.mock('@services/integrations/openin/obsidian-open-target', () => ({
   resolveObsidianOpenTarget: (...args: any[]) => resolveObsidianOpenTargetMock(...args),
@@ -25,7 +29,13 @@ vi.mock('@services/integrations/chatwith/chatwith-settings', () => ({
   formatConversationMarkdownForExternalOutput: (...args: any[]) => formatConversationMarkdownMock(...args),
 }));
 
+vi.mock('@services/shared/storage', () => ({
+  storageGet: (...args: any[]) => storageGetMock(...args),
+  storageSet: (...args: any[]) => storageSetMock(...args),
+}));
+
 import { t } from '@i18n';
+import { DETAIL_HEADER_COPY_LINK_ACTION_STORAGE_KEY } from '@services/integrations/detail-header-copy-link-preference';
 import { DETAIL_HEADER_ACTION_LABELS, resolveDetailHeaderActions } from '@services/integrations/detail-header-actions';
 import { buildNotionPageUrl, normalizeNotionPageId } from '@services/integrations/openin/openin-detail-header-actions';
 
@@ -91,6 +101,10 @@ describe('detail-header-actions', () => {
     writeTextToClipboardMock.mockResolvedValue(true);
     formatConversationMarkdownMock.mockReset();
     formatConversationMarkdownMock.mockResolvedValue('# exact markdown\n');
+    storageGetMock.mockReset();
+    storageGetMock.mockResolvedValue({});
+    storageSetMock.mockReset();
+    storageSetMock.mockResolvedValue(undefined);
   });
 
   it('normalizes a hyphenated Notion page id into the canonical URL form', () => {
@@ -178,6 +192,7 @@ describe('detail-header-actions', () => {
   });
 
   it('keeps copy provider order stable when Notion and Feishu are both available', async () => {
+    storageGetMock.mockResolvedValue({ [DETAIL_HEADER_COPY_LINK_ACTION_STORAGE_KEY]: 'copy-removed-link' });
     const actions = await resolveDetailHeaderActions({
       conversation: {
         id: 4,
@@ -196,6 +211,26 @@ describe('detail-header-actions', () => {
     expect(bySlot(actions, 'copy').map((action) => action.provider)).toEqual(['notion', 'feishu']);
     expect(byId(actions, 'copy-notion-link')?.href).toBe(byId(actions, 'open-in-notion')?.href);
     expect(byId(actions, 'copy-feishu-link')?.href).toBe(byId(actions, 'open-in-feishu')?.href);
+  });
+
+  it('promotes and remembers the last selected copy target', async () => {
+    storageGetMock.mockResolvedValue({ [DETAIL_HEADER_COPY_LINK_ACTION_STORAGE_KEY]: 'copy-feishu-link' });
+    const actions = await resolveDetailHeaderActions({
+      conversation: {
+        id: 40,
+        source: 'chatgpt',
+        conversationKey: 'conv-40',
+        title: 'Conversation',
+        notionPageId: NOTION_PAGE_ID,
+        notionWorkspaceSlug: 'chiimagnus',
+        feishuDocId: 'doc-40',
+      },
+      port: createPort(),
+    });
+
+    expect(bySlot(actions, 'copy').map((action) => action.id)).toEqual(['copy-feishu-link', 'copy-notion-link']);
+    await byId(actions, 'copy-feishu-link')?.onTrigger();
+    expect(storageSetMock).toHaveBeenCalledWith({ [DETAIL_HEADER_COPY_LINK_ACTION_STORAGE_KEY]: 'copy-feishu-link' });
   });
 
   it('hydrates deep-link Notion and Feishu metadata with a single mapping read', async () => {


### PR DESCRIPTION
## Summary

- streamline detail header actions by moving **Open in** destinations into the More menu
- turn multi-target copy-link actions into a split button, with the selected target promoted to the primary action
- remember the last copy-link target so the preferred action is restored on subsequent use
- use provider logos consistently and adapt the Notion logo for dark, black, and system dark themes
- update related smoke tests and remove obsolete i18n entries

## UI behavior

- the primary copy-link action can be triggered directly
- the adjacent dropdown exposes the remaining copy-link targets
- choosing a target promotes it to the primary action and persists that preference
- Notion branding remains visible against dark backgrounds

## Tests

Updated smoke coverage for detail-header action rendering, menu behavior, action ordering, and persisted copy-link preferences.