### PR TITLE
修复 GitHub 设置页 repository discovery 阻塞交互

### DIFF
--- a/src/ui/settings/SettingsScene.tsx
+++ b/src/ui/settings/SettingsScene.tsx
@@ -134,6 +134,8 @@ export function SettingsScene(props: SettingsSceneProps) {
     githubAccount,
     githubRepositoryStatus,
     githubRepositories,
+    githubRepositoriesLoading,
+    githubRepositoryDiscoveryError,
     githubTargetUnavailable,
     githubRepository,
     onChangeGithubRepository,
@@ -386,6 +388,8 @@ export function SettingsScene(props: SettingsSceneProps) {
           account={githubAccount}
           repositoryStatus={githubRepositoryStatus}
           repositories={githubRepositories}
+          repositoriesLoading={githubRepositoriesLoading}
+          repositoryDiscoveryError={githubRepositoryDiscoveryError}
           targetUnavailable={githubTargetUnavailable}
           repository={githubRepository}
           branch={githubBranch}

--- a/src/ui/settings/sections/GitHubSettingsSection.tsx
+++ b/src/ui/settings/sections/GitHubSettingsSection.tsx
@@ -38,6 +38,8 @@ export function GitHubSettingsSection(props: {
   account: { login: string; avatarUrl: string; url: string } | null;
   repositoryStatus: 'ready' | 'github_app_not_installed' | 'github_no_accessible_repositories' | null;
   repositories: GithubRepositoryOption[];
+  repositoriesLoading: boolean;
+  repositoryDiscoveryError: string;
   targetUnavailable: boolean;
   repository: string;
   branch: string;
@@ -66,6 +68,8 @@ export function GitHubSettingsSection(props: {
     account,
     repositoryStatus,
     repositories,
+    repositoriesLoading,
+    repositoryDiscoveryError,
     targetUnavailable,
     repository,
     branch,
@@ -241,7 +245,7 @@ export function GitHubSettingsSection(props: {
                     buttonClassName={`${buttonClassName} tw-w-full`}
                     value={repository}
                     options={repositoryOptions}
-                    disabled={busy || repositoryStatus !== 'ready'}
+                    disabled={busy || repositoriesLoading || repositoryStatus !== 'ready'}
                     ariaLabel={t('githubRepositoryLabel')}
                     maxHeight={360}
                     onChange={onChangeRepository}
@@ -250,14 +254,25 @@ export function GitHubSettingsSection(props: {
                     type="button"
                     title={t('refresh')}
                     onClick={onRefreshRepositories}
-                    disabled={busy}
+                    disabled={busy || repositoriesLoading}
                     className="webclipper-btn webclipper-btn--icon"
                     aria-label={t('githubRefreshRepositories')}
+                    aria-busy={repositoriesLoading}
                   >
-                    ↻
+                    {repositoriesLoading ? '⏳' : '↻'}
                   </button>
                 </div>
               </SettingsFormRow>
+
+              {repositoryDiscoveryError ? (
+                <div
+                  className="tw-text-xs tw-font-semibold tw-text-[var(--error)]"
+                  role="status"
+                  data-github-repository-discovery-error="true"
+                >
+                  {t('statusError')}: {repositoryDiscoveryError}
+                </div>
+              ) : null}
 
               {targetUnavailable ? (
                 <div className="tw-text-xs tw-font-semibold tw-text-[var(--error)]" role="status">

--- a/src/viewmodels/settings/useSettingsSceneController.ts
+++ b/src/viewmodels/settings/useSettingsSceneController.ts
@@ -332,6 +332,9 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
   const [githubAccount, setGithubAccount] = useState<GithubSafeAccount | null>(null);
   const [githubRepositoryStatus, setGithubRepositoryStatus] = useState<GithubRepositoryStatus>(null);
   const [githubRepositories, setGithubRepositories] = useState<GithubRepositoryOption[]>([]);
+  const [, setGithubRepositoriesLoading] = useState(false);
+  const [, setGithubRepositoryDiscoveryError] = useState('');
+  const githubRepositoryDiscoveryGenerationRef = useRef(0);
   const [githubRepository, setGithubRepository] = useState('');
   const [githubBranch, setGithubBranch] = useState('');
   const githubPersistedBranchRef = useRef('');
@@ -426,9 +429,12 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
   }, []);
 
   const clearGithubRepositoryDiscovery = useCallback(() => {
+    githubRepositoryDiscoveryGenerationRef.current += 1;
     setGithubAccount(null);
     setGithubRepositoryStatus(null);
     setGithubRepositories([]);
+    setGithubRepositoriesLoading(false);
+    setGithubRepositoryDiscoveryError('');
   }, []);
 
   const applyGithubAuth = useCallback(
@@ -466,10 +472,17 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
     [applyGithubAuth, applyGithubTargetSettings],
   );
 
-  const loadGithubRepositoriesInternal = useCallback(async () => {
+  const runGithubRepositoryDiscovery = useCallback(async () => {
+    const requestGeneration = githubRepositoryDiscoveryGenerationRef.current + 1;
+    githubRepositoryDiscoveryGenerationRef.current = requestGeneration;
     setGithubConnectionTest({ status: 'idle' });
+    setGithubRepositoryDiscoveryError('');
+    setGithubRepositoriesLoading(true);
+
     try {
       const data = unwrap(await send<ApiResponse<any>>(GITHUB_MESSAGE_TYPES.LIST_REPOSITORIES, {}));
+      if (githubRepositoryDiscoveryGenerationRef.current !== requestGeneration) return;
+
       const status: GithubRepositoryStatus =
         data?.status === 'ready' ||
         data?.status === 'github_app_not_installed' ||
@@ -490,15 +503,26 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
       setGithubRepositories(normalizeGithubRepositoryOptions(data?.repositories));
       if (data?.appUrl) setGithubAppUrl(String(data.appUrl));
       if (data?.installUrl) setGithubInstallUrl(String(data.installUrl));
-      return data;
     } catch (error) {
-      if (toErrorMessage(error, '') === 'github_auth_required') {
-        setGithubAuth({ state: 'disconnected' });
-        clearGithubRepositoryDiscovery();
+      if (githubRepositoryDiscoveryGenerationRef.current !== requestGeneration) return;
+      const message = toErrorMessage(error, 'github_repository_list_failed');
+      if (message === 'github_auth_required') {
+        applyGithubAuth({ state: 'disconnected' });
+        return;
       }
-      throw error;
+      setGithubRepositoryDiscoveryError(message);
+    } finally {
+      if (githubRepositoryDiscoveryGenerationRef.current === requestGeneration) {
+        setGithubRepositoriesLoading(false);
+      }
     }
-  }, [clearGithubRepositoryDiscovery]);
+  }, [applyGithubAuth]);
+
+  useEffect(() => {
+    return () => {
+      githubRepositoryDiscoveryGenerationRef.current += 1;
+    };
+  }, []);
 
   const refreshGithubAuthFromStorageSignal = useCallback(async () => {
     try {
@@ -625,7 +649,7 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
 
     const githubSettings = unwrap(githubRes);
     const githubAuthState = applyGithubSettingsResponse(githubSettings);
-    if (githubAuthState.state === 'connected') await loadGithubRepositoriesInternal();
+    if (githubAuthState.state === 'connected') await runGithubRepositoryDiscovery();
 
     const chatWith = await loadChatWithSettings();
     setChatWithPromptTemplate(String(chatWith.promptTemplate || DEFAULT_CHAT_WITH_PROMPT_TEMPLATE));
@@ -637,7 +661,7 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
     applyGithubSettingsResponse,
     articleDbSpec.storageKey,
     chatDbSpec.storageKey,
-    loadGithubRepositoriesInternal,
+    runGithubRepositoryDiscovery,
     videoDbSpec.storageKey,
   ]);
 
@@ -977,11 +1001,11 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
       async () => {
         const data = unwrap(await send<ApiResponse<any>>(GITHUB_MESSAGE_TYPES.START_DEVICE_FLOW, {}));
         const auth = applyGithubAuth(data?.auth);
-        if (auth.state === 'connected') await loadGithubRepositoriesInternal();
+        if (auth.state === 'connected') await runGithubRepositoryDiscovery();
       },
       { fallbackMessage: 'github_device_start_failed' },
     );
-  }, [applyGithubAuth, loadGithubRepositoriesInternal, runTask]);
+  }, [applyGithubAuth, runGithubRepositoryDiscovery, runTask]);
 
   const onPollGithubDeviceFlow = useCallback(async () => {
     await runTask(
@@ -989,14 +1013,14 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
         try {
           const data = unwrap(await send<ApiResponse<any>>(GITHUB_MESSAGE_TYPES.POLL_DEVICE_FLOW, {}));
           const auth = applyGithubAuth(data?.auth);
-          if (auth.state === 'connected') await loadGithubRepositoriesInternal();
+          if (auth.state === 'connected') await runGithubRepositoryDiscovery();
         } catch (error) {
           // P2 may have advanced nextPollAt or cleared a terminal flow before returning an error.
           // Rehydrate only the safe local DTO so the timer follows the persisted state instead of stale React state.
           try {
             const snapshot = unwrap(await send<ApiResponse<any>>(GITHUB_MESSAGE_TYPES.GET_SETTINGS, {}));
             const auth = applyGithubSettingsResponse(snapshot);
-            if (auth.state === 'connected') await loadGithubRepositoriesInternal();
+            if (auth.state === 'connected') await runGithubRepositoryDiscovery();
           } catch (_refreshError) {
             // Keep the original poll error; GET_SETTINGS is recovery, not a replacement failure surface.
           }
@@ -1005,7 +1029,7 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
       },
       { useBusy: false, clearError: false, fallbackMessage: 'github_device_poll_failed' },
     );
-  }, [applyGithubAuth, applyGithubSettingsResponse, loadGithubRepositoriesInternal, runTask]);
+  }, [applyGithubAuth, applyGithubSettingsResponse, runGithubRepositoryDiscovery, runTask]);
 
   useEffect(() => {
     if (githubAuth.state !== 'pending') return;
@@ -1038,13 +1062,8 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
   }, [applyGithubAuth, runTask]);
 
   const onRefreshGithubRepositories = useCallback(async () => {
-    await runTask(
-      async () => {
-        await loadGithubRepositoriesInternal();
-      },
-      { fallbackMessage: 'github_repository_list_failed' },
-    );
-  }, [loadGithubRepositoriesInternal, runTask]);
+    await runGithubRepositoryDiscovery();
+  }, [runGithubRepositoryDiscovery]);
 
   const onChangeGithubRepository = useCallback(
     async (value: string) => {

--- a/src/viewmodels/settings/useSettingsSceneController.ts
+++ b/src/viewmodels/settings/useSettingsSceneController.ts
@@ -332,8 +332,8 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
   const [githubAccount, setGithubAccount] = useState<GithubSafeAccount | null>(null);
   const [githubRepositoryStatus, setGithubRepositoryStatus] = useState<GithubRepositoryStatus>(null);
   const [githubRepositories, setGithubRepositories] = useState<GithubRepositoryOption[]>([]);
-  const [, setGithubRepositoriesLoading] = useState(false);
-  const [, setGithubRepositoryDiscoveryError] = useState('');
+  const [githubRepositoriesLoading, setGithubRepositoriesLoading] = useState(false);
+  const [githubRepositoryDiscoveryError, setGithubRepositoryDiscoveryError] = useState('');
   const githubRepositoryDiscoveryGenerationRef = useRef(0);
   const [githubRepository, setGithubRepository] = useState('');
   const [githubBranch, setGithubBranch] = useState('');
@@ -648,8 +648,7 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
     setObsidianStatus(t('statusIdle'));
 
     const githubSettings = unwrap(githubRes);
-    const githubAuthState = applyGithubSettingsResponse(githubSettings);
-    if (githubAuthState.state === 'connected') await runGithubRepositoryDiscovery();
+    applyGithubSettingsResponse(githubSettings);
 
     const chatWith = await loadChatWithSettings();
     setChatWithPromptTemplate(String(chatWith.promptTemplate || DEFAULT_CHAT_WITH_PROMPT_TEMPLATE));
@@ -661,7 +660,6 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
     applyGithubSettingsResponse,
     articleDbSpec.storageKey,
     chatDbSpec.storageKey,
-    runGithubRepositoryDiscovery,
     videoDbSpec.storageKey,
   ]);
 
@@ -672,6 +670,22 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
   useEffect(() => {
     void refresh();
   }, [refresh]);
+
+  useEffect(() => {
+    if (activeSection !== 'github') return;
+    if (githubAuth.state !== 'connected') return;
+    if (githubRepositoryStatus != null) return;
+    if (githubRepositoriesLoading) return;
+    if (githubRepositoryDiscoveryError) return;
+    void runGithubRepositoryDiscovery();
+  }, [
+    activeSection,
+    githubAuth.state,
+    githubRepositoriesLoading,
+    githubRepositoryDiscoveryError,
+    githubRepositoryStatus,
+    runGithubRepositoryDiscovery,
+  ]);
 
   useEffect(() => {
     return storageOnChanged((changes: any, areaName: string) => {
@@ -1000,27 +1014,24 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
     await runTask(
       async () => {
         const data = unwrap(await send<ApiResponse<any>>(GITHUB_MESSAGE_TYPES.START_DEVICE_FLOW, {}));
-        const auth = applyGithubAuth(data?.auth);
-        if (auth.state === 'connected') await runGithubRepositoryDiscovery();
+        applyGithubAuth(data?.auth);
       },
       { fallbackMessage: 'github_device_start_failed' },
     );
-  }, [applyGithubAuth, runGithubRepositoryDiscovery, runTask]);
+  }, [applyGithubAuth, runTask]);
 
   const onPollGithubDeviceFlow = useCallback(async () => {
     await runTask(
       async () => {
         try {
           const data = unwrap(await send<ApiResponse<any>>(GITHUB_MESSAGE_TYPES.POLL_DEVICE_FLOW, {}));
-          const auth = applyGithubAuth(data?.auth);
-          if (auth.state === 'connected') await runGithubRepositoryDiscovery();
+          applyGithubAuth(data?.auth);
         } catch (error) {
           // P2 may have advanced nextPollAt or cleared a terminal flow before returning an error.
           // Rehydrate only the safe local DTO so the timer follows the persisted state instead of stale React state.
           try {
             const snapshot = unwrap(await send<ApiResponse<any>>(GITHUB_MESSAGE_TYPES.GET_SETTINGS, {}));
-            const auth = applyGithubSettingsResponse(snapshot);
-            if (auth.state === 'connected') await runGithubRepositoryDiscovery();
+            applyGithubSettingsResponse(snapshot);
           } catch (_refreshError) {
             // Keep the original poll error; GET_SETTINGS is recovery, not a replacement failure surface.
           }
@@ -1029,7 +1040,7 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
       },
       { useBusy: false, clearError: false, fallbackMessage: 'github_device_poll_failed' },
     );
-  }, [applyGithubAuth, applyGithubSettingsResponse, runGithubRepositoryDiscovery, runTask]);
+  }, [applyGithubAuth, applyGithubSettingsResponse, runTask]);
 
   useEffect(() => {
     if (githubAuth.state !== 'pending') return;

--- a/src/viewmodels/settings/useSettingsSceneController.ts
+++ b/src/viewmodels/settings/useSettingsSceneController.ts
@@ -489,6 +489,8 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
         data?.status === 'github_no_accessible_repositories'
           ? data.status
           : null;
+      if (status == null) throw new Error('github_repository_response_invalid');
+
       const login = String(data?.account?.login || '').trim();
       setGithubAccount(
         login

--- a/src/viewmodels/settings/useSettingsSceneController.ts
+++ b/src/viewmodels/settings/useSettingsSceneController.ts
@@ -1976,6 +1976,8 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
     githubAccount,
     githubRepositoryStatus,
     githubRepositories,
+    githubRepositoriesLoading,
+    githubRepositoryDiscoveryError,
     githubTargetUnavailable,
     githubRepository,
     onChangeGithubRepository,

--- a/src/viewmodels/settings/useSettingsSceneController.ts
+++ b/src/viewmodels/settings/useSettingsSceneController.ts
@@ -658,12 +658,7 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
       Array.isArray(chatWith.platforms) ? (chatWith.platforms as any) : DEFAULT_CHAT_WITH_PLATFORMS.slice(),
     );
     chatWithHydratedRef.current = true;
-  }, [
-    applyGithubSettingsResponse,
-    articleDbSpec.storageKey,
-    chatDbSpec.storageKey,
-    videoDbSpec.storageKey,
-  ]);
+  }, [applyGithubSettingsResponse, articleDbSpec.storageKey, chatDbSpec.storageKey, videoDbSpec.storageKey]);
 
   const refresh = useCallback(async () => {
     await runTask(refreshInternal);

--- a/tests/unit/settings-controller-github.test.ts
+++ b/tests/unit/settings-controller-github.test.ts
@@ -19,6 +19,7 @@ const gateMocks = vi.hoisted(() => ({
   setSyncProviderEnabled: vi.fn(),
   syncProviderEnabledStorageKey: vi.fn((id: string) => `webclipper_sync_provider_${id}_enabled`),
 }));
+const chatWithMocks = vi.hoisted(() => ({ loadSettings: vi.fn() }));
 
 vi.mock('@services/shared/runtime', () => ({ send: runtimeMocks.send }));
 vi.mock('@services/shared/storage', () => ({
@@ -41,7 +42,7 @@ vi.mock('@services/integrations/anti-hotlink/anti-hotlink-settings', () => ({
 vi.mock('@services/integrations/chatwith/chatwith-settings', () => ({
   DEFAULT_CHAT_WITH_PLATFORMS: [],
   DEFAULT_CHAT_WITH_PROMPT_TEMPLATE: '',
-  loadChatWithSettings: async () => ({ promptTemplate: '', platforms: [] }),
+  loadChatWithSettings: chatWithMocks.loadSettings,
   resetChatWithPlatforms: async () => [],
   saveChatWithSettings: async () => ({ promptTemplate: '', platforms: [] }),
 }));
@@ -64,6 +65,7 @@ vi.mock('@i18n', () => ({
 }));
 
 type Snapshot = ReturnType<typeof useSettingsSceneController>;
+type SettingsSection = Parameters<typeof useSettingsSceneController>[0]['activeSection'];
 type ApiResponse = { ok: boolean; data: any; error: any };
 type RepositoryResponse = ApiResponse | Promise<ApiResponse> | (() => ApiResponse | Promise<ApiResponse>);
 
@@ -151,8 +153,8 @@ function readyRepositories(fullNames: string[] = ['owner/repo']) {
   };
 }
 
-function ControllerHarness() {
-  const snapshot = useSettingsSceneController({ activeSection: 'github' });
+function ControllerHarness({ activeSection }: { activeSection: SettingsSection }) {
+  const snapshot = useSettingsSceneController({ activeSection });
   useEffect(() => {
     latestSnapshot = snapshot;
   }, [snapshot]);
@@ -192,9 +194,16 @@ async function flushReact() {
   });
 }
 
-async function renderController() {
+async function renderController(activeSection: SettingsSection = 'github') {
   act(() => {
-    root!.render(createElement(ControllerHarness));
+    root!.render(createElement(ControllerHarness, { activeSection }));
+  });
+  await flushReact();
+}
+
+async function rerenderController(activeSection: SettingsSection) {
+  act(() => {
+    root!.render(createElement(ControllerHarness, { activeSection }));
   });
   await flushReact();
 }
@@ -264,6 +273,7 @@ beforeEach(() => {
     };
   });
   gateMocks.setSyncProviderEnabled.mockResolvedValue(undefined);
+  chatWithMocks.loadSettings.mockResolvedValue({ promptTemplate: '', platforms: [] });
 
   runtimeMocks.send.mockImplementation(async (type: string, payload: Record<string, unknown> = {}) => {
     if (type === 'getNotionAuthStatus') return ok({ connected: false });
@@ -363,12 +373,21 @@ describe('Settings controller GitHub Device Flow', () => {
 
     await advance(9_999);
     expect(callCount(GITHUB_MESSAGE_TYPES.POLL_DEVICE_FLOW)).toBe(1);
+    const discovery = deferred<ApiResponse>();
+    repositoryResponses = [discovery.promise];
     await advance(1);
     expect(callCount(GITHUB_MESSAGE_TYPES.POLL_DEVICE_FLOW)).toBe(2);
     expect(latestSnapshot?.githubAuth).toEqual({ state: 'connected' });
+    expect(callCount(GITHUB_MESSAGE_TYPES.LIST_REPOSITORIES)).toBe(1);
+    expect(latestSnapshot?.githubAccount).toBeNull();
+
+    await act(async () => {
+      discovery.resolve(ok(readyRepositories()));
+      await discovery.promise;
+      for (let index = 0; index < 10; index += 1) await Promise.resolve();
+    });
     expect(latestSnapshot?.githubAccount?.login).toBe('octocat');
     expect(latestSnapshot?.githubRepositories.map((item) => item.fullName)).toEqual(['owner/repo']);
-    expect(callCount(GITHUB_MESSAGE_TYPES.LIST_REPOSITORIES)).toBe(1);
   });
 
   it('rehydrates persisted pending state after a poll error instead of retrying from stale timing', async () => {
@@ -444,6 +463,65 @@ describe('Settings controller GitHub Device Flow', () => {
     expect(latestSnapshot?.githubAccount).toBeNull();
     expect(latestSnapshot?.githubRepositories).toEqual([]);
     expect(callCount(GITHUB_MESSAGE_TYPES.DISCONNECT)).toBe(1);
+  });
+
+  it('does not discover GitHub repositories outside the GitHub settings section and loads once on entry', async () => {
+    githubSettingsData = githubSettings({ state: 'connected' });
+
+    await renderController('general');
+    expect(latestSnapshot?.githubAuth).toEqual({ state: 'connected' });
+    expect(callCount(GITHUB_MESSAGE_TYPES.LIST_REPOSITORIES)).toBe(0);
+
+    await rerenderController('github');
+    expect(callCount(GITHUB_MESSAGE_TYPES.LIST_REPOSITORIES)).toBe(1);
+    expect(latestSnapshot?.githubRepositories.map((item) => item.fullName)).toEqual(['owner/repo']);
+
+    await rerenderController('github');
+    expect(callCount(GITHUB_MESSAGE_TYPES.LIST_REPOSITORIES)).toBe(1);
+    await rerenderController('general');
+    await rerenderController('github');
+    expect(callCount(GITHUB_MESSAGE_TYPES.LIST_REPOSITORIES)).toBe(1);
+  });
+
+  it('finishes base hydration and unrelated settings actions while automatic GitHub discovery is pending', async () => {
+    githubSettingsData = githubSettings({ state: 'connected' });
+    chatWithMocks.loadSettings.mockResolvedValue({ promptTemplate: 'hydrated-before-github-network', platforms: [] });
+    const discovery = deferred<ApiResponse>();
+    repositoryResponses = [discovery.promise];
+
+    await renderController('github');
+
+    expect(callCount(GITHUB_MESSAGE_TYPES.LIST_REPOSITORIES)).toBe(1);
+    expect(latestSnapshot?.busy).toBe(false);
+    expect(latestSnapshot?.chatWithPromptTemplate).toBe('hydrated-before-github-network');
+    expect(latestSnapshot?.error).toBeNull();
+
+    await invoke(() => latestSnapshot!.onToggleGithubSyncEnabled(false));
+    expect(gateMocks.setSyncProviderEnabled).toHaveBeenCalledWith('github', false);
+    expect(latestSnapshot?.githubSyncEnabled).toBe(false);
+
+    await act(async () => {
+      discovery.resolve(ok(readyRepositories(['owner/deferred'])));
+      await discovery.promise;
+      for (let index = 0; index < 10; index += 1) await Promise.resolve();
+    });
+    expect(latestSnapshot?.githubRepositories.map((item) => item.fullName)).toEqual(['owner/deferred']);
+  });
+
+  it('does not loop automatic discovery after an ordinary failure and retries only on explicit refresh', async () => {
+    githubSettingsData = githubSettings({ state: 'connected' });
+    repositoryResponses = [fail('github_repository_list_failed')];
+
+    await renderController('github');
+    expect(callCount(GITHUB_MESSAGE_TYPES.LIST_REPOSITORIES)).toBe(1);
+    expect(latestSnapshot?.error).toBeNull();
+    await flushReact();
+    expect(callCount(GITHUB_MESSAGE_TYPES.LIST_REPOSITORIES)).toBe(1);
+
+    repositoryResponses = [ok(readyRepositories(['owner/retry']))];
+    await invoke(() => latestSnapshot!.onRefreshGithubRepositories());
+    expect(callCount(GITHUB_MESSAGE_TYPES.LIST_REPOSITORIES)).toBe(2);
+    expect(latestSnapshot?.githubRepositories.map((item) => item.fullName)).toEqual(['owner/retry']);
   });
 
   it('keeps manual repository refresh outside global busy and the settings task queue', async () => {

--- a/tests/unit/settings-controller-github.test.ts
+++ b/tests/unit/settings-controller-github.test.ts
@@ -65,6 +65,7 @@ vi.mock('@i18n', () => ({
 
 type Snapshot = ReturnType<typeof useSettingsSceneController>;
 type ApiResponse = { ok: boolean; data: any; error: any };
+type RepositoryResponse = ApiResponse | Promise<ApiResponse> | (() => ApiResponse | Promise<ApiResponse>);
 
 const ACCESS_TOKEN = 'sentinel_access_token';
 const REFRESH_TOKEN = 'sentinel_refresh_token';
@@ -85,6 +86,7 @@ let testConnectionResponse: ApiResponse;
 let initializeRepositoryResponse: ApiResponse;
 let saveSettingsResponse: ApiResponse | null;
 let pollResponses: Array<ApiResponse | (() => ApiResponse)> = [];
+let repositoryResponses: RepositoryResponse[] = [];
 
 const ok = (data: any): ApiResponse => ({ ok: true, data, error: null });
 const fail = (message: string, extra: any = null): ApiResponse => ({
@@ -92,6 +94,16 @@ const fail = (message: string, extra: any = null): ApiResponse => ({
   data: null,
   error: { message, extra },
 });
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
 
 function githubSettings(auth: any, repository = 'owner/repo') {
   return {
@@ -234,6 +246,7 @@ beforeEach(() => {
   });
   saveSettingsResponse = null;
   pollResponses = [];
+  repositoryResponses = [];
 
   storageMocks.get.mockImplementation(async (keys: string[]) =>
     Object.fromEntries(keys.map((key) => [key, storageState[key]])),
@@ -267,7 +280,11 @@ beforeEach(() => {
       });
     }
     if (type === GITHUB_MESSAGE_TYPES.GET_SETTINGS) return ok(githubSettingsData);
-    if (type === GITHUB_MESSAGE_TYPES.LIST_REPOSITORIES) return ok(githubRepositoryData);
+    if (type === GITHUB_MESSAGE_TYPES.LIST_REPOSITORIES) {
+      const next = repositoryResponses.shift();
+      if (next != null) return typeof next === 'function' ? next() : next;
+      return ok(githubRepositoryData);
+    }
     if (type === GITHUB_MESSAGE_TYPES.START_DEVICE_FLOW) return startResponse;
     if (type === GITHUB_MESSAGE_TYPES.POLL_DEVICE_FLOW) {
       const next = pollResponses.shift();
@@ -427,6 +444,123 @@ describe('Settings controller GitHub Device Flow', () => {
     expect(latestSnapshot?.githubAccount).toBeNull();
     expect(latestSnapshot?.githubRepositories).toEqual([]);
     expect(callCount(GITHUB_MESSAGE_TYPES.DISCONNECT)).toBe(1);
+  });
+
+  it('keeps manual repository refresh outside global busy and the settings task queue', async () => {
+    githubSettingsData = githubSettings({ state: 'connected' });
+    await renderController();
+
+    const refresh = deferred<ApiResponse>();
+    repositoryResponses = [refresh.promise];
+    let refreshPromise!: Promise<void>;
+    act(() => {
+      refreshPromise = latestSnapshot!.onRefreshGithubRepositories();
+    });
+    await flushReact();
+
+    expect(latestSnapshot?.busy).toBe(false);
+    await invoke(() => latestSnapshot!.onToggleGithubSyncEnabled(false));
+    expect(gateMocks.setSyncProviderEnabled).toHaveBeenCalledWith('github', false);
+    expect(latestSnapshot?.githubSyncEnabled).toBe(false);
+
+    await act(async () => {
+      refresh.resolve(ok(readyRepositories(['owner/refreshed'])));
+      await refreshPromise;
+    });
+    expect(latestSnapshot?.githubRepositories.map((item) => item.fullName)).toEqual(['owner/refreshed']);
+  });
+
+  it('keeps only the latest overlapping repository discovery result and ignores stale errors', async () => {
+    githubSettingsData = githubSettings({ state: 'connected' });
+    await renderController();
+
+    const first = deferred<ApiResponse>();
+    const second = deferred<ApiResponse>();
+    repositoryResponses = [first.promise, second.promise];
+    let firstPromise!: Promise<void>;
+    let secondPromise!: Promise<void>;
+    act(() => {
+      firstPromise = latestSnapshot!.onRefreshGithubRepositories();
+      secondPromise = latestSnapshot!.onRefreshGithubRepositories();
+    });
+    await flushReact();
+
+    await act(async () => {
+      second.resolve(ok(readyRepositories(['owner/latest'])));
+      await secondPromise;
+    });
+    expect(latestSnapshot?.githubRepositories.map((item) => item.fullName)).toEqual(['owner/latest']);
+
+    await act(async () => {
+      first.resolve(fail('github_repository_list_failed'));
+      await firstPromise;
+    });
+    expect(latestSnapshot?.githubRepositories.map((item) => item.fullName)).toEqual(['owner/latest']);
+    expect(latestSnapshot?.error).toBeNull();
+  });
+
+  it('invalidates pending repository discovery when GitHub disconnects', async () => {
+    githubSettingsData = githubSettings({ state: 'connected' });
+    await renderController();
+
+    const refresh = deferred<ApiResponse>();
+    repositoryResponses = [refresh.promise];
+    let refreshPromise!: Promise<void>;
+    act(() => {
+      refreshPromise = latestSnapshot!.onRefreshGithubRepositories();
+    });
+    await flushReact();
+
+    await invoke(() => latestSnapshot!.onDisconnectGithub());
+    expect(latestSnapshot?.githubAuth).toEqual({ state: 'disconnected' });
+    expect(latestSnapshot?.githubAccount).toBeNull();
+    expect(latestSnapshot?.githubRepositories).toEqual([]);
+
+    await act(async () => {
+      refresh.resolve(ok(readyRepositories(['owner/stale'])));
+      await refreshPromise;
+    });
+    expect(latestSnapshot?.githubAuth).toEqual({ state: 'disconnected' });
+    expect(latestSnapshot?.githubAccount).toBeNull();
+    expect(latestSnapshot?.githubRepositories).toEqual([]);
+  });
+
+  it('fails closed on current repository auth failure but ignores stale auth failure', async () => {
+    githubSettingsData = githubSettings({ state: 'connected' });
+    await renderController();
+
+    repositoryResponses = [fail('github_auth_required')];
+    await invoke(() => latestSnapshot!.onRefreshGithubRepositories());
+    expect(latestSnapshot?.githubAuth).toEqual({ state: 'disconnected' });
+    expect(latestSnapshot?.githubRepositories).toEqual([]);
+
+    githubSettingsData = githubSettings({ state: 'connected' });
+    pollResponses = [ok({ auth: { state: 'connected' } })];
+    await invoke(() => latestSnapshot!.onPollGithubDeviceFlow());
+    expect(latestSnapshot?.githubAuth).toEqual({ state: 'connected' });
+
+    const stale = deferred<ApiResponse>();
+    const latest = deferred<ApiResponse>();
+    repositoryResponses = [stale.promise, latest.promise];
+    let stalePromise!: Promise<void>;
+    let latestPromise!: Promise<void>;
+    act(() => {
+      stalePromise = latestSnapshot!.onRefreshGithubRepositories();
+      latestPromise = latestSnapshot!.onRefreshGithubRepositories();
+    });
+    await flushReact();
+
+    await act(async () => {
+      latest.resolve(ok(readyRepositories(['owner/current'])));
+      await latestPromise;
+    });
+    await act(async () => {
+      stale.resolve(fail('github_auth_required'));
+      await stalePromise;
+    });
+
+    expect(latestSnapshot?.githubAuth).toEqual({ state: 'connected' });
+    expect(latestSnapshot?.githubRepositories.map((item) => item.fullName)).toEqual(['owner/current']);
   });
 
   it('keeps a lost stored repository visible and never silently selects or accepts an unauthorized replacement', async () => {

--- a/tests/unit/settings-controller-github.test.ts
+++ b/tests/unit/settings-controller-github.test.ts
@@ -524,6 +524,32 @@ describe('Settings controller GitHub Device Flow', () => {
     expect(latestSnapshot?.githubRepositories.map((item) => item.fullName)).toEqual(['owner/retry']);
   });
 
+  it('treats an unknown discovery status as a scoped failure instead of auto-retrying forever', async () => {
+    githubSettingsData = githubSettings({ state: 'connected' });
+    repositoryResponses = [ok({ ...readyRepositories(), status: 'unexpected_status' })];
+
+    await renderController('github');
+    expect(callCount(GITHUB_MESSAGE_TYPES.LIST_REPOSITORIES)).toBe(1);
+    expect(latestSnapshot?.githubRepositories).toEqual([]);
+    expect(latestSnapshot?.error).toBeNull();
+
+    await flushReact();
+    expect(callCount(GITHUB_MESSAGE_TYPES.LIST_REPOSITORIES)).toBe(1);
+  });
+
+  it('preserves the previous successful catalog when the current manual refresh fails', async () => {
+    githubSettingsData = githubSettings({ state: 'connected' });
+    githubRepositoryData = readyRepositories(['owner/previous']);
+    await renderController();
+    expect(latestSnapshot?.githubRepositories.map((item) => item.fullName)).toEqual(['owner/previous']);
+
+    repositoryResponses = [fail('github_repository_list_failed')];
+    await invoke(() => latestSnapshot!.onRefreshGithubRepositories());
+
+    expect(latestSnapshot?.githubRepositories.map((item) => item.fullName)).toEqual(['owner/previous']);
+    expect(latestSnapshot?.error).toBeNull();
+  });
+
   it('keeps manual repository refresh outside global busy and the settings task queue', async () => {
     githubSettingsData = githubSettings({ state: 'connected' });
     await renderController();
@@ -575,6 +601,35 @@ describe('Settings controller GitHub Device Flow', () => {
     });
     expect(latestSnapshot?.githubRepositories.map((item) => item.fullName)).toEqual(['owner/latest']);
     expect(latestSnapshot?.error).toBeNull();
+  });
+
+  it('invalidates a pending repository discovery when the controller unmounts', async () => {
+    githubSettingsData = githubSettings({ state: 'connected' });
+    await renderController();
+
+    const refresh = deferred<ApiResponse>();
+    repositoryResponses = [refresh.promise];
+    let refreshPromise!: Promise<void>;
+    act(() => {
+      refreshPromise = latestSnapshot!.onRefreshGithubRepositories();
+    });
+    await flushReact();
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await act(async () => {
+      root?.unmount();
+      await Promise.resolve();
+    });
+    root = null;
+
+    await act(async () => {
+      refresh.resolve(ok(readyRepositories(['owner/late-after-unmount'])));
+      await refreshPromise;
+    });
+
+    const errors = consoleError.mock.calls.flat().map(String).join(' ');
+    expect(errors.toLowerCase()).not.toContain('unmounted');
+    consoleError.mockRestore();
   });
 
   it('invalidates pending repository discovery when GitHub disconnects', async () => {

--- a/tests/unit/settings-sections.test.ts
+++ b/tests/unit/settings-sections.test.ts
@@ -260,7 +260,7 @@ describe('settings section definitions', () => {
       verificationUrl: 'https://github.com/login/device',
       appUrl: 'https://github.com/apps/syncnos',
       installUrl: 'https://github.com/apps/syncnos/installations/new',
-      connectionTest: { status: 'idle' },
+      connectionTest: { status: 'uninitialized' },
       githubLogoUrl: '/icons/github.svg',
       onToggleSyncEnabled: () => {},
       onToggleAutoSyncEnabled: () => {},
@@ -292,6 +292,9 @@ describe('settings section definitions', () => {
     const testButton = Array.from(document.querySelectorAll('button')).find(
       (button) => button.textContent?.trim() === 'Test connection',
     ) as HTMLButtonElement | undefined;
+    const initializeButton = Array.from(document.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Initialize repository',
+    ) as HTMLButtonElement | undefined;
     const appLink = document.querySelector('a[href="https://github.com/apps/syncnos"]') as HTMLAnchorElement | null;
 
     expect(repositoryTrigger?.disabled).toBe(true);
@@ -303,6 +306,7 @@ describe('settings section definitions', () => {
     expect(autoSyncToggle?.disabled).toBe(false);
     expect(branchInput?.disabled).toBe(false);
     expect(testButton?.disabled).toBe(false);
+    expect(initializeButton?.disabled).toBe(false);
     expect(appLink).toBeTruthy();
 
     act(() => {

--- a/tests/unit/settings-sections.test.ts
+++ b/tests/unit/settings-sections.test.ts
@@ -81,6 +81,8 @@ describe('settings section definitions', () => {
       account: null,
       repositoryStatus: null,
       repositories: [],
+      repositoriesLoading: false,
+      repositoryDiscoveryError: '',
       targetUnavailable: false,
       repository: '',
       branch: 'main',
@@ -234,6 +236,90 @@ describe('settings section definitions', () => {
     expect(initializeButton).toBeTruthy();
     act(() => initializeButton!.dispatchEvent(new window.MouseEvent('click', { bubbles: true })));
     expect(callbacks.onInitializeRepository).toHaveBeenCalledTimes(1);
+
+    act(() => root.unmount());
+    cleanupDom();
+  });
+
+  it('scopes GitHub repository discovery loading and errors to repository controls', () => {
+    setupDom();
+    const root = ReactDOM.createRoot(document.getElementById('root')!);
+    const baseProps: Parameters<typeof GitHubSettingsSection>[0] = {
+      busy: false,
+      syncEnabled: true,
+      autoSyncEnabled: true,
+      auth: { state: 'connected' },
+      account: { login: 'octocat', avatarUrl: '', url: 'https://github.com/octocat' },
+      repositoryStatus: 'ready',
+      repositories: [{ fullName: 'owner/repo', contentWriteCapable: true }],
+      repositoriesLoading: true,
+      repositoryDiscoveryError: '',
+      targetUnavailable: false,
+      repository: 'owner/repo',
+      branch: 'main',
+      verificationUrl: 'https://github.com/login/device',
+      appUrl: 'https://github.com/apps/syncnos',
+      installUrl: 'https://github.com/apps/syncnos/installations/new',
+      connectionTest: { status: 'idle' },
+      githubLogoUrl: '/icons/github.svg',
+      onToggleSyncEnabled: () => {},
+      onToggleAutoSyncEnabled: () => {},
+      onConnect: () => {},
+      onCancelDeviceFlow: () => {},
+      onDisconnect: () => {},
+      onRefreshRepositories: () => {},
+      onChangeRepository: () => {},
+      onChangeBranch: () => {},
+      onSaveBranch: () => {},
+      onTestConnection: () => {},
+      onInitializeRepository: () => {},
+    };
+
+    act(() => {
+      root.render(createElement(GitHubSettingsSection, baseProps));
+    });
+
+    const repositoryTrigger = document.querySelector('button#githubRepository') as HTMLButtonElement | null;
+    const refreshButton = document.querySelector(
+      'button[aria-label="Refresh repositories"]',
+    ) as HTMLButtonElement | null;
+    const disconnectButton = Array.from(document.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Disconnect',
+    ) as HTMLButtonElement | undefined;
+    const syncToggle = document.querySelector('#githubSyncEnabledToggle') as HTMLInputElement | null;
+    const autoSyncToggle = document.querySelector('#githubAutoSyncEnabledToggle') as HTMLInputElement | null;
+    const branchInput = document.querySelector('input[aria-label="Branch"]') as HTMLInputElement | null;
+    const testButton = Array.from(document.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Test connection',
+    ) as HTMLButtonElement | undefined;
+    const appLink = document.querySelector('a[href="https://github.com/apps/syncnos"]') as HTMLAnchorElement | null;
+
+    expect(repositoryTrigger?.disabled).toBe(true);
+    expect(refreshButton?.disabled).toBe(true);
+    expect(refreshButton?.getAttribute('aria-busy')).toBe('true');
+    expect(refreshButton?.textContent).toContain('⏳');
+    expect(disconnectButton?.disabled).toBe(false);
+    expect(syncToggle?.disabled).toBe(false);
+    expect(autoSyncToggle?.disabled).toBe(false);
+    expect(branchInput?.disabled).toBe(false);
+    expect(testButton?.disabled).toBe(false);
+    expect(appLink).toBeTruthy();
+
+    act(() => {
+      root.render(
+        createElement(GitHubSettingsSection, {
+          ...baseProps,
+          repositoriesLoading: false,
+          repositoryDiscoveryError: 'github_repository_list_failed',
+        }),
+      );
+    });
+
+    const repositoryCard = document.querySelector('section[aria-label="Repository"]');
+    const discoveryError = document.querySelector('[data-github-repository-discovery-error="true"]');
+    expect(discoveryError?.textContent || '').toContain('github_repository_list_failed');
+    expect(repositoryCard?.contains(discoveryError)).toBe(true);
+    expect(document.querySelector('[aria-label="settings-error"]')).toBeNull();
 
     act(() => root.unmount());
     cleanupDom();


### PR DESCRIPTION
## Related issue

Closes #514

## Why

已连接 GitHub 后，进入 WebClipper → Settings → GitHub 时，repository discovery 会被并入 Settings 的全局初始化事务。由于 discovery 需要访问 GitHub `/user`、installations 和 repositories 分页，远端 IO 完成前 global `busy` 会一直保持，导致 GitHub 设置页大量无关按钮、开关和输入控件短暂不可操作。

问题的根因不是渲染性能，而是 loading scope 和 task queue 边界错误：远端派生的 repository catalog 不应成为整个 Settings 基础 hydration 的阻塞条件。

## What changed

- 在 `useSettingsSceneController` 中建立独立的 GitHub repository discovery lifecycle：scoped loading、scoped error 和 request generation。
- repository discovery 直接走现有 `LIST_REPOSITORIES`，不再经过 `runTask` / `taskQueueRef`，因此不会延长 global `busy`，也不会把其他 Settings action 排队在 GitHub 网络请求之后。
- `refreshInternal()` 只恢复基础 settings/auth 状态，不再等待 repository discovery。
- 只有当前 section 为 GitHub 且 auth 已连接时才 lazy discovery；进入其他 Settings section 不主动请求 repositories。
- automatic discovery 和手动 Refresh 共用同一个 runner；成功 discovery 后普通 rerender / 切换 section 不重复请求。
- 使用 generation guard 实现 latest-request-wins；新请求、Disconnect、auth clear、unmount 后，旧 success/error/auth-required 都不会覆盖新状态。
- 普通 discovery failure 只写 scoped error，并保留上一份成功 catalog；当前有效请求遇到 `github_auth_required` 时仍 fail closed 为 disconnected。
- UI 只在 repository catalog 加载期间禁用 Repository selector / Refresh；Disconnect、provider toggle、auto-sync、已保存 branch 编辑、Test connection、Initialize repository 和 GitHub App link 不会仅因 discovery loading 被禁用。
- 删除旧的 blocking discovery 生产路径，不保留 parallel/backward-compatible 实现。

## Scope and non-goals

- 不改变 GitHub App permissions、Device Flow、token refresh、repository access 判定或 preflight。
- 不改变 GitHub sync projection、managed paths、storage key、message contract 或 schema。
- 不引入 repository catalog 持久缓存、TTL 或 stale-while-revalidate。
- 不重构 Notion / 飞书 / Obsidian loading lifecycle。
- 不改变 Test connection / Initialize repository 的业务语义。

## Validation

- `npm run gate:ci`: **PASS** — lint、Prettier、TypeScript compile、完整 Vitest 全通过；259 test files / 1506 tests。
- `npm run gate`: **N/A** — 本 PR 不修改 production build、manifest、权限、打包或发布配置。
- Targeted tests or boundary scans:
  - `tests/unit/settings-controller-github.test.ts`: 21 tests，已包含在完整 gate 中并通过。
  - `tests/unit/settings-sections.test.ts`: 12 tests，已包含在完整 gate 中并通过。
  - `rg -n "@platform/|src/platform|/platform/" src/ui src/viewmodels`: PASS；仅命中 `src/ui/AGENTS.md` 规则文本。
  - `rg -n "@ui/|@viewmodels/" src/services`: PASS。
  - UI radius scan：本 PR 未新增数字圆角违规。
  - `git diff --check origin/main...HEAD`: PASS。

Manual validation:

| Browser / surface | Scenario | Result |
| --- | --- | --- |
| WebClipper Settings → GitHub | 已连接 GitHub，慢速 repository discovery 时确认整页不再灰掉，仅 Repository / Refresh 显示 scoped loading | **PASS（用户手动验收）** |
| WebClipper Settings → GitHub | discovery 期间确认 Disconnect、sync/auto-sync、branch、Test connection、Initialize、GitHub App link 仍按各自前置条件可用 | **PASS（用户手动验收）** |

## Architecture, data, and permissions

- Affected layers / dependency boundaries: `src/viewmodels/settings` 与 `src/ui/settings`；保持 `ui -> viewmodels -> services` 依赖方向，没有新增 UI/ViewModel → platform 依赖。
- Local storage, schema, backup/restore, or migration impact: **N/A**；没有新增/修改 storage key、schema 或 migration。
- Browser permission or external-network impact: **N/A**；仍只使用既有 GitHub API endpoint 和现有权限，改变的是 repository discovery 的触发/等待生命周期。
- Failure path: ordinary discovery failure 不改本地 target，不清上一份成功 catalog，只显示 scoped error；auth-required 仍 fail closed；Disconnect/unmount 后 late response 被 generation guard 丢弃。

## UI evidence

真实浏览器慢速 discovery 已由用户手动验收通过；自动化 UI test 同时锁定 repository loading 下的 disabled matrix 和 scoped error 位置。

## Risks and tradeoffs

- repository catalog 仍然是实时远端派生状态；本 PR没有增加跨 mount cache，因此完全关闭并重新打开 Settings 后仍会进行一次新的 GitHub-section lazy discovery。
- discovery 与 Test connection / Initialize 可以并行；它们各自走实时 preflight/initialize，不依赖 catalog 请求完成。generation guard 只保护 discovery 状态，不改变这些 action 的既有业务流程。

## Documentation and cleanup

- [x] Canonical documentation made stale by this change is updated, or no documentation change is required. `docs/guide/github/GitHubSync.zh.md` / `.en.md` 已复核，现有“授权后发现 repositories / 可手动刷新 repositories”与本改动兼容。
- [x] Replaced production paths, dead compatibility branches, and outdated test assumptions are removed, or none were introduced/replaced.
- [x] I reviewed the final diff from top to bottom before requesting review.

