### PR TITLE
修复：保存微信公众号文章中的内嵌视频

### DIFF
--- a/src/collectors/web/article-extract/engine.ts
+++ b/src/collectors/web/article-extract/engine.ts
@@ -11,8 +11,8 @@ import {
   buildWechatShareMediaGalleryHtml,
   extractWechatShareMediaImageUrls,
   isWechatShareMediaPage,
+  normalizeWechatRichMediaContent,
   prepareWechatRichMediaDom,
-  stripWechatRichMediaNoise,
   waitForXiaohongshuNoteHydrated,
 } from '@collectors/web/article-extract/sites';
 import type { ExtractedWebArticle } from '@collectors/web/article-extract/types';
@@ -262,7 +262,7 @@ function fallbackExtract(baseHref: string) {
     const hostname = String(location.hostname || '').toLowerCase();
     const root = pickRoot();
     const strippedRoot =
-      hostname === 'mp.weixin.qq.com' && root ? stripWechatRichMediaNoise(root as any) : (root as any);
+      hostname === 'mp.weixin.qq.com' && root ? normalizeWechatRichMediaContent(root as any, baseHref) : (root as any);
     const rootHtml = normalizeText((strippedRoot as any)?.innerHTML || '');
     const rootText = normalizeText((strippedRoot as any)?.innerText || '');
     const wechatGalleryHtml = buildWechatShareMediaGalleryHtml(baseHref);
@@ -470,7 +470,7 @@ function extractWechatRichMediaArticle(baseHref: string) {
     normalizeText((document.querySelector('#publish_time') as any)?.textContent || '') ||
     readMeta(["meta[property='article:published_time']", "meta[name='publish_date']", "meta[name='pubdate']"]);
 
-  const strippedRoot = stripWechatRichMediaNoise(root);
+  const strippedRoot = normalizeWechatRichMediaContent(root, baseHref);
   const htmlBody = normalizeText((strippedRoot as any).innerHTML || '');
   const textContent = normalizeText((strippedRoot as any).innerText || (strippedRoot as any).textContent || '');
   if (!htmlBody && !textContent) return null;

--- a/src/collectors/web/article-extract/markdown-turndown.ts
+++ b/src/collectors/web/article-extract/markdown-turndown.ts
@@ -129,6 +129,22 @@ function createTurndownService() {
     },
   });
 
+  turndown.addRule('syncnos-wechat-embedded-video', {
+    filter(node) {
+      const el = node as Element;
+      return el?.getAttribute?.('data-syncnos-origin') === 'wechat-embedded-video';
+    },
+    replacement(_content, node) {
+      const el = node as Element;
+      const coverUrl = normalizeText(el?.querySelector?.('img[src]')?.getAttribute?.('src') || '');
+      const playerUrl = normalizeText(el?.querySelector?.('a[href]')?.getAttribute?.('href') || '');
+      const blocks: string[] = [];
+      if (coverUrl) blocks.push(`![微信视频](${coverUrl})`);
+      blocks.push(playerUrl ? `[微信视频](${playerUrl})` : '微信视频');
+      return `\n\n${blocks.join('\n\n')}\n\n`;
+    },
+  });
+
   turndown.addRule('syncnos-summary', {
     filter: 'summary',
     replacement(content) {

--- a/src/collectors/web/article-extract/sites/index.ts
+++ b/src/collectors/web/article-extract/sites/index.ts
@@ -3,7 +3,7 @@ export {
   buildWechatShareMediaGalleryHtml,
   extractWechatShareMediaImageUrls,
   isWechatShareMediaPage,
+  normalizeWechatRichMediaContent,
   prepareWechatRichMediaDom,
-  stripWechatRichMediaNoise,
 } from '@collectors/web/article-extract/sites/wechat';
 export { waitForXiaohongshuNoteHydrated } from '@collectors/web/article-extract/sites/xiaohongshu';

--- a/src/collectors/web/article-extract/sites/wechat.ts
+++ b/src/collectors/web/article-extract/sites/wechat.ts
@@ -1,5 +1,17 @@
 import { sanitizeWechatMediaUrl } from '@collectors/web/article-extract/url';
 
+const WECHAT_EMBEDDED_VIDEO_CONTAINER_SELECTOR = [
+  '.video_iframe',
+  '[data-mpvid^="wxv_"]',
+  '[vid^="wxv_"]',
+  '[data-src*="video_player_tmpl"]',
+  '[src*="video_player_tmpl"]',
+  '.appmsg_video',
+  '.page_video_wrapper',
+].join(',');
+
+const WECHAT_VIDEO_ID_RE = /\bwxv_[A-Za-z0-9_-]+\b/;
+
 const WECHAT_RICH_MEDIA_NOISE_SELECTORS = [
   '#js_article_bottom_bar',
   '.bottom_bar_wrp',
@@ -19,8 +31,113 @@ const WECHAT_RICH_MEDIA_NOISE_SELECTORS = [
   '.wx_bottom_modal_msg_wrp',
 ];
 
-export function stripWechatRichMediaNoise(root: Element) {
+function decodeUriComponentSafe(value: unknown) {
+  const text = String(value || '').trim();
+  if (!text || !text.includes('%')) return text;
+  try {
+    return decodeURIComponent(text);
+  } catch (_e) {
+    return text;
+  }
+}
+
+function findWechatVideoId(container: Element) {
+  const nodes = [
+    container,
+    ...Array.from(container.querySelectorAll('[data-mpvid],[vid],[data-src],[src]')),
+  ] as Element[];
+  const attributes = ['data-mpvid', 'vid', 'data-src', 'src'];
+
+  for (const node of nodes) {
+    for (const attribute of attributes) {
+      const raw = String(node.getAttribute(attribute) || '').trim();
+      if (!raw) continue;
+      const direct = raw.match(WECHAT_VIDEO_ID_RE)?.[0];
+      if (direct) return direct;
+      const decoded = decodeUriComponentSafe(raw);
+      const decodedMatch = decoded.match(WECHAT_VIDEO_ID_RE)?.[0];
+      if (decodedMatch) return decodedMatch;
+    }
+  }
+  return '';
+}
+
+function findWechatVideoCoverUrl(container: Element, baseHref: string) {
+  const candidates = [
+    container.getAttribute('data-cover'),
+    container.querySelector('[data-cover]')?.getAttribute('data-cover'),
+    container.querySelector('video[poster]')?.getAttribute('poster'),
+  ];
+
+  for (const candidate of candidates) {
+    const decoded = decodeUriComponentSafe(candidate);
+    if (!decoded) continue;
+    const sanitized = sanitizeWechatMediaUrl(decoded, baseHref);
+    if (sanitized) return sanitized;
+  }
+  return '';
+}
+
+function buildWechatVideoPlayerUrl(videoId: string) {
+  if (!WECHAT_VIDEO_ID_RE.test(videoId)) return '';
+  return `https://mp.weixin.qq.com/mp/readtemplate?t=pages/video_player_tmpl&auto=0&vid=${encodeURIComponent(videoId)}`;
+}
+
+function createWechatVideoPlaceholder(container: Element, baseHref: string) {
+  const doc = container.ownerDocument || document;
+  const videoId = findWechatVideoId(container);
+  const playerUrl = buildWechatVideoPlayerUrl(videoId);
+  const coverUrl = findWechatVideoCoverUrl(container, baseHref);
+  const block = doc.createElement('span');
+  block.setAttribute('data-syncnos-origin', 'wechat-embedded-video');
+
+  if (coverUrl) {
+    const image = doc.createElement('img');
+    image.setAttribute('src', coverUrl);
+    image.setAttribute('alt', '微信视频');
+    block.appendChild(image);
+    block.appendChild(doc.createElement('br'));
+  }
+
+  if (playerUrl) {
+    const labelLink = doc.createElement('a');
+    labelLink.setAttribute('href', playerUrl);
+    labelLink.textContent = '微信视频';
+    block.appendChild(labelLink);
+  } else {
+    const label = doc.createElement('span');
+    label.textContent = '微信视频';
+    block.appendChild(label);
+  }
+
+  return block;
+}
+
+function listWechatArticleContentRoots(root: Element) {
+  const roots: Element[] = [];
+  if (typeof root.matches === 'function' && root.matches('#js_content')) roots.push(root);
+  roots.push(...Array.from(root.querySelectorAll('#js_content')));
+  return roots;
+}
+
+function normalizeWechatEmbeddedVideos(root: Element, baseHref: string) {
+  for (const articleRoot of listWechatArticleContentRoots(root)) {
+    const candidates = Array.from(articleRoot.querySelectorAll(WECHAT_EMBEDDED_VIDEO_CONTAINER_SELECTOR)) as Element[];
+    if (!candidates.length) continue;
+
+    const outermost = candidates.filter(
+      (candidate) => !candidates.some((other) => other !== candidate && other.contains(candidate)),
+    );
+    for (const container of outermost) {
+      container.replaceWith(createWechatVideoPlaceholder(container, baseHref));
+    }
+  }
+}
+
+export function normalizeWechatRichMediaContent(root: Element, baseHref: string) {
   const cloned = root.cloneNode(true) as Element;
+  normalizeWechatEmbeddedVideos(cloned, baseHref);
+
   const selector = WECHAT_RICH_MEDIA_NOISE_SELECTORS.join(',');
   if (selector) {
     try {

--- a/tests/smoke/article-extract-wechat-video.test.ts
+++ b/tests/smoke/article-extract-wechat-video.test.ts
@@ -1,0 +1,320 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { extractWebArticleFromCurrentPage } from '../../src/collectors/web/article-extract/engine';
+import { normalizeWechatRichMediaContent } from '../../src/collectors/web/article-extract/sites/wechat';
+import { markdownToNotionBlocks } from '../../src/services/sync/notion/notion-markdown-blocks';
+
+function setDomGlobals(dom: JSDOM) {
+  // @ts-expect-error test global
+  globalThis.window = dom.window;
+  // @ts-expect-error test global
+  globalThis.document = dom.window.document;
+  // @ts-expect-error test global
+  globalThis.Node = dom.window.Node;
+  // @ts-expect-error test global
+  globalThis.location = dom.window.location;
+  // @ts-expect-error test global
+  globalThis.getComputedStyle = dom.window.getComputedStyle;
+}
+
+function clearDomGlobals() {
+  // @ts-expect-error test global
+  delete globalThis.window;
+  // @ts-expect-error test global
+  delete globalThis.document;
+  // @ts-expect-error test global
+  delete globalThis.Node;
+  // @ts-expect-error test global
+  delete globalThis.location;
+  // @ts-expect-error test global
+  delete globalThis.getComputedStyle;
+  // @ts-expect-error test global
+  delete globalThis.Readability;
+}
+
+afterEach(() => {
+  clearDomGlobals();
+});
+
+describe('article-extract wechat embedded video', () => {
+  it('replaces hydrated player DOM with stable video semantics and drops ephemeral player controls', async () => {
+    const firstCover = encodeURIComponent('http://mmbiz.qpic.cn/mmbiz_jpg/demo-first/0?wx_fmt=jpeg&wxfrom=16');
+    const dom = new JSDOM(
+      `<!doctype html>
+      <html>
+        <head><title>微信视频正文测试</title></head>
+        <body>
+          <h1 id="activity-name">微信视频正文测试</h1>
+          <span id="js_name">测试作者</span>
+          <span id="publish_time">2026-08-27</span>
+          <div id="js_content">
+            <p>视频前正文。</p>
+            <span
+              class="video_iframe rich_pages"
+              data-mpvid="wxv_4666694207107973127"
+              vid="wxv_4666694207107973127"
+              data-cover="${firstCover}"
+              data-src="https://mp.weixin.qq.com/mp/readtemplate?t=pages/video_player_tmpl&amp;auto=0&amp;vid=wxv_4666694207107973127"
+            >
+              <div class="add_bg_color appmsg_video">
+                <div class="page_video_wrapper">
+                  <button>Replay Share Like</button>
+                  <div>进度条，百分之0</div>
+                  <div>0.5倍 0.75倍 1.0倍 1.5倍 2.0倍</div>
+                  <div>Video Details</div>
+                  <video
+                    class="video_fill"
+                    src="https://mpvideo.qpic.cn/demo-first.f10002.mp4?auth_key=temporary-secret&amp;vid=wxv_4666694207107973127&amp;dis_t=1787761064"
+                    poster="http://mmbiz.qpic.cn/mmbiz_jpg/demo-first/0?wx_fmt=jpeg&amp;wxfrom=16"
+                  ></video>
+                </div>
+              </div>
+            </span>
+            <p>两段视频之间的正文。</p>
+            <span
+              class="video_iframe rich_pages"
+              data-mpvid="wxv_4999999999999999999"
+              data-src="https://mp.weixin.qq.com/mp/readtemplate?t=pages/video_player_tmpl&amp;auto=0&amp;vid=wxv_4999999999999999999"
+            >
+              <div class="page_video_wrapper">
+                <button>Play</button>
+                <video src="https://mpvideo.qpic.cn/demo-second.f10002.mp4?auth_key=another-secret&amp;vid=wxv_4999999999999999999"></video>
+              </div>
+            </span>
+            <p>视频后正文。</p>
+          </div>
+        </body>
+      </html>`,
+      { url: 'https://mp.weixin.qq.com/s/article-with-video', pretendToBeVisual: true },
+    );
+
+    setDomGlobals(dom);
+    const extracted = await extractWebArticleFromCurrentPage({
+      stabilizationTimeoutMs: 1,
+      stabilizationMinTextLength: 1,
+    });
+    const markdown = String(extracted.contentMarkdown || '');
+    const html = String(extracted.contentHTML || '');
+    const text = String(extracted.textContent || '');
+
+    expect(markdown).toContain('视频前正文。');
+    expect(markdown).toContain('两段视频之间的正文。');
+    expect(markdown).toContain('视频后正文。');
+    expect(markdown).toContain('微信视频');
+    expect(markdown).toContain('http://mmbiz.qpic.cn/mmbiz_jpg/demo-first/0?wx_fmt=jpeg');
+    expect(markdown).toContain(
+      'https://mp.weixin.qq.com/mp/readtemplate?t=pages/video_player_tmpl&auto=0&vid=wxv_4666694207107973127',
+    );
+    expect(markdown).toContain(
+      'https://mp.weixin.qq.com/mp/readtemplate?t=pages/video_player_tmpl&auto=0&vid=wxv_4999999999999999999',
+    );
+
+    for (const value of [
+      'Replay Share Like',
+      '进度条，百分之0',
+      '0.5倍',
+      'Video Details',
+      'mpvideo.qpic.cn',
+      'auth_key',
+    ]) {
+      expect(markdown).not.toContain(value);
+      expect(html).not.toContain(value);
+      expect(text).not.toContain(value);
+    }
+
+    expect(text.match(/微信视频/g)?.length).toBe(2);
+    expect(html.match(/data-syncnos-origin="wechat-embedded-video"/g)?.length).toBe(2);
+    expect(markdown).not.toContain('[![');
+
+    const notionBlocks = markdownToNotionBlocks(markdown);
+    const imageBlocks = notionBlocks.filter((block: any) => block?.type === 'image');
+    expect(imageBlocks).toHaveLength(1);
+    expect(imageBlocks[0]?.image?.external?.url).toBe('http://mmbiz.qpic.cn/mmbiz_jpg/demo-first/0?wx_fmt=jpeg');
+    expect(
+      notionBlocks.some((block: any) =>
+        (block?.paragraph?.rich_text || []).some(
+          (rich: any) =>
+            rich?.text?.content === '微信视频' &&
+            rich?.text?.link?.url ===
+              'https://mp.weixin.qq.com/mp/readtemplate?t=pages/video_player_tmpl&auto=0&vid=wxv_4666694207107973127',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('normalizes an unhydrated metadata-only video without mutating the live article DOM', () => {
+    const cover = encodeURIComponent('https://mmbiz.qpic.cn/mmbiz_jpg/unhydrated/0?wx_fmt=jpeg&wxfrom=16');
+    const dom = new JSDOM(
+      `<body><div id="js_content">
+        <span class="video_iframe" data-src="https://mp.weixin.qq.com/mp/readtemplate?t=pages/video_player_tmpl&amp;auto=0&amp;vid=wxv_unhydrated" data-cover="${cover}"></span>
+      </div></body>`,
+      { url: 'https://mp.weixin.qq.com/s/unhydrated', pretendToBeVisual: true },
+    );
+
+    setDomGlobals(dom);
+    const root = dom.window.document.querySelector('#js_content')!;
+    const normalized = normalizeWechatRichMediaContent(root, dom.window.location.href);
+
+    expect(root.querySelector('.video_iframe')).not.toBeNull();
+    expect(normalized.querySelector('.video_iframe')).toBeNull();
+    expect(normalized.querySelector('img')?.getAttribute('src')).toBe(
+      'https://mmbiz.qpic.cn/mmbiz_jpg/unhydrated/0?wx_fmt=jpeg',
+    );
+    expect(normalized.querySelector('a')?.getAttribute('href')).toBe(
+      'https://mp.weixin.qq.com/mp/readtemplate?t=pages/video_player_tmpl&auto=0&vid=wxv_unhydrated',
+    );
+  });
+
+  it('recovers stable video identity from a partially hydrated runtime player', () => {
+    const dom = new JSDOM(
+      `<body><div id="js_content">
+        <div class="page_video_wrapper">
+          <button>Play Share</button>
+          <video
+            src="https://mpvideo.qpic.cn/runtime.mp4?auth_key=temporary&amp;vid=wxv_runtime_only&amp;dis_t=123"
+            poster="https://mmbiz.qpic.cn/mmbiz_jpg/runtime/0?wx_fmt=jpeg&amp;wxfrom=16"
+          ></video>
+        </div>
+      </div></body>`,
+      { url: 'https://mp.weixin.qq.com/s/runtime-only', pretendToBeVisual: true },
+    );
+
+    setDomGlobals(dom);
+    const root = dom.window.document.querySelector('#js_content')!;
+    const normalized = normalizeWechatRichMediaContent(root, dom.window.location.href);
+    const html = normalized.innerHTML;
+
+    expect(html).toContain('https://mmbiz.qpic.cn/mmbiz_jpg/runtime/0?wx_fmt=jpeg');
+    expect(html).toContain(
+      'https://mp.weixin.qq.com/mp/readtemplate?t=pages/video_player_tmpl&amp;auto=0&amp;vid=wxv_runtime_only',
+    );
+    expect(html).not.toContain('mpvideo.qpic.cn');
+    expect(html).not.toContain('auth_key');
+    expect(html).not.toContain('Play Share');
+  });
+
+  it('never promotes a signed runtime MP4 when no stable wxv identity is available', () => {
+    const dom = new JSDOM(
+      `<body><div id="js_content">
+        <div class="page_video_wrapper">
+          <button>Replay</button>
+          <video
+            src="https://mpvideo.qpic.cn/runtime-without-id.mp4?auth_key=temporary&amp;dis_t=123"
+            poster="https://mmbiz.qpic.cn/mmbiz_jpg/runtime-no-id/0?wx_fmt=jpeg&amp;wxfrom=16"
+          ></video>
+        </div>
+      </div></body>`,
+      { url: 'https://mp.weixin.qq.com/s/runtime-without-id', pretendToBeVisual: true },
+    );
+
+    setDomGlobals(dom);
+    const root = dom.window.document.querySelector('#js_content')!;
+    const normalized = normalizeWechatRichMediaContent(root, dom.window.location.href);
+    const html = normalized.innerHTML;
+
+    expect(html).toContain('https://mmbiz.qpic.cn/mmbiz_jpg/runtime-no-id/0?wx_fmt=jpeg');
+    expect(normalized.textContent).toContain('微信视频');
+    expect(normalized.querySelector('a')).toBeNull();
+    expect(html).not.toContain('mpvideo.qpic.cn');
+    expect(html).not.toContain('auth_key');
+    expect(html).not.toContain('Replay');
+  });
+
+  it('recognizes stable wxv metadata even if WeChat changes the wrapper class name', () => {
+    const dom = new JSDOM(
+      `<body><div id="js_content">
+        <section class="future-wrapper" vid="wxv_future_wrapper">
+          <div>Future player controls</div>
+        </section>
+      </div></body>`,
+      { url: 'https://mp.weixin.qq.com/s/future-wrapper', pretendToBeVisual: true },
+    );
+
+    setDomGlobals(dom);
+    const root = dom.window.document.querySelector('#js_content')!;
+    const normalized = normalizeWechatRichMediaContent(root, dom.window.location.href);
+
+    expect(normalized.textContent?.trim()).toBe('微信视频');
+    expect(normalized.innerHTML).toContain('vid=wxv_future_wrapper');
+    expect(normalized.innerHTML).not.toContain('Future player controls');
+  });
+
+  it('keeps paragraph structure valid when an embedded video sits inside a text paragraph', async () => {
+    const dom = new JSDOM(
+      `<body>
+        <h1 id="activity-name">段内视频</h1>
+        <div id="js_content">
+          <p>视频之前 <span class="video_iframe" data-mpvid="wxv_inline_paragraph" data-cover="https%3A%2F%2Fmmbiz.qpic.cn%2Fmmbiz_jpg%2Finline%2F0%3Fwx_fmt%3Djpeg"></span> 视频之后</p>
+        </div>
+      </body>`,
+      { url: 'https://mp.weixin.qq.com/s/inline-paragraph', pretendToBeVisual: true },
+    );
+
+    setDomGlobals(dom);
+    const extracted = await extractWebArticleFromCurrentPage({
+      stabilizationTimeoutMs: 1,
+      stabilizationMinTextLength: 1,
+    });
+
+    expect(extracted.contentHTML).not.toMatch(/<p[^>]*>[^]*<p[^>]*data-syncnos-origin="wechat-embedded-video"/);
+    expect(extracted.contentMarkdown).toContain('视频之前');
+    expect(extracted.contentMarkdown).toContain(
+      '[微信视频](https://mp.weixin.qq.com/mp/readtemplate?t=pages/video_player_tmpl&auto=0&vid=wxv_inline_paragraph)',
+    );
+    expect(extracted.contentMarkdown).toContain('视频之后');
+    expect(extracted.contentMarkdown.indexOf('视频之前')).toBeLessThan(extracted.contentMarkdown.indexOf('微信视频'));
+    expect(extracted.contentMarkdown.indexOf('微信视频')).toBeLessThan(extracted.contentMarkdown.indexOf('视频之后'));
+
+    const notionBlocks = markdownToNotionBlocks(extracted.contentMarkdown);
+    expect(notionBlocks.some((block: any) => block?.type === 'image')).toBe(true);
+  });
+
+  it('keeps a video-only WeChat article non-empty without retaining player chrome', async () => {
+    const dom = new JSDOM(
+      `<body>
+        <h1 id="activity-name">纯视频文章</h1>
+        <div id="js_content">
+          <span class="video_iframe" data-mpvid="wxv_video_only">
+            <button>Replay Share Like</button>
+          </span>
+        </div>
+      </body>`,
+      { url: 'https://mp.weixin.qq.com/s/video-only', pretendToBeVisual: true },
+    );
+
+    setDomGlobals(dom);
+    const extracted = await extractWebArticleFromCurrentPage({
+      stabilizationTimeoutMs: 1,
+      stabilizationMinTextLength: 1,
+    });
+
+    expect(extracted.textContent).toBe('微信视频');
+    expect(extracted.contentMarkdown).toBe(
+      '[微信视频](https://mp.weixin.qq.com/mp/readtemplate?t=pages/video_player_tmpl&auto=0&vid=wxv_video_only)',
+    );
+    expect(extracted.contentMarkdown).not.toContain('Replay Share Like');
+  });
+
+  it('does not normalize video-like DOM outside the WeChat article #js_content root', () => {
+    const dom = new JSDOM(
+      `<body>
+        <main id="video-page">
+          <div class="page_video_wrapper" data-mpvid="wxv_5000000000000000000">
+            <div>Video Details</div>
+            <video src="https://mpvideo.qpic.cn/standalone.mp4?auth_key=standalone&amp;vid=wxv_5000000000000000000"></video>
+          </div>
+        </main>
+      </body>`,
+      { url: 'https://mp.weixin.qq.com/video-like-outside-article', pretendToBeVisual: true },
+    );
+
+    setDomGlobals(dom);
+    const root = dom.window.document.querySelector('#video-page')!;
+    const normalized = normalizeWechatRichMediaContent(root, dom.window.location.href);
+
+    expect(normalized.querySelector('[data-syncnos-origin="wechat-embedded-video"]')).toBeNull();
+    expect(normalized.textContent).toContain('Video Details');
+    expect(normalized.innerHTML).toContain('mpvideo.qpic.cn');
+    expect(normalized.innerHTML).toContain('auth_key=standalone');
+  });
+});


### PR DESCRIPTION
## Related issue

N/A — 本次为已确认的微信公众号文章采集回归修复；提交前检索仓库 Issues，未发现对应的现有 Issue。

## Why

微信公众号文章中的内嵌视频使用微信自定义播放器 DOM。原有文章抽取路径会把播放器节点当作噪声或不稳定的动态 DOM 处理，导致保存后的文章缺失视频语义，严重时视频为主要内容的文章还可能接近空内容。

这次修复把微信内嵌视频在站点适配层先规范化为稳定、可序列化的文章内容，再交给通用 Markdown 转换链路处理，从而让保存结果不依赖微信播放器运行时 DOM。

## What changed

- 在微信公众号站点适配器中识别多种内嵌视频容器与 `wxv_*` 视频 ID，并兼容编码后的属性值。
- 将动态播放器 DOM 规范化为稳定的视频占位内容：可用时保留封面，并生成微信视频播放页链接；缺少 ID 时仍保留“微信视频”语义。
- 仅在文章正文 `#js_content` 内处理视频节点，同时继续剔除底部交互栏、弹层等微信运行时噪声。
- 将微信富媒体规范化接入文章抽取和 Markdown 转换路径，避免非法段落嵌套破坏最终结构。
- 新增 `tests/smoke/article-extract-wechat-video.test.ts`，覆盖 hydrated player、编码视频 ID、无封面、段落内视频、纯视频文章、噪声清理等 8 个场景。

## Scope and non-goals

- 只修复 `mp.weixin.qq.com` 文章正文中的内嵌视频保存语义，不改其他站点采集器。
- 不下载或转存微信视频二进制文件；保存的是可恢复的视频语义、封面和可用的播放器链接。
- 不修改视频字幕抓取、视频会话类型、同步协议或阅读器 UI。
- 不引入新的兼容分支、存储迁移或浏览器权限。

## Validation

- `npm run gate:ci`: PASS — 在精确提交 `844ee3de6832abe69d5cfc114b4f17d049fa10f9` 的独立 worktree 中先运行 `npm run prepare`，随后完整通过 lint、Prettier、TypeScript compile 和 test。
- `npm run gate`: N/A — 未修改 production build、manifest、权限、打包或发布配置。
- Targeted tests or boundary scans: `tests/smoke/article-extract-wechat-video.test.ts` 8/8 PASS；完整测试 259 files / 1490 tests 全部 PASS。

Manual validation:

| Browser / surface | Scenario | Result |
| --- | --- | --- |
| 微信公众号文章采集 | 真实浏览器页面手动保存 | NOT RUN — 本次 PR 提交阶段未重复进行 live-page 手动验证；行为由站点 fixture/smoke tests 覆盖 |

## Architecture, data, and permissions

- Affected layers / dependency boundaries: `src/collectors/web/article-extract/**`，仍保持站点 DOM 适配逻辑位于 collector 层；未引入 UI / viewmodel / platform 反向依赖。
- Local storage, schema, backup/restore, or migration impact: N/A。
- Browser permission or external-network impact: N/A；未新增权限或网络端点。
- Failure path: 视频容器缺少可解析 ID 或封面时，抽取仍保留稳定的“微信视频”文本占位，不修改已有本地数据，也不会让该失败路径触发迁移或数据删除。

## UI evidence

N/A — 未修改 SyncNos UI；变化只体现在微信公众号文章采集后的内容结果。

## Risks and tradeoffs

微信播放器 DOM 属于站点私有结构，未来微信改版可能需要扩展 selector。当前实现刻意不尝试下载视频文件，而是保存稳定的播放器语义与链接，避免把动态媒体下载、鉴权和缓存复杂度引入文章抽取链路。

## Documentation and cleanup

- [x] Canonical documentation made stale by this change is updated, or no documentation change is required.
- [x] Replaced production paths, dead compatibility branches, and outdated test assumptions are removed, or none were introduced/replaced.
- [x] I reviewed the final diff from top to bottom before requesting review.
