### PR TITLE
优化：统一会话列表复制交互与控件视觉

### DIFF
--- a/src/ui/conversations/ConversationDetailPane.tsx
+++ b/src/ui/conversations/ConversationDetailPane.tsx
@@ -327,7 +327,7 @@ export function ConversationDetailPane({
                     <>
                       <input
                         ref={urlInputRef}
-                        className="tw-min-w-0 tw-w-56 tw-max-w-full tw-rounded-[var(--radius-inline)] tw-border tw-border-[var(--border)] tw-bg-[var(--bg-sunken)] tw-px-2 tw-py-1 tw-text-[11px] tw-font-semibold tw-text-[var(--text-primary)] focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-[var(--focus-ring)]"
+                        className="webclipper-field tw-min-w-0 tw-w-56 tw-max-w-full tw-px-2 tw-py-1 tw-text-[11px] tw-font-semibold tw-text-[var(--text-primary)]"
                         value={urlDraft}
                         onChange={(e) => setUrlDraft(e.target.value)}
                         placeholder="https://"

--- a/src/ui/conversations/ConversationDetailPane.tsx
+++ b/src/ui/conversations/ConversationDetailPane.tsx
@@ -327,7 +327,7 @@ export function ConversationDetailPane({
                     <>
                       <input
                         ref={urlInputRef}
-                        className="tw-min-w-0 tw-w-56 tw-max-w-full tw-rounded-[var(--radius-control)] tw-border tw-border-[var(--border)] tw-bg-[var(--bg-sunken)] tw-px-2 tw-py-1 tw-text-[11px] tw-font-semibold tw-text-[var(--text-primary)] focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-[var(--focus-ring)]"
+                        className="tw-min-w-0 tw-w-56 tw-max-w-full tw-rounded-[var(--radius-inline)] tw-border tw-border-[var(--border)] tw-bg-[var(--bg-sunken)] tw-px-2 tw-py-1 tw-text-[11px] tw-font-semibold tw-text-[var(--text-primary)] focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-[var(--focus-ring)]"
                         value={urlDraft}
                         onChange={(e) => setUrlDraft(e.target.value)}
                         placeholder="https://"

--- a/src/ui/conversations/ConversationListPane.tsx
+++ b/src/ui/conversations/ConversationListPane.tsx
@@ -774,23 +774,14 @@ export function ConversationListPane({
                   </div>
 
                   <div className="tw-mt-1 tw-flex tw-flex-wrap tw-items-center tw-gap-2 tw-text-[11px] tw-font-semibold tw-text-inherit tw-opacity-80">
-                    <span
-                      className="tw-inline-flex"
-                      {...tooltipAttrs(
-                        copiedId === id
-                          ? `${t('copied')} · ${t('tooltipCopyFullMarkdownDetailed')}`
-                          : t('tooltipCopyFullMarkdownDetailed'),
-                      )}
+                    <button
+                      className={buttonMiniIconClassName(isActive)}
+                      type="button"
+                      aria-label={t('copyFullMarkdown')}
+                      onClick={(e) => void onCopyConversation(conversation as any, e)}
                     >
-                      <button
-                        className={buttonMiniIconClassName(isActive)}
-                        type="button"
-                        aria-label={t('copyFullMarkdown')}
-                        onClick={(e) => void onCopyConversation(conversation as any, e)}
-                      >
-                        {copiedId === id ? '✓' : '⧉'}
-                      </button>
-                    </span>
+                      {copiedId === id ? '✓' : '⧉'}
+                    </button>
 
                     <button
                       type="button"

--- a/src/ui/conversations/ConversationListPane.tsx
+++ b/src/ui/conversations/ConversationListPane.tsx
@@ -151,6 +151,8 @@ export function ConversationListPane({
 
   const [copiedId, setCopiedId] = useState<number | null>(null);
   const copiedTimerRef = useRef<number | null>(null);
+  const [copiedLinkId, setCopiedLinkId] = useState<number | null>(null);
+  const copiedLinkTimerRef = useRef<number | null>(null);
   const [enabledSyncProviders, setEnabledSyncProviders] = useState<SyncProvider[]>(['obsidian', 'notion']);
 
   const [, forceDeleteConfirmRender] = useState(0);
@@ -317,6 +319,8 @@ export function ConversationListPane({
     return () => {
       if (copiedTimerRef.current) window.clearTimeout(copiedTimerRef.current);
       copiedTimerRef.current = null;
+      if (copiedLinkTimerRef.current) window.clearTimeout(copiedLinkTimerRef.current);
+      copiedLinkTimerRef.current = null;
     };
   }, []);
 
@@ -539,14 +543,21 @@ export function ConversationListPane({
     }
   };
 
-  const onCopyConversationUrl = async (url: string, e: React.MouseEvent) => {
+  const onCopyConversationUrl = async (conversation: Conversation, e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    const safe = sanitizeHttpUrl(url);
+    const safe = sanitizeHttpUrl((conversation as any).url || '');
     if (!safe) return;
+    const id = Number((conversation as any).id);
     try {
       const copied = await writeTextToClipboard(safe);
       if (!copied) throw new Error(t('copyFailed'));
+      setCopiedLinkId(id);
+      if (copiedLinkTimerRef.current) window.clearTimeout(copiedLinkTimerRef.current);
+      copiedLinkTimerRef.current = window.setTimeout(() => {
+        setCopiedLinkId(null);
+        copiedLinkTimerRef.current = null;
+      }, 1100);
     } catch (err) {
       alert((err as any)?.message ?? t('copyFailed'));
     }
@@ -784,7 +795,7 @@ export function ConversationListPane({
                     <button
                       type="button"
                       className={[
-                        'tw-inline-flex tw-appearance-none tw-items-center tw-border tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-extrabold',
+                        'tw-relative tw-inline-flex tw-appearance-none tw-items-center tw-border tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-extrabold',
                         'tw-rounded-[var(--radius-chip)]',
                         safeUrl
                           ? 'tw-cursor-pointer focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-[var(--focus-ring)]'
@@ -794,9 +805,18 @@ export function ConversationListPane({
                       aria-label={`${t('detailHeaderCopyLinkMenuLabel')}: ${sourceTag.label}`}
                       data-conversation-source-link={String(id)}
                       disabled={!safeUrl}
-                      onClick={(e) => void onCopyConversationUrl(String((conversation as any).url || ''), e)}
+                      onClick={(e) => void onCopyConversationUrl(conversation as any, e)}
                     >
-                      {sourceTag.label}
+                      <span className={copiedLinkId === id ? 'tw-invisible' : undefined}>{sourceTag.label}</span>
+                      {copiedLinkId === id ? (
+                        <span
+                          className="tw-absolute tw-inset-0 tw-flex tw-items-center tw-justify-center"
+                          data-conversation-source-link-check={String(id)}
+                          aria-hidden="true"
+                        >
+                          ✓
+                        </span>
+                      ) : null}
                     </button>
 
                     {Number.isFinite(commentThreadCount) && commentThreadCount > 0 ? (

--- a/src/ui/conversations/ConversationListPane.tsx
+++ b/src/ui/conversations/ConversationListPane.tsx
@@ -226,6 +226,22 @@ export function ConversationListPane({
       }),
     [earlierGroupLabel, filteredItems, sidebarLocale, todayGroupLabel, yesterdayGroupLabel],
   );
+  const sectionIdsByKey = useMemo(() => {
+    const idsByKey = new Map<string, number[]>();
+    let activeSectionKey = '';
+    for (const entry of renderedItems) {
+      if (entry.type === 'section') {
+        activeSectionKey = entry.key;
+        idsByKey.set(activeSectionKey, []);
+        continue;
+      }
+      if (!activeSectionKey) continue;
+      const id = Number((entry.conversation as any)?.id);
+      if (!Number.isFinite(id) || id <= 0) continue;
+      idsByKey.get(activeSectionKey)?.push(id);
+    }
+    return idsByKey;
+  }, [renderedItems]);
   const todayCount = Number((listSummary as any)?.todayCount) || 0;
   const totalCount = Number((listSummary as any)?.totalCount) || 0;
 
@@ -673,14 +689,23 @@ export function ConversationListPane({
 
           {renderedItems.map((entry) => {
             if (entry.type === 'section') {
+              const sectionIds = sectionIdsByKey.get(entry.key) || [];
+              const selectedInSection = sectionIds.filter((id) => selectedIds.includes(id)).length;
+              const sectionAllSelected = sectionIds.length > 0 && selectedInSection === sectionIds.length;
               return (
                 <div
                   key={entry.key}
                   className="tw-sticky tw-top-0 tw-z-10 -tw-mx-3 tw-w-auto tw-bg-[var(--bg-primary)] tw-px-3 tw-py-1.5"
                 >
-                  <div className="tw-inline-flex tw-items-center tw-rounded-[var(--radius-chip)] tw-border tw-border-[var(--border)] tw-bg-[var(--bg-sunken)] tw-px-2.5 tw-py-1 tw-text-[11px] tw-font-extrabold tw-text-[var(--text-secondary)]">
+                  <button
+                    type="button"
+                    className="tw-inline-flex tw-cursor-pointer tw-appearance-none tw-items-center tw-rounded-[var(--radius-chip)] tw-border tw-border-[var(--border)] tw-bg-[var(--bg-sunken)] tw-px-2.5 tw-py-1 tw-text-[11px] tw-font-extrabold tw-text-[var(--text-secondary)] focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-[var(--focus-ring)]"
+                    data-conversation-section-select={entry.key}
+                    aria-pressed={sectionAllSelected}
+                    onClick={() => toggleAll(sectionIds)}
+                  >
                     {entry.label}
-                  </div>
+                  </button>
                 </div>
               );
             }

--- a/src/ui/conversations/ConversationListPane.tsx
+++ b/src/ui/conversations/ConversationListPane.tsx
@@ -25,6 +25,7 @@ import {
   buttonDangerClassName,
   buttonDangerTintClassName,
   buttonFilledClassName,
+  buttonCompactMutedClassName,
   buttonMenuItemClassName,
   buttonMiniIconClassName,
   buttonTintClassName,
@@ -710,7 +711,7 @@ export function ConversationListPane({
                 >
                   <button
                     type="button"
-                    className="tw-inline-flex tw-cursor-pointer tw-appearance-none tw-items-center tw-rounded-[var(--radius-chip)] tw-border tw-border-[var(--border)] tw-bg-[var(--bg-sunken)] tw-px-2.5 tw-py-1 tw-text-[11px] tw-font-extrabold tw-text-[var(--text-secondary)] focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-[var(--focus-ring)]"
+                    className={buttonCompactMutedClassName()}
                     data-conversation-section-select={entry.key}
                     aria-pressed={sectionAllSelected}
                     onClick={() => toggleAll(sectionIds)}
@@ -785,14 +786,7 @@ export function ConversationListPane({
 
                     <button
                       type="button"
-                      className={[
-                        'tw-relative tw-inline-flex tw-appearance-none tw-items-center tw-border tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-extrabold',
-                        'tw-rounded-[var(--radius-chip)]',
-                        safeUrl
-                          ? 'tw-cursor-pointer focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-[var(--focus-ring)]'
-                          : 'tw-cursor-default',
-                        sourceTag.toneClassName,
-                      ].join(' ')}
+                      className={[buttonCompactMutedClassName(), 'tw-relative'].join(' ')}
                       aria-label={`${t('detailHeaderCopyLinkMenuLabel')}: ${sourceTag.label}`}
                       data-conversation-source-link={String(id)}
                       disabled={!safeUrl}
@@ -812,7 +806,7 @@ export function ConversationListPane({
 
                     {Number.isFinite(commentThreadCount) && commentThreadCount > 0 ? (
                       <span
-                        className="tw-inline-flex tw-items-center tw-rounded-[var(--radius-chip)] tw-border tw-border-[var(--border)] tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-extrabold"
+                        className="tw-inline-flex tw-items-center tw-text-[10px] tw-font-extrabold"
                         aria-label={`Comment threads ${commentThreadCount}`}
                       >
                         {'💬 '}

--- a/src/ui/conversations/ConversationListPane.tsx
+++ b/src/ui/conversations/ConversationListPane.tsx
@@ -6,7 +6,7 @@ import { formatConversationMarkdownForExternalOutput } from '@services/integrati
 import { writeTextToClipboard } from '@services/shared/clipboard';
 import { createTwoStepConfirmController } from '@services/shared/two-step-confirm';
 import { sanitizeHttpUrl } from '@services/url-cleaning/http-url';
-import { tabsCreate, openOrFocusExtensionAppTab } from '@services/shared/webext';
+import { openOrFocusExtensionAppTab } from '@services/shared/webext';
 import { storageOnChanged } from '@services/shared/storage';
 import { buildConversationSidebarRenderItems } from '@services/conversations/domain/sidebar-time-groups';
 
@@ -494,6 +494,10 @@ export function ConversationListPane({
   const onRowKeyDown = (e: React.KeyboardEvent, conversationId: number) => {
     if (!e) return;
     if (e.key !== 'Enter' && e.key !== ' ') return;
+    const target = e.target as any;
+    if (target && target.closest) {
+      if (target.closest("input[type='checkbox'], label, button, a")) return;
+    }
     e.preventDefault();
     e.stopPropagation();
     activateRow(conversationId);
@@ -519,15 +523,16 @@ export function ConversationListPane({
     }
   };
 
-  const openConversationUrl = async (url: string, e: React.MouseEvent) => {
+  const onCopyConversationUrl = async (url: string, e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
     const safe = sanitizeHttpUrl(url);
     if (!safe) return;
     try {
-      await tabsCreate({ url: safe });
-    } catch (_e) {
-      // ignore
+      const copied = await writeTextToClipboard(safe);
+      if (!copied) throw new Error(t('copyFailed'));
+    } catch (err) {
+      alert((err as any)?.message ?? t('copyFailed'));
     }
   };
 
@@ -751,32 +756,23 @@ export function ConversationListPane({
                       </button>
                     </span>
 
-                    <span
-                      className="tw-inline-flex"
-                      {...tooltipAttrs(
-                        safeUrl ? t('tooltipOpenChatDetailed') : t('tooltipOpenChatMissingLinkDetailed'),
-                      )}
-                    >
-                      <button
-                        className={buttonMiniIconClassName(isActive)}
-                        type="button"
-                        aria-label={t('openOriginalChat')}
-                        disabled={!safeUrl}
-                        onClick={(e) => void openConversationUrl(String((conversation as any).url || ''), e)}
-                      >
-                        ↗
-                      </button>
-                    </span>
-
-                    <span
+                    <button
+                      type="button"
                       className={[
-                        'tw-inline-flex tw-items-center tw-border tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-extrabold',
+                        'tw-inline-flex tw-appearance-none tw-items-center tw-border tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-extrabold',
                         'tw-rounded-[var(--radius-chip)]',
+                        safeUrl
+                          ? 'tw-cursor-pointer focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-[var(--focus-ring)]'
+                          : 'tw-cursor-default',
                         sourceTag.toneClassName,
                       ].join(' ')}
+                      aria-label={`${t('detailHeaderCopyLinkMenuLabel')}: ${sourceTag.label}`}
+                      data-conversation-source-link={String(id)}
+                      disabled={!safeUrl}
+                      onClick={(e) => void onCopyConversationUrl(String((conversation as any).url || ''), e)}
                     >
                       {sourceTag.label}
-                    </span>
+                    </button>
 
                     {Number.isFinite(commentThreadCount) && commentThreadCount > 0 ? (
                       <span

--- a/src/ui/conversations/DetailHeaderActionBar.tsx
+++ b/src/ui/conversations/DetailHeaderActionBar.tsx
@@ -56,19 +56,30 @@ export function DetailHeaderActionBar({
   const [menuOpen, setMenuOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const [primaryActionId, setPrimaryActionId] = useState('');
+  const [copiedActionId, setCopiedActionId] = useState('');
   const [labelOverride, setLabelOverride] = useState<string>('');
+  const copiedResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const labelResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleTrigger = async (action: DetailHeaderAction) => {
     if (busy || action.disabled) return;
+    if (copiedResetTimerRef.current != null) globalThis.clearTimeout(copiedResetTimerRef.current);
+    copiedResetTimerRef.current = null;
     if (labelResetTimerRef.current != null) globalThis.clearTimeout(labelResetTimerRef.current);
     labelResetTimerRef.current = null;
+    setCopiedActionId('');
     setLabelOverride('');
     setPrimaryActionId(action.id);
     setBusy(true);
     try {
       await action.onTrigger();
-      if (action.afterTriggerLabel) {
+      if (action.kind === 'copy-text' && !inlineMenuItems) {
+        setCopiedActionId(action.id);
+        copiedResetTimerRef.current = globalThis.setTimeout(() => {
+          setCopiedActionId('');
+          copiedResetTimerRef.current = null;
+        }, 1_100);
+      } else if (action.afterTriggerLabel) {
         setLabelOverride(String(action.afterTriggerLabel));
         labelResetTimerRef.current = globalThis.setTimeout(() => {
           setLabelOverride('');
@@ -90,6 +101,8 @@ export function DetailHeaderActionBar({
 
   useEffect(() => {
     return () => {
+      if (copiedResetTimerRef.current != null) globalThis.clearTimeout(copiedResetTimerRef.current);
+      copiedResetTimerRef.current = null;
       if (labelResetTimerRef.current != null) globalThis.clearTimeout(labelResetTimerRef.current);
       labelResetTimerRef.current = null;
     };
@@ -97,7 +110,18 @@ export function DetailHeaderActionBar({
 
   if (!actions.length) return null;
 
-  const resolveInlineActionIcon = (action: DetailHeaderAction) => {
+  const resolveActionIcon = (action: DetailHeaderAction) => {
+    if (action.kind === 'copy-text' && copiedActionId === action.id) {
+      return (
+        <span
+          className="tw-inline-flex tw-h-4 tw-w-4 tw-items-center tw-justify-center"
+          data-detail-header-copy-check={action.id}
+          aria-hidden="true"
+        >
+          ✓
+        </span>
+      );
+    }
     const logo = providerLogo(action);
     if (logo) return logo;
     if (action.kind === 'copy-text') return <Copy size={16} strokeWidth={2} aria-hidden="true" />;
@@ -124,7 +148,7 @@ export function DetailHeaderActionBar({
             }}
           >
             <span className="tw-inline-flex tw-items-center tw-gap-1.5">
-              {resolveInlineActionIcon(action)}
+              {resolveActionIcon(action)}
               <span className="tw-whitespace-normal tw-break-words">{action.label}</span>
             </span>
           </button>
@@ -144,7 +168,7 @@ export function DetailHeaderActionBar({
   ) : null;
   if (actions.length === 1) {
     const action = actions[0]!;
-    const resolvedTriggerIcon = providerLogo(action) || <ExternalLink size={16} strokeWidth={2} aria-hidden="true" />;
+    const resolvedTriggerIcon = resolveActionIcon(action);
     return (
       <div className={['tw-relative tw-flex tw-items-center tw-gap-2', className || ''].join(' ').trim()}>
         <button
@@ -168,9 +192,7 @@ export function DetailHeaderActionBar({
   }
 
   const primaryAction = actions.find((action) => action.id === primaryActionId) || actions[0]!;
-  const resolvedTriggerIcon = providerLogo(primaryAction) || (
-    <ExternalLink size={16} strokeWidth={2} aria-hidden="true" />
-  );
+  const resolvedTriggerIcon = resolveActionIcon(primaryAction);
   const resolvedMenuTriggerLabel = String(menuTriggerLabel || '').trim() || 'Open in...';
   const resolvedMenuTriggerAriaLabel = String(menuTriggerAriaLabel || '').trim() || 'Open destinations';
   const resolvedMenuAriaLabel = String(menuAriaLabel || '').trim() || resolvedMenuTriggerAriaLabel;

--- a/src/ui/conversations/DetailHeaderActionBar.tsx
+++ b/src/ui/conversations/DetailHeaderActionBar.tsx
@@ -110,6 +110,10 @@ export function DetailHeaderActionBar({
 
   if (!actions.length) return null;
 
+  const copyOnly = actions.every((action) => action.kind === 'copy-text');
+  const resolveActionTooltipAttrs = (action: DetailHeaderAction) =>
+    action.kind === 'copy-text' ? {} : tooltipAttrs(action.label);
+
   const resolveActionIcon = (action: DetailHeaderAction) => {
     if (action.kind === 'copy-text' && copiedActionId === action.id) {
       return (
@@ -174,7 +178,7 @@ export function DetailHeaderActionBar({
         <button
           key={action.id}
           type="button"
-          {...tooltipAttrs(action.label)}
+          {...resolveActionTooltipAttrs(action)}
           onClick={() => {
             void handleTrigger(action);
             closeMenuOnActionTrigger?.();
@@ -204,7 +208,7 @@ export function DetailHeaderActionBar({
         <button
           key={primaryAction.id}
           type="button"
-          {...tooltipAttrs(primaryAction.label)}
+          {...resolveActionTooltipAttrs(primaryAction)}
           onClick={() => {
             void handleTrigger(primaryAction);
             closeMenuOnActionTrigger?.();
@@ -228,7 +232,7 @@ export function DetailHeaderActionBar({
           trigger={(triggerProps) => (
             <button
               {...triggerProps}
-              {...tooltipAttrs(resolvedMenuTriggerLabel)}
+              {...(copyOnly ? {} : tooltipAttrs(resolvedMenuTriggerLabel))}
               aria-label={resolvedMenuTriggerAriaLabel}
               className={buttonClassName}
             >

--- a/src/ui/conversations/DetailHeaderActionBar.tsx
+++ b/src/ui/conversations/DetailHeaderActionBar.tsx
@@ -165,7 +165,7 @@ export function DetailHeaderActionBar({
     <span
       role="status"
       aria-live="polite"
-      className="tw-absolute tw-right-0 tw-top-[calc(100%+6px)] tw-z-10 tw-whitespace-nowrap tw-rounded-[var(--radius-control)] tw-border tw-border-[var(--border)] tw-bg-[var(--bg-card)] tw-px-2 tw-py-1 tw-text-[11px] tw-font-semibold tw-text-[var(--text-primary)] tw-shadow-[0_8px_24px_rgba(0,0,0,0.14)]"
+      className="tw-absolute tw-right-0 tw-top-[calc(100%+6px)] tw-z-10 tw-whitespace-nowrap tw-rounded-[var(--radius-inline)] tw-border tw-border-[var(--border)] tw-bg-[var(--bg-card)] tw-px-2 tw-py-1 tw-text-[11px] tw-font-semibold tw-text-[var(--text-primary)] tw-shadow-[0_8px_24px_rgba(0,0,0,0.14)]"
     >
       {labelOverride}
     </span>

--- a/src/ui/conversations/conversation-list-tags.ts
+++ b/src/ui/conversations/conversation-list-tags.ts
@@ -23,28 +23,6 @@ const SOURCE_LABEL_MAP: Record<string, SourceLabelMapItem> = {
   web: { key: 'web', i18nKey: 'sourceWeb' },
 };
 
-const SOURCE_TONE_CLASS_MAP: Record<string, string> = {
-  chatgpt:
-    'tw-border-[var(--brand-chatgpt)] tw-bg-[color-mix(in_srgb,var(--brand-chatgpt)_12%,var(--bg-card))] tw-text-[var(--text-primary)]',
-  deepseek:
-    'tw-border-[var(--brand-deepseek)] tw-bg-[color-mix(in_srgb,var(--brand-deepseek)_12%,var(--bg-card))] tw-text-[var(--text-primary)]',
-  notionai:
-    'tw-border-[var(--brand-notionai)] tw-bg-[color-mix(in_srgb,var(--brand-notionai)_12%,var(--bg-card))] tw-text-[var(--text-primary)]',
-  gemini:
-    'tw-border-[var(--brand-gemini)] tw-bg-[color-mix(in_srgb,var(--brand-gemini)_12%,var(--bg-card))] tw-text-[var(--text-primary)]',
-  googleaistudio:
-    'tw-border-[var(--brand-googleaistudio)] tw-bg-[color-mix(in_srgb,var(--brand-googleaistudio)_12%,var(--bg-card))] tw-text-[var(--text-primary)]',
-  kimi: 'tw-border-[var(--brand-kimi)] tw-bg-[color-mix(in_srgb,var(--brand-kimi)_12%,var(--bg-card))] tw-text-[var(--text-primary)]',
-  doubao:
-    'tw-border-[var(--brand-doubao)] tw-bg-[color-mix(in_srgb,var(--brand-doubao)_12%,var(--bg-card))] tw-text-[var(--text-primary)]',
-  yuanbao:
-    'tw-border-[var(--brand-yuanbao)] tw-bg-[color-mix(in_srgb,var(--brand-yuanbao)_12%,var(--bg-card))] tw-text-[var(--text-primary)]',
-  poe: 'tw-border-[var(--brand-poe)] tw-bg-[color-mix(in_srgb,var(--brand-poe)_12%,var(--bg-card))] tw-text-[var(--text-primary)]',
-  zai: 'tw-border-[var(--brand-zai)] tw-bg-[color-mix(in_srgb,var(--brand-zai)_12%,var(--bg-card))] tw-text-[var(--text-primary)]',
-  web: 'tw-border-[var(--border)] tw-bg-[var(--bg-sunken)] tw-text-[var(--text-secondary)]',
-  unknown: 'tw-border-[var(--border)] tw-bg-[var(--bg-sunken)] tw-text-[var(--text-secondary)]',
-};
-
 function safeString(value: unknown): string {
   return String(value ?? '').trim();
 }
@@ -108,10 +86,9 @@ export function resolveConversationSourceOptionLabel(input: {
 export function resolveConversationListTag(input: {
   conversation: Pick<Conversation, 'source' | 'listSourceKey' | 'listSiteKey' | 'url'>;
   translate: Translate;
-}): { sourceKey: string; label: string; toneClassName: string } {
+}): { sourceKey: string; label: string } {
   const conversation = input.conversation;
   const sourceKey = resolveConversationSourceKey(conversation);
   const label = resolveSourceLabel(sourceKey, conversation?.source, conversation, input.translate);
-  const toneClassName = SOURCE_TONE_CLASS_MAP[sourceKey] || SOURCE_TONE_CLASS_MAP.unknown;
-  return { sourceKey, label, toneClassName };
+  return { sourceKey, label };
 }

--- a/src/ui/i18n/locales/en.ts
+++ b/src/ui/i18n/locales/en.ts
@@ -272,7 +272,6 @@ export const en = {
   tooltipLoadedVisibleSelectionScope: 'Only currently loaded visible items',
   copyFullMarkdown: 'Copy full markdown',
   copied: 'Copied',
-  tooltipCopyFullMarkdownDetailed: 'Copy the full conversation as Markdown',
   openChat: 'Open chat',
   noLinkAvailable: 'No link available',
   tooltipOpenChatDetailed: 'Open the original link in a new tab',

--- a/src/ui/i18n/locales/zh.ts
+++ b/src/ui/i18n/locales/zh.ts
@@ -268,7 +268,6 @@ export const zh: { [K in TranslationKey]: string } = {
   tooltipLoadedVisibleSelectionScope: '仅当前已加载可见项',
   copyFullMarkdown: '复制完整 Markdown',
   copied: '已复制',
-  tooltipCopyFullMarkdownDetailed: '将该对话完整复制为 Markdown',
   openChat: '打开原始对话',
   noLinkAvailable: '暂无链接',
   tooltipOpenChatDetailed: '在新标签页打开原始链接',

--- a/src/ui/popup/PopupShell.tsx
+++ b/src/ui/popup/PopupShell.tsx
@@ -102,7 +102,7 @@ function PopupSyncNudgeDialog(props: PopupSyncNudgeDialogProps) {
         <div className="tw-text-sm tw-font-extrabold">{title}</div>
         <div className="tw-mt-2 tw-text-xs tw-font-semibold tw-text-[var(--text-secondary)]">{body}</div>
 
-        <label className="tw-mt-3 tw-flex tw-cursor-pointer tw-select-none tw-items-start tw-gap-2 tw-rounded-[var(--radius-control)] tw-border tw-border-[var(--border)] tw-bg-[var(--bg-sunken)] tw-p-2.5">
+        <label className="tw-mt-3 tw-flex tw-cursor-pointer tw-select-none tw-items-start tw-gap-2 tw-rounded-[var(--radius-inline)] tw-border tw-border-[var(--border)] tw-bg-[var(--bg-sunken)] tw-p-2.5">
           <input
             type="checkbox"
             checked={dontShowAgain}

--- a/src/ui/reader/NarrationPanel.tsx
+++ b/src/ui/reader/NarrationPanel.tsx
@@ -129,7 +129,7 @@ export function NarrationPanel({ prefs, update, error, webSpeechAvailable = true
       {error ? (
         <div
           role="alert"
-          className="tw-flex tw-flex-col tw-gap-2 tw-rounded-[var(--radius-control)] tw-border tw-border-[var(--border)] tw-bg-[var(--bg-sunken)] tw-p-2 tw-text-xs tw-text-[var(--text-primary)]"
+          className="tw-flex tw-flex-col tw-gap-2 tw-rounded-[var(--radius-inline)] tw-border tw-border-[var(--border)] tw-bg-[var(--bg-sunken)] tw-p-2 tw-text-xs tw-text-[var(--text-primary)]"
         >
           <span>{error}</span>
           {tts.engine === 'ai' ? (

--- a/src/ui/settings/sections/ChatWithAiSection.tsx
+++ b/src/ui/settings/sections/ChatWithAiSection.tsx
@@ -11,8 +11,7 @@ import {
 } from '@ui/settings/ui';
 import { SettingsFormRow } from '@ui/settings/sections/SettingsFormRow';
 
-const textareaClassName =
-  'tw-min-h-[140px] tw-w-full tw-rounded-xl tw-border tw-border-[var(--border)] tw-bg-[var(--bg-sunken)] tw-px-2.5 tw-py-2 tw-text-sm tw-text-[var(--text-primary)] focus-visible:tw-border-[var(--focus-ring)] focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-[var(--focus-ring)]';
+const textareaClassName = `${textInputClassName} tw-min-h-[140px] tw-w-full tw-py-2`;
 
 function makePlatformId(): string {
   const rand = Math.random().toString(16).slice(2, 10);

--- a/src/ui/settings/sections/GitHubSettingsSection.tsx
+++ b/src/ui/settings/sections/GitHubSettingsSection.tsx
@@ -127,7 +127,7 @@ export function GitHubSettingsSection(props: {
     <>
       <section className={cardClassName} aria-label={t('githubSettingsTitle')}>
         <div className="tw-flex tw-items-center tw-gap-2">
-          <span className="tw-inline-flex tw-h-6 tw-w-6 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-[var(--radius-control)] tw-bg-white tw-p-0.5">
+          <span className="tw-inline-flex tw-h-6 tw-w-6 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-[var(--radius-inline)] tw-bg-white tw-p-0.5">
             <img className="tw-h-5 tw-w-5" src={githubLogoUrl} alt="" aria-hidden="true" />
           </span>
           <div className="tw-min-w-0 tw-flex-1">

--- a/src/ui/settings/sections/InpageSection.tsx
+++ b/src/ui/settings/sections/InpageSection.tsx
@@ -20,7 +20,7 @@ function UserNameCard(props: { value: string; onChange: (next: string) => void; 
       </h2>
       <input
         className={[
-          'tw-mt-3 tw-w-full tw-rounded-[var(--radius-control)] tw-border tw-border-[var(--border)] tw-bg-[var(--bg-primary)]',
+          'tw-mt-3 tw-w-full tw-rounded-[var(--radius-inline)] tw-border tw-border-[var(--border)] tw-bg-[var(--bg-primary)]',
           'tw-px-3 tw-py-2 tw-text-sm tw-font-semibold tw-text-[var(--text-primary)]',
           'focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-[var(--focus-ring)] focus-visible:tw-ring-offset-2',
           'focus-visible:tw-ring-offset-[var(--bg-card)]',

--- a/src/ui/settings/sections/InpageSection.tsx
+++ b/src/ui/settings/sections/InpageSection.tsx
@@ -1,6 +1,6 @@
 import { t, type LocalePreference } from '@i18n';
 import { SUPPORTED_AI_CHAT_SITES } from '@collectors/ai-chat-sites';
-import { buttonClassName, cardClassName, checkboxClassName } from '@ui/settings/ui';
+import { buttonClassName, cardClassName, checkboxClassName, textInputClassName } from '@ui/settings/ui';
 import { buttonTintClassName } from '@ui/shared/button-styles';
 import { SelectMenu } from '@ui/shared/SelectMenu';
 import {
@@ -19,12 +19,7 @@ function UserNameCard(props: { value: string; onChange: (next: string) => void; 
         {t('aboutYouUserNameSectionTitle')}
       </h2>
       <input
-        className={[
-          'tw-mt-3 tw-w-full tw-rounded-[var(--radius-inline)] tw-border tw-border-[var(--border)] tw-bg-[var(--bg-primary)]',
-          'tw-px-3 tw-py-2 tw-text-sm tw-font-semibold tw-text-[var(--text-primary)]',
-          'focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-[var(--focus-ring)] focus-visible:tw-ring-offset-2',
-          'focus-visible:tw-ring-offset-[var(--bg-card)]',
-        ].join(' ')}
+        className={`${textInputClassName} tw-mt-3 tw-w-full tw-px-3 tw-py-2 tw-font-semibold`}
         value={value}
         onChange={(e) => onChange(String((e.target as any)?.value || ''))}
         onBlur={onSave}

--- a/src/ui/settings/ui.ts
+++ b/src/ui/settings/ui.ts
@@ -10,7 +10,7 @@ export const primaryButtonClassName = buttonFilledClassName();
 export const dangerButtonClassName = buttonDangerTintClassName();
 
 export const textInputClassName =
-  'tw-min-h-9 tw-rounded-[var(--radius-control)] tw-border tw-border-[var(--border)] tw-bg-[var(--bg-sunken)] tw-px-2.5 tw-text-sm tw-text-[var(--text-primary)] tw-transition-colors tw-duration-150 hover:tw-bg-[var(--bg-primary)] focus-visible:tw-border-[var(--focus-ring)] focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-[var(--focus-ring)] disabled:tw-cursor-not-allowed disabled:tw-opacity-[0.38]';
+  'tw-min-h-9 tw-rounded-[var(--radius-inline)] tw-border tw-border-[var(--border)] tw-bg-[var(--bg-sunken)] tw-px-2.5 tw-text-sm tw-text-[var(--text-primary)] tw-transition-colors tw-duration-150 hover:tw-bg-[var(--bg-primary)] focus-visible:tw-border-[var(--focus-ring)] focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-[var(--focus-ring)] disabled:tw-cursor-not-allowed disabled:tw-opacity-[0.38]';
 
 export const checkboxClassName =
   'tw-size-[18px] tw-cursor-pointer tw-accent-[var(--accent)] focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-[var(--focus-ring)] disabled:tw-cursor-not-allowed disabled:tw-opacity-[0.38]';

--- a/src/ui/settings/ui.ts
+++ b/src/ui/settings/ui.ts
@@ -9,8 +9,7 @@ export const primaryButtonClassName = buttonFilledClassName();
 
 export const dangerButtonClassName = buttonDangerTintClassName();
 
-export const textInputClassName =
-  'tw-min-h-9 tw-rounded-[var(--radius-inline)] tw-border tw-border-[var(--border)] tw-bg-[var(--bg-sunken)] tw-px-2.5 tw-text-sm tw-text-[var(--text-primary)] tw-transition-colors tw-duration-150 hover:tw-bg-[var(--bg-primary)] focus-visible:tw-border-[var(--focus-ring)] focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-[var(--focus-ring)] disabled:tw-cursor-not-allowed disabled:tw-opacity-[0.38]';
+export const textInputClassName = 'webclipper-field tw-min-h-9 tw-px-2.5 tw-text-sm tw-text-[var(--text-primary)]';
 
 export const checkboxClassName =
   'tw-size-[18px] tw-cursor-pointer tw-accent-[var(--accent)] focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-[var(--focus-ring)] disabled:tw-cursor-not-allowed disabled:tw-opacity-[0.38]';

--- a/src/ui/shared/ChatMessageBubble.tsx
+++ b/src/ui/shared/ChatMessageBubble.tsx
@@ -161,7 +161,7 @@ export function ChatMessageBubble({
   // NOTE: asset URLs are resolved before render via markdown-it env;
   // no post-render DOM hydration is needed, which avoids re-render race conditions.
 
-  const bubbleBase = 'tw-min-w-0 tw-border tw-rounded-[var(--radius-chip)] tw-p-3 tw-shadow-none';
+  const bubbleBase = 'tw-min-w-0 tw-border tw-rounded-[var(--radius-inline)] tw-p-3 tw-shadow-none';
 
   const bubbleRoleClass =
     bubbleRole === 'user'

--- a/src/ui/shared/button-styles.ts
+++ b/src/ui/shared/button-styles.ts
@@ -47,6 +47,10 @@ export function buttonIconCircleGhostClassName(): string {
   return 'webclipper-btn webclipper-btn--icon webclipper-btn--icon-xxs webclipper-btn--tone-muted';
 }
 
+export function buttonCompactMutedClassName(): string {
+  return 'webclipper-btn webclipper-btn--compact webclipper-btn--tone-muted';
+}
+
 export function buttonMiniIconClassName(active: boolean): string {
   if (active) return 'webclipper-btn webclipper-btn--icon webclipper-btn--icon-xxs';
   return 'webclipper-btn webclipper-btn--icon webclipper-btn--icon-xxs webclipper-btn--tone-muted';

--- a/src/ui/shared/nav-styles.ts
+++ b/src/ui/shared/nav-styles.ts
@@ -2,8 +2,8 @@ import { buttonTintClassName } from '@ui/shared/button-styles';
 
 export function navItemClassName(active: boolean): string {
   const base = [
-    // Sidebar item follows shared chip-level radius token and existing spacing.
-    'tw-flex tw-min-h-9 tw-w-full tw-cursor-pointer tw-appearance-none tw-items-center tw-gap-2 tw-rounded-[var(--radius-chip)] tw-border-0 tw-px-3 tw-py-2 tw-text-left tw-text-[13px] tw-shadow-none',
+    // Sidebar items use the same inline control radius as the shared button system.
+    'tw-flex tw-min-h-9 tw-w-full tw-cursor-pointer tw-appearance-none tw-items-center tw-gap-2 tw-rounded-[var(--radius-inline)] tw-border-0 tw-px-3 tw-py-2 tw-text-left tw-text-[13px] tw-shadow-none',
     'tw-transition-colors tw-duration-150',
     'focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-[var(--focus-ring)]',
   ].join(' ');

--- a/src/ui/styles/buttons.css
+++ b/src/ui/styles/buttons.css
@@ -1,3 +1,16 @@
+.webclipper-btn,
+.webclipper-field {
+  /* Shared control edge: same radius, border, and bevel language. */
+  --edge-stroke-tl: color-mix(in srgb, var(--edge-surface) 62%, white);
+  --edge-stroke-br: color-mix(in srgb, var(--edge-surface) 74%, black);
+
+  border: 1px solid var(--border);
+  border-radius: var(--radius-inline);
+  box-shadow:
+    inset 1px 1px 0 var(--edge-stroke-tl),
+    inset -1px -1px 0 var(--edge-stroke-br);
+}
+
 .webclipper-btn {
   /* Reset */
   appearance: none;
@@ -12,7 +25,6 @@
   gap: 6px;
   min-height: 36px;
   padding: 0 12px;
-  border-radius: var(--radius-inline);
   cursor: pointer;
 
   /* Typography */
@@ -20,18 +32,9 @@
   font-weight: 800;
   line-height: 1;
 
-  /* Bevel strokes derive from the actual surface color. */
-  --btn-surface: var(--bg-card);
-  --btn-stroke-tl: color-mix(in srgb, var(--btn-surface) 62%, white);
-  --btn-stroke-br: color-mix(in srgb, var(--btn-surface) 74%, black);
-
-  border: 1px solid var(--border);
-  background-color: var(--bg-card);
+  --edge-surface: var(--bg-card);
+  background-color: var(--edge-surface);
   color: var(--text-primary);
-
-  box-shadow:
-    inset 1px 1px 0 var(--btn-stroke-tl),
-    inset -1px -1px 0 var(--btn-stroke-br);
 
   transition:
     background-color 160ms ease,
@@ -42,19 +45,46 @@
     opacity 160ms ease;
 }
 
+.webclipper-field {
+  appearance: none;
+  box-sizing: border-box;
+  font: inherit;
+
+  --edge-surface: var(--bg-sunken);
+  background-color: var(--edge-surface);
+  color: var(--text-primary);
+
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    box-shadow 120ms ease,
+    opacity 160ms ease;
+}
+
+.webclipper-field:hover:not(:disabled) {
+  --edge-surface: var(--bg-primary);
+  background-color: var(--edge-surface);
+}
+
 .webclipper-btn:active {
   box-shadow:
-    inset 1px 1px 0 var(--btn-stroke-br),
-    inset -1px -1px 0 var(--btn-stroke-tl);
+    inset 1px 1px 0 var(--edge-stroke-br),
+    inset -1px -1px 0 var(--edge-stroke-tl);
   transform: translateY(1px);
 }
 
-.webclipper-btn:focus-visible {
+.webclipper-btn:focus-visible,
+.webclipper-field:focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
 }
 
-.webclipper-btn:disabled {
+.webclipper-field:focus-visible {
+  border-color: var(--focus-ring);
+}
+
+.webclipper-btn:disabled,
+.webclipper-field:disabled {
   cursor: not-allowed;
   opacity: 0.38;
 }
@@ -62,33 +92,36 @@
 .webclipper-btn:not(.webclipper-btn--filled):not(.webclipper-btn--danger):not(.webclipper-btn--danger-tint):not(
     .webclipper-btn--menu-item
   ):hover:not(:disabled) {
-  background-color: var(--bg-sunken);
+  --edge-surface: var(--bg-sunken);
+  background-color: var(--edge-surface);
 }
 
 .webclipper-btn:not(.webclipper-btn--filled):not(.webclipper-btn--danger):not(.webclipper-btn--danger-tint):not(
     .webclipper-btn--menu-item
   )[aria-pressed='true'] {
-  --btn-surface: var(--bg-sunken);
+  --edge-surface: var(--bg-sunken);
   background-color: var(--bg-sunken);
 }
 
 .webclipper-btn--filled {
-  --btn-surface: var(--accent);
+  --edge-surface: var(--accent);
   border: 0;
   background-color: var(--accent);
   color: var(--accent-foreground);
 }
 
 .webclipper-btn--filled:hover:not(:disabled) {
-  background-color: var(--accent-hover);
+  --edge-surface: var(--accent-hover);
+  background-color: var(--edge-surface);
 }
 
 .webclipper-btn--filled:active:not(:disabled) {
-  background-color: var(--accent-active);
+  --edge-surface: var(--accent-active);
+  background-color: var(--edge-surface);
 }
 
 .webclipper-btn--danger {
-  --btn-surface: var(--error);
+  --edge-surface: var(--error);
   border: 0;
   background-color: var(--error);
   color: var(--error-foreground);
@@ -103,18 +136,16 @@
 }
 
 .webclipper-btn--danger-tint {
-  --btn-surface: var(--bg-card);
+  --edge-surface: var(--bg-card);
   border: 1px solid color-mix(in srgb, var(--error) 55%, var(--border));
   background-color: var(--bg-card);
   color: var(--error);
 }
 
-.webclipper-btn--danger-tint:hover:not(:disabled) {
-  background-color: var(--bg-sunken);
-}
-
+.webclipper-btn--danger-tint:hover:not(:disabled),
 .webclipper-btn--danger-tint:active:not(:disabled) {
-  background-color: var(--bg-sunken);
+  --edge-surface: var(--bg-sunken);
+  background-color: var(--edge-surface);
 }
 
 .webclipper-btn--menu-item {
@@ -130,9 +161,9 @@
   padding: 8px 10px;
   border-radius: var(--radius-inline);
 
-  --btn-surface: color-mix(in srgb, var(--bg-card) 88%, transparent);
+  --edge-surface: color-mix(in srgb, var(--bg-card) 88%, transparent);
   border: 1px solid transparent;
-  background-color: var(--btn-surface);
+  background-color: var(--edge-surface);
   color: var(--text-primary);
 
   font-weight: 650;
@@ -140,13 +171,13 @@
 }
 
 .webclipper-btn--menu-item:hover:not(:disabled) {
-  --btn-surface: var(--bg-sunken);
-  background-color: var(--btn-surface);
+  --edge-surface: var(--bg-sunken);
+  background-color: var(--edge-surface);
   border-color: var(--border);
 }
 
 .webclipper-btn--menu-item[aria-checked='true'] {
-  --btn-surface: var(--bg-sunken);
+  --edge-surface: var(--bg-sunken);
   background-color: var(--bg-sunken);
   border-color: var(--border);
 }

--- a/src/ui/styles/buttons.css
+++ b/src/ui/styles/buttons.css
@@ -12,7 +12,7 @@
   gap: 6px;
   min-height: 36px;
   padding: 0 12px;
-  border-radius: var(--radius-chip);
+  border-radius: var(--radius-inline);
   cursor: pointer;
 
   /* Typography */
@@ -151,6 +151,13 @@
   border-color: var(--border);
 }
 
+.webclipper-btn--compact {
+  min-height: 24px;
+  padding: 0 8px;
+  border-radius: var(--radius-inline);
+  font-size: 11px;
+}
+
 .webclipper-btn--icon {
   --btn-icon-size: 36px;
   width: var(--btn-icon-size);
@@ -225,7 +232,7 @@
 }
 
 .webclipper-menu-popover-panel {
-  border-radius: var(--radius-control);
+  border-radius: var(--radius-inline);
 }
 
 .webclipper-menu-popover-backdrop {

--- a/src/ui/styles/inpage-button.css
+++ b/src/ui/styles/inpage-button.css
@@ -8,7 +8,7 @@
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: var(--radius-control);
+  border-radius: var(--radius-inline);
   background: transparent;
   color: inherit;
   font:

--- a/src/ui/styles/inpage-comments-panel.css
+++ b/src/ui/styles/inpage-comments-panel.css
@@ -226,7 +226,7 @@
   max-width: min(300px, 76vw);
   padding: 4px;
   border: 1px solid color-mix(in srgb, var(--panel-border) 88%, transparent);
-  border-radius: var(--radius-control);
+  border-radius: var(--radius-inline);
   background: color-mix(in srgb, var(--panel-bg) 98%, transparent);
   box-shadow: 0 12px 30px rgb(0 0 0 / 16%);
 }
@@ -353,7 +353,7 @@
 .webclipper-inpage-comments-panel__notice {
   margin: 0 0 8px 0;
   padding: 6px 8px;
-  border-radius: var(--radius-chip);
+  border-radius: var(--radius-inline);
   border: 1px solid var(--panel-border);
   background: color-mix(in srgb, var(--panel-bg) 88%, transparent);
   color: var(--panel-text-muted);
@@ -528,7 +528,7 @@
   height: 9px;
   border-bottom: 1px solid color-mix(in srgb, var(--panel-border) 82%, transparent);
   border-left: 1px solid color-mix(in srgb, var(--panel-border) 82%, transparent);
-  border-bottom-left-radius: var(--radius-chip);
+  border-bottom-left-radius: var(--radius-inline);
 }
 
 .webclipper-inpage-comments-panel__icon-btn[data-confirm='1'] {
@@ -586,7 +586,7 @@
   min-width: 0;
   overflow: hidden;
   border: 1px solid var(--panel-border);
-  border-radius: var(--radius-control);
+  border-radius: var(--radius-inline);
   background: color-mix(in srgb, var(--panel-bg) 92%, transparent);
   transition:
     border-color 120ms ease,

--- a/src/ui/styles/inpage-item-mention.css
+++ b/src/ui/styles/inpage-item-mention.css
@@ -4,7 +4,7 @@
   --wm-muted: var(--color-text-2, #666666);
   --wm-border: var(--color-border-1, rgba(0, 0, 0, 0.12));
   --wm-accent: var(--color-accent-1, #2563eb);
-  --wm-radius: var(--radius-control, 12px);
+  --wm-radius: var(--radius-inline, 8px);
   --wm-shadow: 0 18px 46px rgba(0, 0, 0, 0.14);
 
   font-family:

--- a/src/ui/styles/inpage-tip.css
+++ b/src/ui/styles/inpage-tip.css
@@ -32,7 +32,7 @@
   max-width: min(300px, 100vw);
   padding: 7px 11px;
   border: 1px solid var(--bubble-surface-border);
-  border-radius: var(--radius-chip);
+  border-radius: var(--radius-inline);
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0)), var(--bubble-surface-bg);
   color: var(--bubble-surface-text);
   font:

--- a/src/ui/styles/tokens.css
+++ b/src/ui/styles/tokens.css
@@ -26,18 +26,6 @@
   --tertiary: rgb(232 200 106);
   --tertiary-foreground: rgb(44 48 56);
 
-  /* Source brand colors */
-  --brand-chatgpt: #10a37f;
-  --brand-deepseek: #6b7280;
-  --brand-notionai: #111111;
-  --brand-gemini: #4285f4;
-  --brand-googleaistudio: #4285f4;
-  --brand-kimi: #3b82f6;
-  --brand-doubao: #f97316;
-  --brand-yuanbao: #ef4444;
-  --brand-poe: #ec4899;
-  --brand-zai: #14b8a6;
-
   /* Semantic + On-Color */
   --error: rgb(229 62 62);
   --error-foreground: rgb(255 255 255);
@@ -73,8 +61,6 @@
    */
   --radius-outer: 24px;
   --radius-card: 20px;
-  --radius-control: 12px;
-  --radius-chip: 10px;
   --radius-inline: 8px;
   --radius-pill: 999px;
 

--- a/tests/smoke/app-detail-header-actions.test.ts
+++ b/tests/smoke/app-detail-header-actions.test.ts
@@ -295,6 +295,8 @@ describe('ConversationDetailPane header actions', () => {
     const primaryButton = document.querySelector('[aria-label="Copy Notion link"]') as HTMLButtonElement | null;
     expect(trigger).toBeTruthy();
     expect(primaryButton).toBeTruthy();
+    expect(trigger?.getAttribute('data-tooltip-id')).toBeNull();
+    expect(primaryButton?.getAttribute('data-tooltip-id')).toBeNull();
     expect(document.querySelectorAll('[aria-label="Copy destinations"][aria-haspopup="menu"]')).toHaveLength(1);
     expect(trigger?.closest('.tw-order-1')).toBeTruthy();
 

--- a/tests/smoke/app-detail-header-actions.test.ts
+++ b/tests/smoke/app-detail-header-actions.test.ts
@@ -247,7 +247,8 @@ describe('ConversationDetailPane header actions', () => {
     });
     expect(copyTrigger).toHaveBeenCalledTimes(1);
     expect(openTrigger).not.toHaveBeenCalled();
-    expect(document.querySelector('[role="status"]')?.textContent).toBe('Copied');
+    expect(copyButton?.querySelector('[data-detail-header-copy-check="copy-notion-link"]')?.textContent).toBe('✓');
+    expect(document.querySelector('[role="status"]')).toBeFalsy();
     expect(document.body.textContent || '').not.toContain('Copied Notion link');
   });
 
@@ -364,7 +365,7 @@ describe('ConversationDetailPane header actions', () => {
     expect(document.querySelector('[role="status"]')).toBeFalsy();
   });
 
-  it('clears Copied feedback when the same copy action id points to a new href', async () => {
+  it('clears copy success feedback when the same copy action id points to a new href', async () => {
     const firstTrigger = vi.fn(async () => {});
     currentState.detailHeaderActions = [
       {
@@ -388,7 +389,7 @@ describe('ConversationDetailPane header actions', () => {
       await Promise.resolve();
     });
     expect(firstTrigger).toHaveBeenCalledTimes(1);
-    expect(document.querySelector('[role="status"]')?.textContent).toBe('Copied');
+    expect(firstButton.querySelector('[data-detail-header-copy-check="copy-notion-link"]')?.textContent).toBe('✓');
 
     const nextTrigger = vi.fn(async () => {});
     currentState.detailHeaderActions = [
@@ -407,6 +408,7 @@ describe('ConversationDetailPane header actions', () => {
       root!.render(createElement(ConversationDetailPane));
     });
 
+    expect(document.querySelector('[data-detail-header-copy-check="copy-notion-link"]')).toBeFalsy();
     expect(document.querySelector('[role="status"]')).toBeFalsy();
     const nextButton = document.querySelector('[aria-label="Copy Notion link"]') as HTMLButtonElement;
     await act(async () => {
@@ -439,7 +441,7 @@ describe('ConversationDetailPane header actions', () => {
     expect(document.querySelector('[aria-label="Copy Notion link"]')).toBeFalsy();
   });
 
-  it('clears Copied feedback when the copy action set or selected conversation changes', async () => {
+  it('clears copy success feedback when the copy action set or selected conversation changes', async () => {
     vi.useFakeTimers();
     try {
       const copyNotion = {
@@ -461,7 +463,7 @@ describe('ConversationDetailPane header actions', () => {
         button.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
         await Promise.resolve();
       });
-      expect(document.querySelector('[role="status"]')?.textContent).toBe('Copied');
+      expect(button.querySelector('[data-detail-header-copy-check="copy-notion-link"]')?.textContent).toBe('✓');
 
       currentState.detailHeaderActions = [
         copyNotion,
@@ -478,6 +480,7 @@ describe('ConversationDetailPane header actions', () => {
       act(() => {
         root!.render(createElement(ConversationDetailPane));
       });
+      expect(document.querySelector('[data-detail-header-copy-check]')).toBeFalsy();
       expect(document.querySelector('[role="status"]')).toBeFalsy();
 
       const multiTrigger = document.querySelector('[aria-label="Copy destinations"]') as HTMLButtonElement;
@@ -492,7 +495,7 @@ describe('ConversationDetailPane header actions', () => {
         notionItem.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
         await Promise.resolve();
       });
-      expect(document.querySelector('[role="status"]')?.textContent).toBe('Copied');
+      expect(document.querySelector('[data-detail-header-copy-check="copy-notion-link"]')?.textContent).toBe('✓');
 
       currentState.activeId = 12;
       currentState.selectedConversation = {
@@ -504,6 +507,7 @@ describe('ConversationDetailPane header actions', () => {
       act(() => {
         root!.render(createElement(ConversationDetailPane));
       });
+      expect(document.querySelector('[data-detail-header-copy-check]')).toBeFalsy();
       expect(document.querySelector('[role="status"]')).toBeFalsy();
     } finally {
       vi.useRealTimers();

--- a/tests/smoke/detail-header-action-menu.test.ts
+++ b/tests/smoke/detail-header-action-menu.test.ts
@@ -272,7 +272,7 @@ describe('DetailHeaderActionBar', () => {
     expect(alertSpy).toHaveBeenCalledWith('Failed to open Notion page');
   });
 
-  it('shows transient icon-only success status without changing the button into a text action', async () => {
+  it('shows a transient check for copy actions without changing the icon slot size', async () => {
     vi.useFakeTimers();
     try {
       const onTrigger = vi.fn(async () => {});
@@ -298,22 +298,24 @@ describe('DetailHeaderActionBar', () => {
       const button = document.querySelector('[aria-label="Copy Notion link"]') as HTMLButtonElement | null;
       expect(button).toBeTruthy();
       expect(button?.textContent || '').not.toContain('Copy Notion link');
+      expect(button?.querySelector('[data-provider-logo="notion"]')?.className || '').toContain('tw-h-4 tw-w-4');
 
       await act(async () => {
         button!.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
         await Promise.resolve();
       });
 
-      const status = document.querySelector('[role="status"]') as HTMLElement | null;
-      expect(status?.textContent).toBe('Copied');
-      expect(status?.className || '').toContain('tw-absolute');
-      expect(button?.textContent || '').not.toContain('Copied');
+      const check = button?.querySelector('[data-detail-header-copy-check="copy-notion-link"]') as HTMLElement | null;
+      expect(check?.textContent).toBe('✓');
+      expect(check?.className || '').toContain('tw-h-4 tw-w-4');
+      expect(document.querySelector('[role="status"]')).toBeFalsy();
 
       await act(async () => {
-        vi.advanceTimersByTime(2_600);
+        vi.advanceTimersByTime(1_100);
         await Promise.resolve();
       });
-      expect(document.querySelector('[role="status"]')).toBeFalsy();
+      expect(button?.querySelector('[data-detail-header-copy-check="copy-notion-link"]')).toBeFalsy();
+      expect(button?.querySelector('[data-provider-logo="notion"]')).toBeTruthy();
     } finally {
       vi.useRealTimers();
     }
@@ -348,13 +350,14 @@ describe('DetailHeaderActionBar', () => {
       button.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
       await Promise.resolve();
     });
-    expect(document.querySelector('[role="status"]')?.textContent).toBe('Copied');
+    expect(button.querySelector('[data-detail-header-copy-check="copy-notion-link"]')?.textContent).toBe('✓');
 
     await act(async () => {
       button.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
       await Promise.resolve();
     });
     expect(alertSpy).toHaveBeenCalledWith('copy denied');
+    expect(button.querySelector('[data-detail-header-copy-check="copy-notion-link"]')).toBeFalsy();
     expect(document.querySelector('[role="status"]')).toBeFalsy();
   });
 

--- a/tests/smoke/detail-header-action-menu.test.ts
+++ b/tests/smoke/detail-header-action-menu.test.ts
@@ -81,6 +81,7 @@ describe('DetailHeaderActionBar', () => {
     const logo = button?.querySelector('[data-provider-logo="notion"]') as HTMLImageElement | null;
     expect(logo?.getAttribute('src')).toBe('/icons/notion.svg');
     expect(logo?.className).toContain('webclipper-provider-logo--notion');
+    expect(button?.getAttribute('data-tooltip-id')).toBe('webclipper-tooltip');
     expect(button?.textContent).not.toContain('▾');
   });
 
@@ -298,6 +299,7 @@ describe('DetailHeaderActionBar', () => {
       const button = document.querySelector('[aria-label="Copy Notion link"]') as HTMLButtonElement | null;
       expect(button).toBeTruthy();
       expect(button?.textContent || '').not.toContain('Copy Notion link');
+      expect(button?.getAttribute('data-tooltip-id')).toBeNull();
       expect(button?.querySelector('[data-provider-logo="notion"]')?.className || '').toContain('tw-h-4 tw-w-4');
 
       await act(async () => {

--- a/tests/unit/conversation-list-row-actions.test.ts
+++ b/tests/unit/conversation-list-row-actions.test.ts
@@ -228,8 +228,19 @@ describe('ConversationListPane row actions', () => {
     });
 
     expect(writeTextToClipboardMock).toHaveBeenCalledWith('https://example.com/path?x=1#section');
+    expect(sourceButton?.querySelector('[data-conversation-source-link-check="11"]')?.textContent).toBe('✓');
+    const sourceLabel = sourceButton?.querySelector('span:not([data-conversation-source-link-check])');
+    expect(sourceLabel?.textContent).toBe('sourceChatgpt');
+    expect(sourceLabel?.classList.contains('tw-invisible')).toBe(true);
     expect(currentState.setActiveId).not.toHaveBeenCalled();
     expect(onOpenConversation).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1100);
+      await flushMicrotasks();
+    });
+    expect(sourceButton?.querySelector('[data-conversation-source-link-check="11"]')).toBeNull();
+    expect(sourceLabel?.classList.contains('tw-invisible')).toBe(false);
   });
 
   it('copies http original URLs from the source badge', async () => {

--- a/tests/unit/conversation-list-row-actions.test.ts
+++ b/tests/unit/conversation-list-row-actions.test.ts
@@ -189,6 +189,7 @@ describe('ConversationListPane row actions', () => {
     expect(copyButton).toBeTruthy();
     expect(document.querySelector('[data-conversation-source-link="11"]')).toBeTruthy();
     expect(document.querySelector('[aria-label="openOriginalChat"]')).toBeNull();
+    expect(copyButton?.getAttribute('data-tooltip-id')).toBeNull();
     expect(copyButton?.textContent).toBe('⧉');
 
     await act(async () => {

--- a/tests/unit/conversation-list-row-actions.test.ts
+++ b/tests/unit/conversation-list-row-actions.test.ts
@@ -8,7 +8,6 @@ import { ConversationListPane } from '../../src/ui/conversations/ConversationLis
 const getConversationDetailMock = vi.fn();
 const formatConversationMarkdownMock = vi.fn();
 const writeTextToClipboardMock = vi.fn();
-const tabsCreateMock = vi.fn();
 const getEnabledSyncProvidersMock = vi.fn();
 let currentState: any = null;
 
@@ -31,7 +30,6 @@ vi.mock('../../src/services/shared/clipboard', () => ({
 }));
 
 vi.mock('../../src/services/shared/webext', () => ({
-  tabsCreate: (...args: any[]) => tabsCreateMock(...args),
   openOrFocusExtensionAppTab: vi.fn(),
 }));
 
@@ -189,7 +187,8 @@ describe('ConversationListPane row actions', () => {
     await renderPane();
     const copyButton = document.querySelector('[aria-label="copyFullMarkdown"]') as HTMLButtonElement | null;
     expect(copyButton).toBeTruthy();
-    expect(document.querySelector('[aria-label="openOriginalChat"]')).toBeTruthy();
+    expect(document.querySelector('[data-conversation-source-link="11"]')).toBeTruthy();
+    expect(document.querySelector('[aria-label="openOriginalChat"]')).toBeNull();
     expect(copyButton?.textContent).toBe('⧉');
 
     await act(async () => {
@@ -215,44 +214,63 @@ describe('ConversationListPane row actions', () => {
     expect(copyButton?.textContent).toBe('⧉');
   });
 
-  it('opens the exact trimmed original https URL without activating the row', async () => {
+  it('copies the exact trimmed original https URL from the source badge without activating the row', async () => {
     currentState.items[0].url = '  https://example.com/path?x=1#section  ';
     await renderPane();
-    const openButton = document.querySelector('[aria-label="openOriginalChat"]') as HTMLButtonElement | null;
-    expect(openButton).toBeTruthy();
-    expect(openButton?.disabled).toBe(false);
+    const sourceButton = document.querySelector('[data-conversation-source-link="11"]') as HTMLButtonElement | null;
+    expect(sourceButton).toBeTruthy();
+    expect(sourceButton?.textContent).toBe('sourceChatgpt');
+    expect(sourceButton?.disabled).toBe(false);
 
     await act(async () => {
-      openButton!.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
+      sourceButton!.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
       await flushMicrotasks();
     });
 
-    expect(tabsCreateMock).toHaveBeenCalledWith({ url: 'https://example.com/path?x=1#section' });
+    expect(writeTextToClipboardMock).toHaveBeenCalledWith('https://example.com/path?x=1#section');
     expect(currentState.setActiveId).not.toHaveBeenCalled();
     expect(onOpenConversation).not.toHaveBeenCalled();
   });
 
-  it('keeps http original URLs available', async () => {
+  it('copies http original URLs from the source badge', async () => {
     currentState.items[0].url = ' http://example.com/path#hash ';
     await renderPane();
-    const openButton = document.querySelector('[aria-label="openOriginalChat"]') as HTMLButtonElement | null;
+    const sourceButton = document.querySelector('[data-conversation-source-link="11"]') as HTMLButtonElement | null;
 
     await act(async () => {
-      openButton!.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
+      sourceButton!.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
       await flushMicrotasks();
     });
 
-    expect(tabsCreateMock).toHaveBeenCalledWith({ url: 'http://example.com/path#hash' });
+    expect(writeTextToClipboardMock).toHaveBeenCalledWith('http://example.com/path#hash');
   });
 
-  it.each(['', 'javascript:alert(1)', 'obsidian://open?vault=x'])('disables Open original for %s', async (url) => {
-    currentState.items[0].url = url;
-    await renderPane();
-    const openButton = document.querySelector('[aria-label="openOriginalChat"]') as HTMLButtonElement | null;
+  it.each(['', 'javascript:alert(1)', 'obsidian://open?vault=x'])(
+    'disables source-link copying for %s',
+    async (url) => {
+      currentState.items[0].url = url;
+      await renderPane();
+      const sourceButton = document.querySelector('[data-conversation-source-link="11"]') as HTMLButtonElement | null;
 
-    expect(openButton).toBeTruthy();
-    expect(openButton?.disabled).toBe(true);
-    expect(tabsCreateMock).not.toHaveBeenCalled();
+      expect(sourceButton).toBeTruthy();
+      expect(sourceButton?.disabled).toBe(true);
+      expect(writeTextToClipboardMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it('does not let the row Enter handler consume source-badge keyboard interaction', async () => {
+    await renderPane();
+    const sourceButton = document.querySelector('[data-conversation-source-link="11"]') as HTMLButtonElement | null;
+
+    await act(async () => {
+      sourceButton!.dispatchEvent(
+        new window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }),
+      );
+      await flushMicrotasks();
+    });
+
+    expect(currentState.setActiveId).not.toHaveBeenCalled();
+    expect(onOpenConversation).not.toHaveBeenCalled();
   });
 
   it('dispatches a single enabled GitHub provider shortcut to the GitHub context callback', async () => {

--- a/tests/unit/conversation-list-row-actions.test.ts
+++ b/tests/unit/conversation-list-row-actions.test.ts
@@ -273,6 +273,44 @@ describe('ConversationListPane row actions', () => {
     expect(onOpenConversation).not.toHaveBeenCalled();
   });
 
+  it('toggles only the conversations under the clicked date section', async () => {
+    const today = new Date();
+    today.setHours(12, 0, 0, 0);
+    const yesterday = new Date(today);
+    yesterday.setDate(today.getDate() - 1);
+    currentState.items = [
+      { ...conversation, id: 11, lastCapturedAt: today.getTime() },
+      { ...conversation, id: 12, conversationKey: 'conv-12', lastCapturedAt: today.getTime() - 1000 },
+      { ...conversation, id: 13, conversationKey: 'conv-13', lastCapturedAt: yesterday.getTime() },
+    ];
+    currentState.listSummary = { totalCount: 3, todayCount: 2 };
+
+    await renderPane();
+    const todayButton = document.querySelector(
+      '[data-conversation-section-select="section:today"]',
+    ) as HTMLButtonElement | null;
+    const yesterdayButton = document.querySelector(
+      '[data-conversation-section-select="section:yesterday"]',
+    ) as HTMLButtonElement | null;
+
+    expect(todayButton).toBeTruthy();
+    expect(yesterdayButton).toBeTruthy();
+
+    await act(async () => {
+      todayButton!.click();
+      await flushMicrotasks();
+    });
+    expect(currentState.toggleAll).toHaveBeenLastCalledWith([11, 12]);
+
+    await act(async () => {
+      yesterdayButton!.click();
+      await flushMicrotasks();
+    });
+    expect(currentState.toggleAll).toHaveBeenLastCalledWith([13]);
+    expect(currentState.setActiveId).not.toHaveBeenCalled();
+    expect(onOpenConversation).not.toHaveBeenCalled();
+  });
+
   it('dispatches a single enabled GitHub provider shortcut to the GitHub context callback', async () => {
     currentState.selectedIds = [11];
     getEnabledSyncProvidersMock.mockResolvedValue(['github']);

--- a/tests/unit/conversation-list-row-actions.test.ts
+++ b/tests/unit/conversation-list-row-actions.test.ts
@@ -222,6 +222,8 @@ describe('ConversationListPane row actions', () => {
     expect(sourceButton).toBeTruthy();
     expect(sourceButton?.textContent).toBe('sourceChatgpt');
     expect(sourceButton?.disabled).toBe(false);
+    expect(sourceButton?.classList.contains('webclipper-btn')).toBe(true);
+    expect(sourceButton?.classList.contains('webclipper-btn--compact')).toBe(true);
 
     await act(async () => {
       sourceButton!.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
@@ -307,6 +309,8 @@ describe('ConversationListPane row actions', () => {
 
     expect(todayButton).toBeTruthy();
     expect(yesterdayButton).toBeTruthy();
+    expect(todayButton?.classList.contains('webclipper-btn')).toBe(true);
+    expect(todayButton?.classList.contains('webclipper-btn--compact')).toBe(true);
 
     await act(async () => {
       todayButton!.click();

--- a/tests/unit/conversation-list-tags.test.ts
+++ b/tests/unit/conversation-list-tags.test.ts
@@ -59,36 +59,12 @@ describe('resolveConversationListTag', () => {
     expect(result.label).toBe('insightUnknownLabel');
   });
 
-  it('uses brand tone variables for non-web source keys', () => {
-    const chatgpt = resolveConversationListTag({
+  it('returns source identity and label without presentation classes', () => {
+    const result = resolveConversationListTag({
       conversation: { source: 'chatgpt' },
       translate: tr,
     });
-    const gemini = resolveConversationListTag({
-      conversation: { source: 'gemini' },
-      translate: tr,
-    });
-    const kimi = resolveConversationListTag({
-      conversation: { source: 'kimi' },
-      translate: tr,
-    });
 
-    expect(chatgpt.toneClassName).toContain('var(--brand-chatgpt)');
-    expect(gemini.toneClassName).toContain('var(--brand-gemini)');
-    expect(kimi.toneClassName).toContain('var(--brand-kimi)');
-  });
-
-  it('keeps web tone fixed and not brand-driven', () => {
-    const result = resolveConversationListTag({
-      conversation: {
-        source: 'web',
-        listSourceKey: 'web',
-        listSiteKey: 'domain:example.com',
-      },
-      translate: tr,
-    });
-
-    expect(result.toneClassName).toContain('var(--border)');
-    expect(result.toneClassName).not.toContain('--brand-');
+    expect(result).toEqual({ sourceKey: 'chatgpt', label: 'sourceChatgpt' });
   });
 });

--- a/tests/unit/settings-sections.test.ts
+++ b/tests/unit/settings-sections.test.ts
@@ -162,7 +162,7 @@ describe('settings section definitions', () => {
     expect(document.querySelector('input[aria-label="Repository"]')).toBeNull();
     const branchInput = document.querySelector('input[aria-label="Branch"]') as HTMLInputElement | null;
     expect(branchInput).toBeTruthy();
-    expect(branchInput?.className || '').toContain('tw-rounded-[var(--radius-inline)]');
+    expect(branchInput?.className || '').toContain('webclipper-field');
     expect(document.querySelector('input[aria-label="AI Chats Folder"]')).toBeNull();
     expect(document.querySelector('input[aria-label="Web Clipper Folder"]')).toBeNull();
     expect(document.querySelector('input[aria-label="Video Scripts Folder"]')).toBeNull();
@@ -449,6 +449,7 @@ describe('inpage anti-hotlink advanced editor', () => {
     const input = document.querySelector('input[autocomplete="off"]') as HTMLInputElement | null;
     expect(input).toBeTruthy();
     expect(input?.value).toBe('Ada');
+    expect(input?.className || '').toContain('webclipper-field');
 
     act(() => {
       input!.dispatchEvent(new window.FocusEvent('focusout', { bubbles: true }));

--- a/tests/unit/settings-sections.test.ts
+++ b/tests/unit/settings-sections.test.ts
@@ -162,6 +162,7 @@ describe('settings section definitions', () => {
     expect(document.querySelector('input[aria-label="Repository"]')).toBeNull();
     const branchInput = document.querySelector('input[aria-label="Branch"]') as HTMLInputElement | null;
     expect(branchInput).toBeTruthy();
+    expect(branchInput?.className || '').toContain('tw-rounded-[var(--radius-inline)]');
     expect(document.querySelector('input[aria-label="AI Chats Folder"]')).toBeNull();
     expect(document.querySelector('input[aria-label="Web Clipper Folder"]')).toBeNull();
     expect(document.querySelector('input[aria-label="Video Scripts Folder"]')).toBeNull();


### PR DESCRIPTION
## Related issue

Closes #504

## Why

会话列表和详情页此前存在几组不一致的交互与视觉规则：

- 来源标签旁存在独立的“打开原链接”按钮，而来源标签本身不能直接复制原始链接；
- 日期分组标题只是静态 chip，无法直接选择该分组中已加载的条目；
- 不同复制入口的成功反馈不一致，并存在重复 tooltip；
- 来源标签、日期分组、复制按钮和表单输入框分别使用不同的圆角与 edge 体系，导致同一界面出现多套 control chrome。

这组改动将这些行为与视觉规则收敛到共享实现，避免继续维护平行的局部样式体系。

## What changed

- 会话来源标签直接作为“复制原始链接”入口，移除独立的原链接按钮；复制成功后在不改变按钮尺寸的前提下短暂显示 `✓`。
- 日期分组标题可切换当前已加载分组的选择状态，并复用现有 `toggleAll(scopeIds)`，不复制选择业务逻辑。
- 详情页纯复制 action 统一使用成功 `✓` 反馈；More 菜单保持原有行为。
- 删除纯复制 UI 上重复的 tooltip，并清理无引用文案。
- 来源标签与日期分组改为共享 compact button 视觉体系，删除来源品牌色 tone map 与对应死 token。
- 删除旧的 `--radius-chip` / `--radius-control` 圆角层级，将小型交互控件统一到 canonical `--radius-inline`。
- 新增共享 `webclipper-field` edge primitive，使文本输入框与按钮共享相同的 border、radius、bevel strokes 和 focus outline；输入框仍保留 sunken surface 以维持编辑语义。
- GitHub Branch、Notion / Feishu / Obsidian 设置输入、Reader 输入、用户名输入、Chat with AI textarea 和详情 URL 编辑框接入共享 field 样式。
- 更新相关单元 / smoke 测试，约束复制反馈、日期分组选择、tooltip 和 shared control 样式契约。

## Scope and non-goals

- 不改变 More 菜单中复制项的现有关闭与反馈行为。
- 日期分组选择仅作用于当前已加载的列表项，不改变分页和全量读取契约。
- 不修改会话数据模型、同步逻辑、存储 schema 或迁移路径。
- 不修改浏览器权限、外部网络请求或 OAuth 行为。
- checkbox、range 等非矩形文本输入控件不强制套用 `webclipper-field`。

## Validation

- `npm run gate:ci`: PASS — 同步最新 `origin/main` 后重新执行；259 个测试文件、1491 个测试全部通过。
- `npm run gate`: N/A — 未修改 production build、manifest、权限、打包或发布路径。
- Targeted tests or boundary scans:
  - 会话列表复制 / 日期分组相关定向测试通过。
  - Header action / menu / settings / narration 相关定向测试通过。
  - `--radius-chip`、`--radius-control`、旧来源品牌 tone/token 在 `src + tests` 中已清零。
  - Chat with AI textarea 不再使用硬编码 `tw-rounded-xl`。
  - `git diff --check`: PASS。

Manual validation:

| Browser / surface | Scenario | Result |
| --- | --- | --- |
| App / 会话列表 | 来源复制、日期分组、复制成功反馈与按钮尺寸 | PASS — 按问题截图与交互契约核对 |
| App / 详情 Header | copy-text 成功反馈；More 菜单保持原行为 | PASS — 定向 smoke tests |
| Settings / GitHub | Branch 输入框与按钮使用统一 edge | PASS — shared-field 契约测试 |

## Architecture, data, and permissions

- Affected layers / dependency boundaries: 仅 `src/ui/**` 与 UI 测试；未新增 `ui -> platform` 等违规依赖。选择行为继续调用既有 ViewModel API。
- Local storage, schema, backup/restore, or migration impact: N/A。
- Browser permission or external-network impact: N/A。
- Failure path: 本 PR 不改变数据读写或外部服务失败路径；复制失败仍沿用现有 clipboard 错误处理，现有本地数据不受影响。

## UI evidence

本 PR 为视觉改动。问题基线来自开发过程中提供的会话列表与 GitHub Settings 截图；本地已按这些状态完成样式核对。当前 PR 未额外上传新的浏览器录屏/截图附件。

## Risks and tradeoffs

- 共享 control edge 的调整会同时影响所有使用 `webclipper-btn` / `webclipper-field` 的相关 surface，因此已在同步 `main` 后执行完整 `gate:ci`。
- 输入框与按钮共享 edge language，但保留不同 surface，避免把输入框视觉上误判为按钮。
- 来源品牌色 badge 被有意移除，以换取跨来源一致的 control hierarchy。

## Documentation and cleanup

- [x] Canonical documentation made stale by this change is updated, or no documentation change is required.
- [x] Replaced production paths, dead compatibility branches, and outdated test assumptions are removed, or none were introduced/replaced.
- [x] I reviewed the final diff from top to bottom before requesting review.

