### PR TITLE
Fix ChatGPT virtual conversation scanning and readiness check

### DIFF
--- a/src/collectors/chatgpt/chatgpt-collector.ts
+++ b/src/collectors/chatgpt/chatgpt-collector.ts
@@ -438,12 +438,16 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
 
   function isVisibleWindow(wrapper: any): boolean {
     try {
+      const virtualizer = wrapper?.closest?.('[data-is-intersecting]');
+      const intersecting = String(virtualizer?.getAttribute?.('data-is-intersecting') || '').trim();
+      if (intersecting === 'true') return true;
+      if (intersecting === 'false') return false;
       const rect = wrapper?.getBoundingClientRect?.();
       const top = Number(rect?.top);
       const bottom = Number(rect?.bottom);
       const height = Number(rect?.height);
       const viewportHeight = Number(env.window?.innerHeight);
-      // ponytail: 仅等待有布局盒的当前窗口；无布局盒的离屏壳由后续滚动触发渲染。
+      // ponytail: 优先沿用 ChatGPT 虚拟器的相交标记；没有标记时才按布局盒判断。
       return height > 0 && viewportHeight > 0 && bottom >= 0 && top <= viewportHeight;
     } catch (_error) {
       return false;
@@ -540,12 +544,10 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
     readScrollSeed: () => getConversationRoot(),
     readDescriptors: readCurrentDescriptors,
     readDescriptorKeys: () => readCurrentDescriptors().map((descriptor) => descriptor.key),
-    readUnresolvedKeys: () => {
-      const { descriptors, inputsByKey } = manualAdapter.readWindow();
-      return descriptors
-        .filter((descriptor) => descriptor.visible && (!descriptor.rendered || !inputsByKey.has(descriptor.key)))
-        .map((descriptor) => descriptor.turnKey);
-    },
+    readUnresolvedKeys: () =>
+      readCurrentDescriptors()
+        .filter((descriptor) => descriptor.visible && !descriptor.rendered)
+        .map((descriptor) => descriptor.key),
     readWindow: () => readCurrentManualWindow(true),
     getExtractionCount: () => manualExtractionCount,
   };

--- a/src/collectors/chatgpt/chatgpt-collector.ts
+++ b/src/collectors/chatgpt/chatgpt-collector.ts
@@ -300,6 +300,7 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
     fingerprint: string;
     hasDeepResearch: boolean;
     rendered: boolean;
+    visible: boolean;
   };
 
   type ChatgptExtractionInput = ChatgptDescriptor & {
@@ -435,6 +436,20 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
     return compactFingerprintPart(source);
   }
 
+  function isVisibleWindow(wrapper: any): boolean {
+    try {
+      const rect = wrapper?.getBoundingClientRect?.();
+      const top = Number(rect?.top);
+      const bottom = Number(rect?.bottom);
+      const height = Number(rect?.height);
+      const viewportHeight = Number(env.window?.innerHeight);
+      // ponytail: 仅等待有布局盒的当前窗口；无布局盒的离屏壳由后续滚动触发渲染。
+      return height > 0 && viewportHeight > 0 && bottom >= 0 && top <= viewportHeight;
+    } catch (_error) {
+      return false;
+    }
+  }
+
   function readCurrentManualWindow(includeInputs = false): {
     descriptors: ChatgptDescriptor[];
     inputsByKey: Map<string, ChatgptExtractionInput>;
@@ -465,6 +480,7 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
         fingerprint: descriptorFingerprint({ role, key, text, imageUrls, iframeUrl }),
         hasDeepResearch: !!iframe,
         rendered: !!text || imageUrls.length > 0 || !!iframe,
+        visible: isVisibleWindow(wrapper),
       };
       descriptors.push(descriptor);
       if (includeInputs) {
@@ -524,10 +540,12 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
     readScrollSeed: () => getConversationRoot(),
     readDescriptors: readCurrentDescriptors,
     readDescriptorKeys: () => readCurrentDescriptors().map((descriptor) => descriptor.key),
-    readUnresolvedKeys: () =>
-      readCurrentDescriptors()
-        .filter((descriptor) => !descriptor.rendered)
-        .map((descriptor) => descriptor.turnKey),
+    readUnresolvedKeys: () => {
+      const { descriptors, inputsByKey } = manualAdapter.readWindow();
+      return descriptors
+        .filter((descriptor) => descriptor.visible && (!descriptor.rendered || !inputsByKey.has(descriptor.key)))
+        .map((descriptor) => descriptor.turnKey);
+    },
     readWindow: () => readCurrentManualWindow(true),
     getExtractionCount: () => manualExtractionCount,
   };
@@ -631,7 +649,6 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
         },
         accumulator,
         {
-          maxPasses: options.maxPasses,
           totalDeadlineMs: options.totalDeadlineMs,
           maxSteps: options.maxSteps,
           stableSamples: options.stableSamples,

--- a/src/collectors/googleaistudio/googleaistudio-collector.ts
+++ b/src/collectors/googleaistudio/googleaistudio-collector.ts
@@ -567,7 +567,7 @@ export function createGoogleAiStudioCollectorDef(env: CollectorEnv): CollectorDe
           readUnresolvedKeys: () =>
             readCurrentDescriptors()
               .filter((descriptor) => !descriptor.rendered)
-              .map((descriptor) => descriptor.turnKey),
+              .map((descriptor) => descriptor.key),
           harvest: (target) => harvestManualInto(target, ctx),
         },
         accumulator,

--- a/src/collectors/googleaistudio/googleaistudio-collector.ts
+++ b/src/collectors/googleaistudio/googleaistudio-collector.ts
@@ -572,7 +572,6 @@ export function createGoogleAiStudioCollectorDef(env: CollectorEnv): CollectorDe
         },
         accumulator,
         {
-          maxPasses: options.maxPasses,
           totalDeadlineMs: options.totalDeadlineMs,
           maxSteps: options.maxSteps,
           stableSamples: options.stableSamples,

--- a/src/collectors/virtualized-chat/virtualized-chat-sweep.ts
+++ b/src/collectors/virtualized-chat/virtualized-chat-sweep.ts
@@ -414,6 +414,7 @@ export type VirtualizedPassAdapter<T> = {
   getScrollSeed: () => Element | null;
   sampleIdentity: () => string | null;
   readDescriptorKeys: () => string[];
+  // Unresolved entries must use the matching descriptor/message key, never a shared turn key.
   readUnresolvedKeys?: () => string[];
   harvest: (accumulator: PreparedAccumulator<T>) => Promise<{ added: number; updated: number }>;
 };
@@ -554,7 +555,6 @@ export async function runVirtualizedPass<T>(
   const clearResolvedKeys = () => {
     for (const record of accumulator.records) {
       unresolvedKeys.delete(record.key);
-      unresolvedKeys.delete(record.turnKey);
     }
   };
 

--- a/src/collectors/virtualized-chat/virtualized-chat-sweep.ts
+++ b/src/collectors/virtualized-chat/virtualized-chat-sweep.ts
@@ -218,7 +218,6 @@ const VIRTUALIZED_REASON_CODES = new Set([
   'order_conflict',
   'step_timeout',
   'step_budget_exhausted',
-  'pass_budget_exhausted',
   'total_deadline_exhausted',
   'unresolved_turn',
   'pass_failed',
@@ -452,7 +451,6 @@ const PASS_DEFAULTS = Object.freeze({
 });
 
 const SWEEP_DEFAULTS = Object.freeze({
-  maxPasses: 4,
   totalDeadlineMs: 30_000,
 });
 
@@ -537,17 +535,21 @@ export async function runVirtualizedPass<T>(
   let added = 0;
   let updated = 0;
   const unresolvedKeys = new Set<string>();
-  const sampleUnresolvedKeys = (): boolean => {
+  const readUnresolvedKeys = (): string[] | null => {
     try {
+      const output: string[] = [];
       for (const key of adapter.readUnresolvedKeys?.() || []) {
         const normalized = String(key || '').trim();
-        if (normalized) unresolvedKeys.add(normalized);
+        if (normalized) output.push(normalized);
       }
-      return true;
+      return output;
     } catch (_error) {
       addReason('pass_failed');
-      return false;
+      return null;
     }
+  };
+  const rememberUnresolvedKeys = (keys: string[]) => {
+    for (const key of keys) unresolvedKeys.add(key);
   };
   const clearResolvedKeys = () => {
     for (const record of accumulator.records) {
@@ -578,28 +580,32 @@ export async function runVirtualizedPass<T>(
     return true;
   };
 
-  const stabilize = async (): Promise<{ metrics: ScrollMetrics; keys: string[] } | null> => {
+  const stabilize = async (): Promise<{ metrics: ScrollMetrics; keys: string[]; unresolvedKeys: string[] } | null> => {
     const deadline = now() + stepTimeoutMs;
     let lastSignature = '';
     let stableCount = 0;
+    let latest: { metrics: ScrollMetrics; keys: string[]; unresolvedKeys: string[] } | null = null;
     while (now() <= deadline) {
       const metrics = readScrollMetrics(runtime, root);
       const keys = adapter
         .readDescriptorKeys()
         .map((key) => String(key || '').trim())
         .filter(Boolean);
+      const currentUnresolvedKeys = readUnresolvedKeys();
+      if (!currentUnresolvedKeys) return null;
+      latest = { metrics, keys, unresolvedKeys: currentUnresolvedKeys };
       const signature = contentFreeWindowSignature(originalIdentity, metrics, keys);
       if (signature === lastSignature) stableCount += 1;
       else {
         lastSignature = signature;
         stableCount = 1;
       }
-      if (stableCount >= stableSamples) return { metrics, keys };
+      if (stableCount >= stableSamples && !currentUnresolvedKeys.length) return latest;
       await sleep(pollMs);
       if (deadlineExceeded() || !validateAfterAwait()) return null;
     }
-    addReason('step_timeout');
-    return null;
+    if (latest && !latest.unresolvedKeys.length) addReason('step_timeout');
+    return latest;
   };
 
   try {
@@ -626,7 +632,7 @@ export async function runVirtualizedPass<T>(
         continue;
       }
       if (!hasOverlap && knownKeys.size) addReason('order_unanchored');
-      if (!sampleUnresolvedKeys()) break;
+      rememberUnresolvedKeys(stable.unresolvedKeys);
 
       if (deadlineExceeded()) break;
       const checkpoint = checkpointAccumulatorData(accumulator);
@@ -684,7 +690,6 @@ export async function runVirtualizedPass<T>(
 }
 
 export type VirtualizedSweepOptions = VirtualizedPassOptions & {
-  maxPasses?: number;
   totalDeadlineMs?: number;
 };
 
@@ -705,7 +710,6 @@ const INCOMPLETE_REASONS = new Set([
   'restore_failed',
   'step_timeout',
   'step_budget_exhausted',
-  'pass_budget_exhausted',
   'total_deadline_exhausted',
   'root_detached',
   'root_replaced',
@@ -727,20 +731,9 @@ export async function runVirtualizedSweep<T>(
   accumulator: PreparedAccumulator<T>,
   options: VirtualizedSweepOptions = {},
 ): Promise<VirtualizedSweepResult> {
-  const maxPasses = boundedInteger(options.maxPasses, SWEEP_DEFAULTS.maxPasses, 2, 20);
   const totalDeadlineMs = boundedInteger(options.totalDeadlineMs, SWEEP_DEFAULTS.totalDeadlineMs, 1, 300_000);
   const now = options.now || Date.now;
   const deadline = now() + totalDeadlineMs;
-  let passes = 0;
-  let steps = 0;
-  let maxScrollExtent = 0;
-  let reachedTop = false;
-  let reachedBottom = false;
-  let previousExtent: number | null = null;
-  let complete = false;
-  let finalUnresolved: string[] = [];
-  const unresolvedAcrossPasses = new Set<string>();
-  let finalLiveChanged = false;
   const sweepIdentity = String(adapter.sampleIdentity() || '').trim();
   const validateSweepIdentity = (): boolean => {
     const currentIdentity = String(adapter.sampleIdentity() || '').trim();
@@ -749,99 +742,51 @@ export async function runVirtualizedSweep<T>(
     invalidateAccumulatorIdentity(accumulator);
     return false;
   };
-  const terminalPassReasons = new Set([
-    'missing_identity',
-    'identity_changed',
-    'root_detached',
-    'root_replaced',
-    'extraction_error',
-    'pass_failed',
-  ]);
-
-  for (; passes < maxPasses; ) {
-    if (!validateSweepIdentity()) break;
-    if (now() > deadline) {
-      addPreparedReason(accumulator, 'total_deadline_exhausted');
-      break;
-    }
-    const pass = await runVirtualizedPass(runtime, adapter, accumulator, { ...options, deadline });
-    passes += 1;
-    steps += pass.steps;
-    maxScrollExtent = Math.max(maxScrollExtent, pass.maxScrollExtent);
-    reachedTop = pass.reachedTop;
-    reachedBottom = pass.reachedBottom;
-
-    if (!validateSweepIdentity()) break;
-    if (now() > deadline) {
-      addPreparedReason(accumulator, 'total_deadline_exhausted');
-      break;
-    }
-    if (pass.reasons.some((reason) => terminalPassReasons.has(reason))) break;
-
-    for (const key of pass.unresolvedKeys) unresolvedAcrossPasses.add(key);
-    for (const record of accumulator.records) {
-      unresolvedAcrossPasses.delete(record.key);
-      unresolvedAcrossPasses.delete(record.turnKey);
-    }
-    const unresolved = Array.from(unresolvedAcrossPasses);
-    finalUnresolved = unresolved;
-    const extentStable = previousExtent !== null && previousExtent === pass.maxScrollExtent;
-    previousExtent = pass.maxScrollExtent;
-    const noChanges = pass.added === 0 && pass.updated === 0;
-    const hasBlockingReason = accumulator.reasons.some((reason) => INCOMPLETE_REASONS.has(reason));
-    if (hasBlockingReason) break;
-
-    if (
-      passes >= 2 &&
-      noChanges &&
-      extentStable &&
-      pass.reachedTop &&
-      pass.reachedBottom &&
-      accumulator.identityVerified &&
-      !unresolved.length &&
-      !hasBlockingReason
-    ) {
-      const checkpoint = checkpointAccumulatorData(accumulator);
-      try {
-        const finalLive = await adapter.harvest(accumulator);
-        if (!validateSweepIdentity()) {
-          restoreAccumulatorData(accumulator, checkpoint);
-          invalidateAccumulatorIdentity(accumulator);
-          break;
-        }
-        if (finalLive.added === 0 && finalLive.updated === 0) {
-          complete = true;
-          break;
-        }
-        finalLiveChanged = true;
-      } catch (_error) {
-        restoreAccumulatorData(accumulator, checkpoint);
-        addPreparedReason(accumulator, 'extraction_error');
-        break;
-      }
+  let pass: VirtualizedPassResult = {
+    reachedTop: false,
+    reachedBottom: false,
+    steps: 0,
+    maxScrollExtent: 0,
+    reasons: [],
+    added: 0,
+    updated: 0,
+    unresolvedKeys: [],
+  };
+  let ranPass = false;
+  if (validateSweepIdentity()) {
+    if (now() > deadline) addPreparedReason(accumulator, 'total_deadline_exhausted');
+    else {
+      ranPass = true;
+      pass = await runVirtualizedPass(runtime, adapter, accumulator, { ...options, deadline });
     }
   }
+  if (validateSweepIdentity() && now() > deadline) addPreparedReason(accumulator, 'total_deadline_exhausted');
 
-  if (!complete && finalUnresolved.length) addPreparedReason(accumulator, 'unresolved_turn');
-  if (!complete && finalLiveChanged) addPreparedReason(accumulator, 'final_live_changed');
-  if (!complete && passes >= maxPasses) addPreparedReason(accumulator, 'pass_budget_exhausted');
-  if (!reachedTop) addPreparedReason(accumulator, 'top_not_reached');
-  if (!reachedBottom) addPreparedReason(accumulator, 'bottom_not_reached');
+  if (pass.unresolvedKeys.length) addPreparedReason(accumulator, 'unresolved_turn');
+  if (!pass.reachedTop) addPreparedReason(accumulator, 'top_not_reached');
+  if (!pass.reachedBottom) addPreparedReason(accumulator, 'bottom_not_reached');
+  const hasBlockingReason = accumulator.reasons.some((reason) => INCOMPLETE_REASONS.has(reason));
+  const complete =
+    pass.reachedTop &&
+    pass.reachedBottom &&
+    accumulator.identityVerified &&
+    !pass.unresolvedKeys.length &&
+    !hasBlockingReason;
   accumulator.completeness = complete ? 'complete' : 'partial';
   accumulator.sweepMetrics = {
-    passes,
-    steps,
-    maxScrollExtent,
-    reachedTop,
-    reachedBottom,
+    passes: ranPass ? 1 : 0,
+    steps: pass.steps,
+    maxScrollExtent: pass.maxScrollExtent,
+    reachedTop: pass.reachedTop,
+    reachedBottom: pass.reachedBottom,
   };
   return {
     completeness: accumulator.completeness,
-    passes,
-    steps,
-    maxScrollExtent,
-    reachedTop,
-    reachedBottom,
+    passes: ranPass ? 1 : 0,
+    steps: pass.steps,
+    maxScrollExtent: pass.maxScrollExtent,
+    reachedTop: pass.reachedTop,
+    reachedBottom: pass.reachedBottom,
     reasons: accumulator.reasons.slice(),
   };
 }

--- a/tests/collectors/chatgpt-collector.test.ts
+++ b/tests/collectors/chatgpt-collector.test.ts
@@ -541,61 +541,20 @@ describe('chatgpt virtualized share fixture (5 rounds)', () => {
     expect(after[0].fingerprint).not.toBe(first.fingerprint);
   });
 
-  it('retries a rendered message when its first plain snapshot is transiently unavailable', async () => {
-    const dom = setupChatgptDom(
-      `
-        <article data-testid="conversation-turn-1" data-turn-id="turn_retry">
-          <div data-message-author-role="assistant"><div class="markdown prose"><p>retry me</p></div></div>
-        </article>
-      `,
-      'https://chatgpt.com/c/conv_retry',
-    );
-    (dom.window as any).scrollTo = vi.fn();
-    const def = createChatgptCollectorDef(
-      createCollectorEnv({
-        window: dom.window as any,
-        document: dom.window.document as any,
-        location: dom.window.location as any,
-        normalize: normalizeApi,
-      }),
-    ) as any;
-    const adapter = def.collector.__test.manualAdapter;
-    const originalReadWindow = adapter.readWindow;
-    let remainingMisses = 1;
-    adapter.readWindow = () => {
-      const window = originalReadWindow();
-      if (remainingMisses > 0) {
-        remainingMisses -= 1;
-        return { ...window, inputsByKey: new Map() };
-      }
-      return window;
-    };
-
-    const prepared = await def.collector.prepareManualCapture({
-      maxSteps: 4,
-      stableSamples: 1,
-      pollMs: 0,
-      stepTimeoutMs: 20,
-    });
-
-    expect(remainingMisses).toBe(0);
-    expect(prepared.records.map((record: any) => record.payload.contentText)).toEqual(['retry me']);
-  });
-
-  it('waits for a visible virtualized shell within one top-to-bottom pass', async () => {
+  it('waits for an intersecting virtualized shell within one top-to-bottom pass', async () => {
     const dom = setupChatgptDom(
       `
         <article data-testid="conversation-turn-1" data-turn-id="turn_question">
           <div data-message-author-role="user"><div class="whitespace-pre-wrap">question</div></div>
         </article>
-        <article data-testid="conversation-turn-2" data-turn-id="turn_late"></article>
+        <div data-is-intersecting="true">
+          <article data-testid="conversation-turn-2" data-turn-id="turn_late"></article>
+        </div>
       `,
       'https://chatgpt.com/c/conv_visible_shell',
     );
     (dom.window as any).scrollTo = vi.fn();
     const shell = dom.window.document.querySelector('[data-turn-id="turn_late"]') as HTMLElement;
-    shell.getBoundingClientRect = () =>
-      ({ top: 20, bottom: 120, height: 100, left: 0, right: 100, width: 100 }) as DOMRect;
     const def = createChatgptCollectorDef(
       createCollectorEnv({
         window: dom.window as any,

--- a/tests/collectors/chatgpt-collector.test.ts
+++ b/tests/collectors/chatgpt-collector.test.ts
@@ -572,7 +572,6 @@ describe('chatgpt virtualized share fixture (5 rounds)', () => {
     };
 
     const prepared = await def.collector.prepareManualCapture({
-      maxPasses: 2,
       maxSteps: 4,
       stableSamples: 1,
       pollMs: 0,
@@ -581,6 +580,46 @@ describe('chatgpt virtualized share fixture (5 rounds)', () => {
 
     expect(remainingMisses).toBe(0);
     expect(prepared.records.map((record: any) => record.payload.contentText)).toEqual(['retry me']);
+  });
+
+  it('waits for a visible virtualized shell within one top-to-bottom pass', async () => {
+    const dom = setupChatgptDom(
+      `
+        <article data-testid="conversation-turn-1" data-turn-id="turn_question">
+          <div data-message-author-role="user"><div class="whitespace-pre-wrap">question</div></div>
+        </article>
+        <article data-testid="conversation-turn-2" data-turn-id="turn_late"></article>
+      `,
+      'https://chatgpt.com/c/conv_visible_shell',
+    );
+    (dom.window as any).scrollTo = vi.fn();
+    const shell = dom.window.document.querySelector('[data-turn-id="turn_late"]') as HTMLElement;
+    shell.getBoundingClientRect = () =>
+      ({ top: 20, bottom: 120, height: 100, left: 0, right: 100, width: 100 }) as DOMRect;
+    const def = createChatgptCollectorDef(
+      createCollectorEnv({
+        window: dom.window as any,
+        document: dom.window.document as any,
+        location: dom.window.location as any,
+        normalize: normalizeApi,
+      }),
+    ) as any;
+    let waits = 0;
+
+    const prepared = await def.collector.prepareManualCapture({
+      stableSamples: 1,
+      pollMs: 0,
+      stepTimeoutMs: 20,
+      sleep: async () => {
+        waits += 1;
+        if (waits !== 1) return;
+        shell.innerHTML = '<div data-message-author-role="assistant"><div class="markdown prose">answer</div></div>';
+      },
+    });
+
+    expect(waits).toBe(1);
+    expect(prepared.metrics).toMatchObject({ passes: 1, reachedTop: true, reachedBottom: true });
+    expect(prepared.records.map((record: any) => record.payload.contentText)).toEqual(['question', 'answer']);
   });
 
   it('bounds manual extraction to new or changed descriptor fingerprints', async () => {
@@ -604,7 +643,6 @@ describe('chatgpt virtualized share fixture (5 rounds)', () => {
     });
     const def = createChatgptCollectorDef(env) as any;
     const prepared = await def.collector.prepareManualCapture({
-      maxPasses: 2,
       maxSteps: 4,
       stableSamples: 1,
       pollMs: 0,
@@ -653,7 +691,6 @@ describe('chatgpt virtualized share fixture (5 rounds)', () => {
     });
     const def = createChatgptCollectorDef(env) as any;
     const prepared = await def.collector.prepareManualCapture({
-      maxPasses: 2,
       maxSteps: 4,
       stableSamples: 1,
       pollMs: 0,
@@ -692,7 +729,6 @@ describe('chatgpt virtualized share fixture (5 rounds)', () => {
     });
     const def = createChatgptCollectorDef(env) as any;
     const prepared = await def.collector.prepareManualCapture({
-      maxPasses: 2,
       stableSamples: 1,
       pollMs: 0,
       stepTimeoutMs: 20,
@@ -794,6 +830,7 @@ describe('chatgpt manual scroll-sweep capture (P2)', () => {
       stableSamples: 1,
     });
     expect(counter.hydrated).toBe(3);
+    expect(preparedCapture.metrics).toMatchObject({ passes: 1, reachedTop: true, reachedBottom: true });
 
     const snap = (await Promise.resolve(def.collector.capture({ manual: true, preparedCapture }))) as any;
     expect(snap.messages.length).toBe(12);
@@ -841,7 +878,6 @@ describe('chatgpt manual scroll-sweep capture (P2)', () => {
     };
 
     const prepared = await def.collector.prepareManualCapture({
-      maxPasses: 2,
       maxSteps: 4,
       maxOverlapRecoveries: 0,
       stableSamples: 1,
@@ -884,7 +920,6 @@ describe('chatgpt manual scroll-sweep capture (P2)', () => {
     const def = createChatgptCollectorDef(buildEnv(dom)) as any;
 
     const prepared = await def.collector.prepareManualCapture({
-      maxPasses: 2,
       maxSteps: 4,
       maxOverlapRecoveries: 0,
       stableSamples: 1,
@@ -918,7 +953,6 @@ describe('chatgpt manual scroll-sweep capture (P2)', () => {
     const def = createChatgptCollectorDef(buildEnv(dom)) as any;
 
     const prepared = await def.collector.prepareManualCapture({
-      maxPasses: 2,
       maxSteps: 8,
       stableSamples: 1,
       pollMs: 0,

--- a/tests/collectors/googleaistudio-collector.test.ts
+++ b/tests/collectors/googleaistudio-collector.test.ts
@@ -553,7 +553,6 @@ describe('googleaistudio-collector', () => {
       }),
     ) as any;
     const prepared = await def.collector.prepareManualCapture({
-      maxPasses: 3,
       maxSteps: 20,
       stableSamples: 1,
       pollMs: 0,

--- a/tests/collectors/googleaistudio-collector.test.ts
+++ b/tests/collectors/googleaistudio-collector.test.ts
@@ -591,6 +591,34 @@ describe('googleaistudio-collector', () => {
     ).toBe(true);
   });
 
+  it('keeps an unloaded message in a multi-message turn partial', async () => {
+    const html = `<div class="chat-session-content"><ms-chat-turn id="turn-1"><div data-turn-role="User"><div class="turn-content">Q</div></div><div data-turn-role="Model"><div class="turn-content"></div></div></ms-chat-turn></div>`;
+    const dom = setupDom(html, 'https://aistudio.google.com/app/identity');
+    const def = createGoogleAiStudioCollectorDef(
+      createCollectorEnv({
+        window: dom.window as any,
+        document: dom.window.document as any,
+        location: dom.window.location as any,
+        normalize: normalizeApi,
+      }),
+    ) as any;
+    let clock = 0;
+
+    const preparedCapture = await def.collector.prepareManualCapture({
+      stableSamples: 1,
+      pollMs: 1,
+      stepTimeoutMs: 2,
+      now: () => clock,
+      sleep: async () => {
+        clock += 1;
+      },
+    });
+
+    expect(preparedCapture.completeness).toBe('partial');
+    expect(preparedCapture.reasons).toContain('unresolved_turn');
+    expect(preparedCapture.records.map((record: any) => record.key)).toEqual(['turn-1:user:0']);
+  });
+
   it('refuses to verify manual identity when stable turn ids are missing', async () => {
     const html = `<div class="chat-session-content"><ms-chat-turn><div data-turn-role="User"><div class="turn-content">Q</div></div></ms-chat-turn></div>`;
     const dom = setupDom(html, 'https://aistudio.google.com/app/missing-id');

--- a/tests/collectors/virtualized-chat-sweep.test.ts
+++ b/tests/collectors/virtualized-chat-sweep.test.ts
@@ -533,7 +533,7 @@ describe('virtualized chat single pass', () => {
   });
 });
 
-describe('virtualized chat confirmation sweep', () => {
+describe('virtualized chat single-pass sweep', () => {
   function singlePageAdapter(
     harvestPayloads: Array<Array<{ key: string; fingerprint: string; text: string }>>,
     unresolved: () => string[] = () => [],
@@ -578,7 +578,7 @@ describe('virtualized chat confirmation sweep', () => {
     return { dom, accumulator, adapter };
   }
 
-  it('marks complete only after a no-change confirmation pass and final live sample', async () => {
+  it('marks complete after one stable top-to-bottom pass', async () => {
     const test = singlePageAdapter([
       [{ key: 'a', fingerprint: 'a', text: 'A' }],
       [{ key: 'a', fingerprint: 'a', text: 'A' }],
@@ -588,106 +588,49 @@ describe('virtualized chat confirmation sweep', () => {
       { document: test.dom.window.document, window: test.dom.window as any },
       test.adapter,
       test.accumulator,
-      { stableSamples: 1, pollMs: 0, maxPasses: 4 },
+      { stableSamples: 1, pollMs: 0 },
     );
     expect(result).toMatchObject({ completeness: 'complete', reachedTop: true, reachedBottom: true });
-    expect(result.passes).toBe(2);
+    expect(result.passes).toBe(1);
   });
 
-  it('continues when a second pass discovers a late turn', async () => {
-    const test = singlePageAdapter([
-      [{ key: 'a', fingerprint: 'a', text: 'A' }],
-      [
-        { key: 'a', fingerprint: 'a', text: 'A' },
-        { key: 'b', fingerprint: 'b', text: 'B' },
-      ],
-      [
-        { key: 'a', fingerprint: 'a', text: 'A' },
-        { key: 'b', fingerprint: 'b', text: 'B' },
-      ],
-      [
-        { key: 'a', fingerprint: 'a', text: 'A' },
-        { key: 'b', fingerprint: 'b', text: 'B' },
-      ],
-    ]);
+  it('waits within the current window for an unresolved turn instead of starting another pass', async () => {
+    let unresolvedReads = 0;
+    let clock = 0;
+    const test = singlePageAdapter([[{ key: 'a', fingerprint: 'a', text: 'A' }]], () =>
+      unresolvedReads++ < 2 ? ['turn-a'] : [],
+    );
     const result = await runVirtualizedSweep(
       { document: test.dom.window.document, window: test.dom.window as any },
       test.adapter,
       test.accumulator,
-      { stableSamples: 1, pollMs: 0, maxPasses: 5 },
+      {
+        stableSamples: 1,
+        pollMs: 1,
+        stepTimeoutMs: 20,
+        now: () => clock,
+        sleep: async () => {
+          clock += 1;
+        },
+      },
     );
     expect(result.completeness).toBe('complete');
-    expect(finishPreparedCapture(test.accumulator).records.map((record) => record.key)).toEqual(['a', 'b']);
+    expect(result.passes).toBe(1);
+    expect(unresolvedReads).toBeGreaterThanOrEqual(2);
+    expect(finishPreparedCapture(test.accumulator).records.map((record) => record.key)).toEqual(['a']);
   });
 
-  it('requires another confirmation after a late known-key update or final-live change', async () => {
-    const test = singlePageAdapter([
-      [{ key: 'a', fingerprint: 'draft', text: 'draft' }],
-      [{ key: 'a', fingerprint: 'final', text: 'final' }],
-      [{ key: 'a', fingerprint: 'final', text: 'final' }],
-      [
-        { key: 'a', fingerprint: 'final', text: 'final' },
-        { key: 'b', fingerprint: 'late', text: 'late' },
-      ],
-      [
-        { key: 'a', fingerprint: 'final', text: 'final' },
-        { key: 'b', fingerprint: 'late', text: 'late' },
-      ],
-      [
-        { key: 'a', fingerprint: 'final', text: 'final' },
-        { key: 'b', fingerprint: 'late', text: 'late' },
-      ],
-    ]);
-    const result = await runVirtualizedSweep(
-      { document: test.dom.window.document, window: test.dom.window as any },
-      test.adapter,
-      test.accumulator,
-      { stableSamples: 1, pollMs: 0, maxPasses: 6 },
-    );
-    expect(result.completeness).toBe('complete');
-    expect(finishPreparedCapture(test.accumulator).records.map((record) => record.payload.text)).toEqual([
-      'final',
-      'late',
-    ]);
-  });
-
-  it('clears an unresolved turn when a message from that turn is harvested later', async () => {
-    let phase = 0;
-    const test = singlePageAdapter(
-      [
-        [],
-        [{ key: 'message-a', fingerprint: 'a', text: 'A' }],
-        [{ key: 'message-a', fingerprint: 'a', text: 'A' }],
-        [{ key: 'message-a', fingerprint: 'a', text: 'A' }],
-      ],
-      () => (phase++ === 0 ? ['turn-a'] : []),
-    );
-    const originalHarvest = test.adapter.harvest;
-    test.adapter.harvest = async (target) => {
-      const result = await originalHarvest(target);
-      for (const record of target.records) record.turnKey = 'turn-a';
-      return result;
-    };
-    const result = await runVirtualizedSweep(
-      { document: test.dom.window.document, window: test.dom.window as any },
-      test.adapter,
-      test.accumulator,
-      { stableSamples: 1, pollMs: 0, maxPasses: 4 },
-    );
-    expect(result.completeness).toBe('complete');
-    expect(result.reasons).not.toContain('unresolved_turn');
-  });
-
-  it('keeps unresolved expected turns and pass exhaustion partial', async () => {
+  it('keeps unresolved expected turns partial without restarting the pass', async () => {
     const test = singlePageAdapter([[{ key: 'a', fingerprint: 'a', text: 'A' }]], () => ['unresolved-shell']);
     const result = await runVirtualizedSweep(
       { document: test.dom.window.document, window: test.dom.window as any },
       test.adapter,
       test.accumulator,
-      { stableSamples: 1, pollMs: 0, maxPasses: 2 },
+      { stableSamples: 1, pollMs: 0, stepTimeoutMs: 3, sleep: async () => {} },
     );
     expect(result.completeness).toBe('partial');
-    expect(result.reasons).toEqual(expect.arrayContaining(['unresolved_turn', 'pass_budget_exhausted']));
+    expect(result).toMatchObject({ passes: 1 });
+    expect(result.reasons).toContain('unresolved_turn');
   });
 
   it('keeps sanitized provider errors incomplete', async () => {
@@ -707,7 +650,7 @@ describe('virtualized chat confirmation sweep', () => {
       { document: test.dom.window.document, window: test.dom.window as any },
       test.adapter,
       test.accumulator,
-      { stableSamples: 1, pollMs: 0, maxPasses: 2 },
+      { stableSamples: 1, pollMs: 0 },
     );
 
     expect(result.completeness).toBe('partial');
@@ -726,7 +669,6 @@ describe('virtualized chat confirmation sweep', () => {
       {
         stableSamples: 2,
         pollMs: 1,
-        maxPasses: 4,
         totalDeadlineMs: 3,
         now: () => clock,
         sleep: async () => {
@@ -750,7 +692,6 @@ describe('virtualized chat confirmation sweep', () => {
       test.adapter,
       test.accumulator,
       {
-        maxPasses: Number.NaN,
         maxSteps: -10,
         stableSamples: 0,
         pollMs: -1,
@@ -761,10 +702,10 @@ describe('virtualized chat confirmation sweep', () => {
       },
     );
     expect(result.completeness).toBe('complete');
-    expect(result.passes).toBe(2);
+    expect(result.passes).toBe(1);
   });
 
-  it('invalidates data when identity changes between passes', async () => {
+  it('invalidates data when identity changes during the pass', async () => {
     const test = singlePageAdapter([
       [{ key: 'old-message', fingerprint: 'old', text: 'old' }],
       [{ key: 'new-message', fingerprint: 'new', text: 'new' }],
@@ -782,7 +723,7 @@ describe('virtualized chat confirmation sweep', () => {
       { document: test.dom.window.document, window: test.dom.window as any },
       test.adapter,
       test.accumulator,
-      { stableSamples: 1, pollMs: 0, maxPasses: 2 },
+      { stableSamples: 1, pollMs: 0 },
     );
 
     expect(result.completeness).toBe('partial');

--- a/tests/collectors/virtualized-chat-sweep.test.ts
+++ b/tests/collectors/virtualized-chat-sweep.test.ts
@@ -633,6 +633,39 @@ describe('virtualized chat single-pass sweep', () => {
     expect(result.reasons).toContain('unresolved_turn');
   });
 
+  it('does not resolve an unloaded sibling from the same turn', async () => {
+    let clock = 0;
+    const test = singlePageAdapter([[{ key: 'turn-a:user:0', fingerprint: 'q', text: 'Q' }]], () => ['turn-a']);
+    test.adapter.harvest = async (target) =>
+      mergePreparedRecords(target, [
+        {
+          key: 'turn-a:user:0',
+          turnKey: 'turn-a',
+          withinTurn: 0,
+          fingerprint: 'q',
+          payload: { text: 'Q' },
+        },
+      ]);
+
+    const result = await runVirtualizedSweep(
+      { document: test.dom.window.document, window: test.dom.window as any },
+      test.adapter,
+      test.accumulator,
+      {
+        stableSamples: 1,
+        pollMs: 1,
+        stepTimeoutMs: 2,
+        now: () => clock,
+        sleep: async () => {
+          clock += 1;
+        },
+      },
+    );
+
+    expect(result.completeness).toBe('partial');
+    expect(result.reasons).toContain('unresolved_turn');
+  });
+
   it('keeps sanitized provider errors incomplete', async () => {
     const test = singlePageAdapter([
       [{ key: 'a', fingerprint: 'a', text: 'A' }],

--- a/tests/smoke/collectors-images-smoke.test.ts
+++ b/tests/smoke/collectors-images-smoke.test.ts
@@ -32,7 +32,6 @@ describe('collectors images (smoke)', () => {
     });
     const collector = createChatgptCollectorDef(env).collector;
     const preparedCapture = await collector.prepareManualCapture({
-      maxPasses: 1,
       maxSteps: 1,
       stableSamples: 1,
       pollMs: 0,


### PR DESCRIPTION
# ChatGPT fetch 重复滚动

## 现象

手动抓取较长的 ChatGPT 对话时，页面会从顶部滚到底部，再重复多次。根因不是需要多次全量扫描，而是虚拟列表在某个窗口进入视口后才把正文填入 DOM；旧实现没有在该窗口等待就绪，只能用第二轮、第三轮重新碰运气。

## 已确认根因

1. 共享虚拟列表扫描器把「第二轮无变化」当作完整性条件，因此正常成功也至少完整滚动两次。
2. ChatGPT 的空 turn 节点本身没有高度；实际的可见状态由父虚拟器的 `data-is-intersecting` 提供。只检查空节点的布局盒会跳过应等待的窗口。
3. 未渲染状态曾按共享 `turnKey` 消除。同一个 turn 含多个 message 时，一个已保存的 sibling 会让另一个未渲染 message 被误判为已完成。等待轮询还会反复生成整窗 `outerHTML` 快照，反而占用渲染时间。

## 解决记录（2026-08-27）

- `33ca23a1bf6edd9003eb84a2bd09db4255448441`：移除 `maxPasses` 和多轮全量扫描。扫描器只从上到下走一遍；每个窗口在继续滚动前等待 descriptor 稳定且可抓取。仍未就绪的窗口会尽力保存已渲染内容，并以 `partial` / `unresolved_turn` 明确报告，不回到顶部重扫。
- `5943b1ba098ab28ad9767755d121483d681ff0e2`：将未就绪状态统一为 message/descriptor key；只由同一 message 的成功抓取清除。ChatGPT 优先读取最近虚拟器的 `data-is-intersecting`，缺失该信号时才回退到布局盒。轮询只读取轻量 descriptor；`outerHTML` 快照仅在实际 harvest 时生成。Google AI Studio 使用同一 message-key 完整性规则。

## 保持的边界

- ChatGPT 和 Google AI Studio 仍只允许手动抓取；不加入自动保存列表。
- 身份变化、滚动根替换、无法恢复原滚动位置、未渲染 message 或最终实时 harvest 出现新内容时，结果必须是 `partial`，不能静默标记为完整。
- 手动抓取结束后恢复原滚动位置。

## 验证

- 新增真实 ChatGPT 父虚拟器相交标记、同一 turn 多 message、AI Studio 未渲染 sibling 的回归用例。
- 已运行 `npm run gate:ci`：lint、格式检查、TypeScript 编译和全量测试均通过。
