### PR TITLE
修复：明确已加载条目的选择语义

### DIFF
--- a/src/ui/conversations/ConversationListPane.tsx
+++ b/src/ui/conversations/ConversationListPane.tsx
@@ -600,8 +600,7 @@ export function ConversationListPane({
   const deleteConfirming = !!deleteConfirmKey && armedDeleteKey != null && deleteConfirm.isArmed(deleteConfirmKey);
   const loadedVisibleScopeHint = t('tooltipLoadedVisibleSelectionScope');
   const loadedSelectionAction = total > 0 && selectedCount === total ? t('deselectLoadedItems') : t('selectAll');
-  const loadedSelectionTooltip =
-    total > 0 ? `${loadedSelectionAction} (${total})` : loadedSelectionAction;
+  const loadedSelectionTooltip = total > 0 ? `${loadedSelectionAction} (${total})` : loadedSelectionAction;
   const deleteTooltip = deleteConfirming
     ? `${t('tooltipDeleteSelectedConfirmDetailed')} · ${loadedVisibleScopeHint}`
     : hasSelection

--- a/src/ui/conversations/ConversationListPane.tsx
+++ b/src/ui/conversations/ConversationListPane.tsx
@@ -599,10 +599,9 @@ export function ConversationListPane({
   const armedDeleteKey = deleteConfirm.getArmedKey();
   const deleteConfirming = !!deleteConfirmKey && armedDeleteKey != null && deleteConfirm.isArmed(deleteConfirmKey);
   const loadedVisibleScopeHint = t('tooltipLoadedVisibleSelectionScope');
-  const selectAllTooltip =
-    total > 0
-      ? `${t('selectAll')} · ${loadedVisibleScopeHint} (${total})`
-      : `${t('selectAll')} · ${loadedVisibleScopeHint}`;
+  const loadedSelectionAction = total > 0 && selectedCount === total ? t('deselectLoadedItems') : t('selectAll');
+  const loadedSelectionTooltip =
+    total > 0 ? `${loadedSelectionAction} (${total})` : loadedSelectionAction;
   const deleteTooltip = deleteConfirming
     ? `${t('tooltipDeleteSelectedConfirmDetailed')} · ${loadedVisibleScopeHint}`
     : hasSelection
@@ -849,7 +848,7 @@ export function ConversationListPane({
             <label
               className="tw-inline-flex tw-items-center tw-justify-center tw-text-[var(--text-secondary)]"
               aria-label={t('selectAll')}
-              {...tooltipAttrs(selectAllTooltip)}
+              {...tooltipAttrs(hasSelection ? loadedSelectionTooltip : '')}
             >
               <input
                 ref={selectAllRef}
@@ -917,7 +916,7 @@ export function ConversationListPane({
                   : 'tw-max-w-0 tw-opacity-0 tw-translate-x-2 tw-scale-[0.98] tw-pointer-events-none',
               ].join(' ')}
             >
-              <span className="tw-inline-flex" {...tooltipAttrs(deleteTooltip)}>
+              <span className="tw-inline-flex" {...tooltipAttrs(hasSelection ? deleteTooltip : '')}>
                 <button
                   id="btnDelete"
                   type="button"
@@ -959,7 +958,7 @@ export function ConversationListPane({
                 align="end"
                 panelMinWidth={150}
                 trigger={(triggerProps) => (
-                  <span className="tw-inline-flex" {...tooltipAttrs(exportTooltip)}>
+                  <span className="tw-inline-flex" {...tooltipAttrs(hasSelection ? exportTooltip : '')}>
                     <button {...triggerProps} id="btnExport" className={actionButton}>
                       <span className="tw-leading-none">{t('exportButton')}</span>
                       <span
@@ -999,7 +998,7 @@ export function ConversationListPane({
               </MenuPopover>
 
               {singleSyncProvider ? (
-                <span className="tw-inline-flex" {...tooltipAttrs(singleSyncTooltip)}>
+                <span className="tw-inline-flex" {...tooltipAttrs(hasSelection ? singleSyncTooltip : '')}>
                   <button
                     id="btnSyncProvider"
                     className={actionButton}
@@ -1024,7 +1023,7 @@ export function ConversationListPane({
                   align="end"
                   panelMinWidth={170}
                   trigger={(triggerProps) => (
-                    <span className="tw-inline-flex" {...tooltipAttrs(syncMenuTooltip)}>
+                    <span className="tw-inline-flex" {...tooltipAttrs(hasSelection ? syncMenuTooltip : '')}>
                       <button {...triggerProps} id="btnSyncTo" className={actionButton}>
                         <span className="tw-leading-none">{syncMenuButtonLabel}</span>
                         <span

--- a/src/ui/i18n/locales/en.ts
+++ b/src/ui/i18n/locales/en.ts
@@ -267,7 +267,8 @@ export const en = {
   // untitled is shared: used by ConversationListPane, ConversationDetailPane, and ConversationsScene
   untitled: '(Untitled)',
   selectLabel: 'Select',
-  selectAll: 'Select all',
+  selectAll: 'Select loaded items',
+  deselectLoadedItems: 'Deselect loaded items',
   tooltipLoadedVisibleSelectionScope: 'Only currently loaded visible items',
   copyFullMarkdown: 'Copy full markdown',
   copied: 'Copied',

--- a/src/ui/i18n/locales/zh.ts
+++ b/src/ui/i18n/locales/zh.ts
@@ -263,7 +263,8 @@ export const zh: { [K in TranslationKey]: string } = {
   // untitled is shared: used by ConversationListPane, ConversationDetailPane, and ConversationsScene
   untitled: '(无标题)',
   selectLabel: '选择',
-  selectAll: '全选',
+  selectAll: '选择已加载项',
+  deselectLoadedItems: '取消选择已加载项',
   tooltipLoadedVisibleSelectionScope: '仅当前已加载可见项',
   copyFullMarkdown: '复制完整 Markdown',
   copied: '已复制',

--- a/tests/unit/conversation-list-pagination.test.ts
+++ b/tests/unit/conversation-list-pagination.test.ts
@@ -237,7 +237,18 @@ describe('ConversationListPane pagination behaviors', () => {
     expect(loadMoreList).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps select-all and batch tooltip semantics scoped to loaded visible items', async () => {
+  it('does not attach selection or batch tooltips when nothing is selected', async () => {
+    currentState = buildState({ selectedIds: [] });
+    await renderPane();
+
+    const selectAllLabel = document.querySelector('label[aria-label="selectAll"]') as HTMLLabelElement | null;
+    expect(selectAllLabel?.hasAttribute('data-tooltip-content')).toBe(false);
+    for (const buttonId of ['btnDelete', 'btnExport', 'btnSyncProvider']) {
+      expect(document.getElementById(buttonId)?.closest('[data-tooltip-content]')).toBeNull();
+    }
+  });
+
+  it('keeps loaded-item selection and batch tooltip semantics scoped to loaded visible items', async () => {
     const toggleAll = vi.fn();
     currentState = buildState({
       selectedIds: [11, 22, 999],
@@ -249,11 +260,9 @@ describe('ConversationListPane pagination behaviors', () => {
       await flushMicrotasks();
     });
 
-    const selectAllLabel = document.querySelector('label[aria-label="selectAll"]') as HTMLLabelElement | null;
-    expect(selectAllLabel).toBeTruthy();
-    expect(String(selectAllLabel?.getAttribute('data-tooltip-content') || '')).toContain(
-      'tooltipLoadedVisibleSelectionScope',
-    );
+    const loadedSelectionLabel = document.querySelector('label[aria-label="selectAll"]') as HTMLLabelElement | null;
+    expect(loadedSelectionLabel).toBeTruthy();
+    expect(String(loadedSelectionLabel?.getAttribute('data-tooltip-content') || '')).toBe('deselectLoadedItems (2)');
 
     const selectAllCheckbox = document.getElementById('chkSelectAll') as HTMLInputElement | null;
     expect(selectAllCheckbox).toBeTruthy();


### PR DESCRIPTION
## 修改内容

- 将容易误解的“全选”文案调整为“选择已加载项”语义。
- 保留原有的全局勾选/半选状态判断：只有全部条目都真正选中时才显示完整勾选。
- 点击复选框时仍然只作用于当前已加载条目，不改变现有懒加载和分页行为。
- 没有任何条目被选中时，不再显示批量操作相关的多余 Tooltip。

## 验证

- `npm test -- tests/unit/conversation-list-pagination.test.ts`
- `npm run compile`
- `npm test`：258 个测试文件、1482 个测试全部通过
- `git diff --cached --check`

## 关联 Issue

Closes #508
