### PR TITLE
feat: 抓取用户已展开的 ChatGPT COT

### DIFF
--- a/src/collectors/chatgpt/chatgpt-collector.ts
+++ b/src/collectors/chatgpt/chatgpt-collector.ts
@@ -369,6 +369,7 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
 
   type CotAssociation = {
     semanticText: string;
+    semanticMarkdown: string;
     outerHtml: string;
   };
 
@@ -431,43 +432,24 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
 
   function extractCotContent(root: any): CotContent {
     const blocks = collectCotContentBlocks(root);
-    if (!blocks.length) {
-      const text = String(chatgptMarkdown.extractRenderedText?.(root) || '').trim();
-      const markdown = String(chatgptMarkdown.extractRenderedMarkdown?.(root) || text).trim();
-      return { text, markdown };
-    }
+    if (!blocks.length) return { text: '', markdown: '' };
 
     const textBlocks: string[] = [];
     const markdownBlocks: string[] = [];
     for (const block of blocks) {
       const text = String(chatgptMarkdown.extractRenderedText?.(block.node) || '').trim();
-      if (!text) continue;
-      textBlocks.push(text);
       const markdown =
         block.kind === 'reasoning'
           ? String(chatgptMarkdown.extractRenderedMarkdown?.(block.node) || text).trim()
           : text;
-      markdownBlocks.push(markdown || text);
+      if (!text && !markdown) continue;
+      if (text) textBlocks.push(text);
+      if (markdown) markdownBlocks.push(markdown);
     }
     return {
       text: joinContentBlocks(textBlocks),
       markdown: joinContentBlocks(markdownBlocks),
     };
-  }
-
-  function buttonCarriesRenderedSource(button: any): boolean {
-    const values = [
-      button?.getAttribute?.('data-clipboard-text'),
-      button?.getAttribute?.('data-copy-text'),
-      button?.getAttribute?.('data-code'),
-      button?.getAttribute?.('data-source'),
-      button?.getAttribute?.('data-mermaid'),
-      button?.getAttribute?.('data-mermaid-source'),
-    ];
-    return values.some((value) => {
-      const text = String(value || '');
-      return !!text && (text.includes('\n') || text.length > 120);
-    });
   }
 
   function pruneCotBodyClone(body: any): any | null {
@@ -491,23 +473,13 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
       } catch (_error) {
         // ignore
       }
+      try {
+        toggle?.remove?.();
+      } catch (_error) {
+        // ignore
+      }
     }
 
-    for (const node of Array.from(clone.querySelectorAll('svg, path')) as any[]) {
-      try {
-        node.remove?.();
-      } catch (_error) {
-        // ignore
-      }
-    }
-    for (const button of Array.from(clone.querySelectorAll('button')) as any[]) {
-      if (buttonCarriesRenderedSource(button)) continue;
-      try {
-        button.remove?.();
-      } catch (_error) {
-        // ignore
-      }
-    }
     return clone;
   }
 
@@ -525,9 +497,11 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
     if (!clone) return null;
     const content = extractCotContent(clone);
     const semanticText = String(content.text || '').trim();
-    if (!semanticText) return null;
+    const semanticMarkdown = String(content.markdown || '').trim();
+    if (!semanticText && !semanticMarkdown) return null;
     return {
       semanticText,
+      semanticMarkdown,
       outerHtml: includeOuterHtml ? String(clone.outerHTML || '') : '',
     };
   }
@@ -548,7 +522,7 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
       wrappersByGroup.set(group, groupWrappers);
     }
 
-    const pending = new Map<any, { semanticParts: string[]; htmlParts: string[] }>();
+    const pending = new Map<any, { textParts: string[]; markdownParts: string[]; htmlParts: string[] }>();
     for (const [group, groupWrappers] of wrappersByGroup) {
       const assistants = groupWrappers.filter((wrapper) => roleFromWrapper(wrapper) === 'assistant');
       if (!assistants.length || !group?.querySelectorAll) continue;
@@ -575,8 +549,9 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
         if (!owner) continue;
         const snapshot = snapshotCotBody(body, includeOuterHtml);
         if (!snapshot) continue;
-        const bucket = pending.get(owner) || { semanticParts: [], htmlParts: [] };
-        bucket.semanticParts.push(snapshot.semanticText);
+        const bucket = pending.get(owner) || { textParts: [], markdownParts: [], htmlParts: [] };
+        if (snapshot.semanticText) bucket.textParts.push(snapshot.semanticText);
+        if (snapshot.semanticMarkdown) bucket.markdownParts.push(snapshot.semanticMarkdown);
         if (includeOuterHtml && snapshot.outerHtml) bucket.htmlParts.push(snapshot.outerHtml);
         pending.set(owner, bucket);
       }
@@ -585,7 +560,8 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
     const result = new Map<any, CotAssociation>();
     for (const [owner, bucket] of pending) {
       result.set(owner, {
-        semanticText: joinContentBlocks(bucket.semanticParts),
+        semanticText: joinContentBlocks(bucket.textParts),
+        semanticMarkdown: joinContentBlocks(bucket.markdownParts),
         outerHtml: includeOuterHtml ? bucket.htmlParts.join('\n') : '',
       });
     }
@@ -614,15 +590,16 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
     key: string;
     text: string;
     cotText: string;
+    cotMarkdown: string;
     imageUrls: string[];
     iframeUrl: string;
   }): string {
     const imageRefs = input.imageUrls.join('|');
     const source = `${input.role}|${input.key}|${input.text.length}|${compactFingerprintPart(input.text)}|${
       input.cotText.length
-    }|${compactFingerprintPart(input.cotText)}|${input.imageUrls.length}|${compactFingerprintPart(
-      imageRefs,
-    )}|${compactFingerprintPart(input.iframeUrl)}`;
+    }|${compactFingerprintPart(input.cotText)}|${input.cotMarkdown.length}|${compactFingerprintPart(
+      input.cotMarkdown,
+    )}|${input.imageUrls.length}|${compactFingerprintPart(imageRefs)}|${compactFingerprintPart(input.iframeUrl)}`;
     return compactFingerprintPart(source);
   }
 
@@ -669,12 +646,13 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
       const iframeUrl = String(iframe?.getAttribute?.('src') || '').trim();
       const cot = role === 'assistant' && !iframe ? cotByOwner.get(wrapper) || null : null;
       const cotText = String(cot?.semanticText || '');
+      const cotMarkdown = String(cot?.semanticMarkdown || '');
       const descriptor: ChatgptDescriptor = {
         key,
         turnKey,
         withinTurn,
         role,
-        fingerprint: descriptorFingerprint({ role, key, text, cotText, imageUrls, iframeUrl }),
+        fingerprint: descriptorFingerprint({ role, key, text, cotText, cotMarkdown, imageUrls, iframeUrl }),
         hasDeepResearch: !!iframe,
         rendered: !!text || imageUrls.length > 0 || !!iframe,
         visible: isVisibleWindow(wrapper),

--- a/src/collectors/chatgpt/chatgpt-collector.ts
+++ b/src/collectors/chatgpt/chatgpt-collector.ts
@@ -541,10 +541,7 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
         const body = button?.nextElementSibling;
         if (!body || body?.closest?.('[data-message-author-role]')) continue;
         const owner = assistants.find(
-          (wrapper) =>
-            wrapper !== group &&
-            !body?.contains?.(wrapper) &&
-            compareDocumentOrder(body, wrapper) < 0,
+          (wrapper) => wrapper !== group && !body?.contains?.(wrapper) && compareDocumentOrder(body, wrapper) < 0,
         );
         if (!owner) continue;
         const snapshot = snapshotCotBody(body, includeOuterHtml);

--- a/src/collectors/chatgpt/chatgpt-collector.ts
+++ b/src/collectors/chatgpt/chatgpt-collector.ts
@@ -273,13 +273,6 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
     return env.document.querySelector('main') || env.document.querySelector("[role='main']") || env.document.body;
   }
 
-  function inEditMode(root: any): any {
-    if (!root) return false;
-    const ta = root.querySelector('textarea');
-    if (!ta) return false;
-    return env.document.activeElement === ta || ta.contains(env.document.activeElement);
-  }
-
   function userContentNode(element: any): any {
     return element.querySelector('.whitespace-pre-wrap') || element;
   }
@@ -366,55 +359,6 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
     if (wrapper && wrapper.classList && wrapper.classList.contains('agent-turn')) return 'assistant';
     if (wrapper && wrapper.querySelector && wrapper.querySelector("div[class*='user']")) return 'user';
     return 'assistant';
-  }
-
-  // Extract a single message from one turn wrapper. Returns null when the wrapper has no
-  // textual content and no images (e.g. virtualized empty shells), so callers can skip it.
-  async function extractMessageFromWrapper(el: any, i: number, { messageKeyOverride }: any = {}): Promise<any | null> {
-    const role = roleFromWrapper(el);
-    const messageId =
-      (el.getAttribute && (el.getAttribute('data-message-id') || el.getAttribute('data-turn-id') || el.id)) || '';
-    const node = role === 'user' ? userContentNode(el) : assistantContentNode(el);
-    const raw = node ? node.innerText || node.textContent || '' : '';
-    const fallbackText = env.normalize.normalizeText(raw);
-    let contentText =
-      role === 'assistant' && typeof chatgptMarkdown.extractAssistantText === 'function'
-        ? chatgptMarkdown.extractAssistantText(el) || fallbackText
-        : fallbackText;
-    const imageUrls = (() => {
-      const primary = extractChatgptImageUrls(node || el);
-      if (!node || node === el) return primary;
-      const secondary = extractChatgptImageUrls(el);
-      return Array.from(new Set(primary.concat(secondary)));
-    })();
-
-    let baseMarkdown =
-      role === 'assistant' && typeof chatgptMarkdown.extractAssistantMarkdown === 'function'
-        ? chatgptMarkdown.extractAssistantMarkdown(el) || contentText || ''
-        : contentText || '';
-
-    const deepResearchIframe = role === 'assistant' ? findDeepResearchIframe(el) : null;
-    if (role === 'assistant' && deepResearchIframe) {
-      const iframeUrl = String(deepResearchIframe.getAttribute?.('src') || '').trim();
-      const placeholder = iframeUrl ? `Deep Research (iframe): ${iframeUrl}` : 'Deep Research (iframe)';
-      contentText = placeholder;
-      baseMarkdown = placeholder;
-    }
-
-    if (!contentText && !imageUrls.length) return null;
-    const contentMarkdown = appendImageMarkdown(baseMarkdown, imageUrls);
-    const messageKey =
-      String(messageKeyOverride || '').trim() ||
-      messageId ||
-      env.normalize.makeFallbackMessageKey({ role, contentText, sequence: i });
-    return {
-      messageKey,
-      role,
-      contentText,
-      contentMarkdown,
-      sequence: i,
-      updatedAt: Date.now(),
-    };
   }
 
   function compactFingerprintPart(value: string): string {
@@ -551,21 +495,6 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
     readWindow: () => readCurrentManualWindow(true),
     getExtractionCount: () => manualExtractionCount,
   };
-
-  async function collectMessages({ allowEditing }: any = {}): Promise<any[]> {
-    const root = getConversationRoot();
-    if (!root) return [];
-    if (!allowEditing && inEditMode(root)) return [];
-
-    const wrappers = getTurnWrappers(root);
-    const out: any[] = [];
-    for (let i = 0; i < wrappers.length; i += 1) {
-      const msg = await extractMessageFromWrapper(wrappers[i], i);
-      if (msg) out.push(msg);
-    }
-
-    return out;
-  }
 
   async function harvestRenderedInto(
     accumulator: PreparedAccumulator<any>,
@@ -743,7 +672,6 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
       identityConversationKey,
       manualAdapter,
       getRoot: getConversationRoot,
-      collectMessages,
     },
   };
 

--- a/src/collectors/chatgpt/chatgpt-collector.ts
+++ b/src/collectors/chatgpt/chatgpt-collector.ts
@@ -39,6 +39,7 @@ export function turnKeyOf(el: any): string {
 
 export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinition {
   const consumePreparedCapture = createPreparedCaptureConsumer<any>('chatgpt');
+  const MODERN_TURN_SELECTOR = "[data-testid^='conversation-turn-'], [data-testid='conversation-turn']";
 
   function findDeepResearchIframe(wrapper: any): any | null {
     if (!wrapper || !wrapper.querySelector) return null;
@@ -126,9 +127,7 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
 
   function readTurnShells(root: any): any[] {
     if (!root?.querySelectorAll) return [];
-    return Array.from(
-      root.querySelectorAll("[data-testid^='conversation-turn-'], [data-testid='conversation-turn']"),
-    ) as any[];
+    return Array.from(root.querySelectorAll(MODERN_TURN_SELECTOR)) as any[];
   }
 
   function sampleIdentityGuard(root: any): PreparedIdentityGuard {
@@ -300,6 +299,7 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
     outerHtml: string;
     imageUrls: string[];
     iframeUrl: string;
+    cotOuterHtml: string;
   };
 
   function getTurnWrappers(root: any): any {
@@ -322,9 +322,7 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
 
     const roleNodes = Array.from(scope.querySelectorAll('[data-message-author-role]')) as any[];
     // Modern ChatGPT wraps each turn with `data-testid="conversation-turn-N"` but the tag varies (`article`, `section`, etc).
-    const turnNodes = Array.from(
-      scope.querySelectorAll("[data-testid^='conversation-turn-'], [data-testid='conversation-turn']"),
-    ) as any[];
+    const turnNodes = Array.from(scope.querySelectorAll(MODERN_TURN_SELECTOR)) as any[];
 
     // Prefer message-level nodes if available. Some modern ChatGPT DOMs group multiple assistant
     // messages inside a single `.agent-turn` container; keeping `.agent-turn` as the wrapper would
@@ -361,6 +359,251 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
     return 'assistant';
   }
 
+  const COT_REASONING_SELECTOR = '.markdown.prose, .markdown';
+  const COT_TOOL_ICON_SELECTOR = "[data-testid='cot-v5-tool-icon-pile']";
+
+  type CotContent = {
+    text: string;
+    markdown: string;
+  };
+
+  type CotAssociation = {
+    semanticText: string;
+    outerHtml: string;
+  };
+
+  function compareDocumentOrder(left: any, right: any): number {
+    if (left === right) return 0;
+    if (!left?.compareDocumentPosition || !right) return 0;
+    const position = left.compareDocumentPosition(right);
+    const following = env.window?.Node?.DOCUMENT_POSITION_FOLLOWING ?? 4;
+    const preceding = env.window?.Node?.DOCUMENT_POSITION_PRECEDING ?? 2;
+    if (position & following) return -1;
+    if (position & preceding) return 1;
+    return 0;
+  }
+
+  function joinContentBlocks(values: unknown[]): string {
+    return values
+      .map((value) => String(value || '').trim())
+      .filter(Boolean)
+      .join('\n\n');
+  }
+
+  function isExplicitlyHiddenWithin(node: any, root: any): boolean {
+    let current = node;
+    while (current) {
+      if (current.hasAttribute?.('hidden') || String(current.getAttribute?.('aria-hidden') || '') === 'true') {
+        return true;
+      }
+      if (current === root) break;
+      current = current.parentElement;
+    }
+    return false;
+  }
+
+  function collectCotContentBlocks(root: any): Array<{ kind: 'reasoning' | 'tool'; node: any }> {
+    if (!root?.querySelectorAll) return [];
+    const candidates: Array<{ kind: 'reasoning' | 'tool'; node: any }> = [];
+    const seen = new Set<any>();
+    const push = (kind: 'reasoning' | 'tool', node: any) => {
+      if (!node || seen.has(node) || isExplicitlyHiddenWithin(node, root)) return;
+      seen.add(node);
+      candidates.push({ kind, node });
+    };
+
+    if (root.matches?.(COT_REASONING_SELECTOR)) push('reasoning', root);
+    for (const node of Array.from(root.querySelectorAll(COT_REASONING_SELECTOR)) as any[]) {
+      push('reasoning', node);
+    }
+    for (const marker of Array.from(root.querySelectorAll(COT_TOOL_ICON_SELECTOR)) as any[]) {
+      push('tool', marker?.parentElement || null);
+    }
+
+    candidates.sort((left, right) => compareDocumentOrder(left.node, right.node));
+    return candidates.filter(
+      (candidate) =>
+        !candidates.some(
+          (other) => other !== candidate && other.node?.contains?.(candidate.node) && other.node !== candidate.node,
+        ),
+    );
+  }
+
+  function extractCotContent(root: any): CotContent {
+    const blocks = collectCotContentBlocks(root);
+    if (!blocks.length) {
+      const text = String(chatgptMarkdown.extractRenderedText?.(root) || '').trim();
+      const markdown = String(chatgptMarkdown.extractRenderedMarkdown?.(root) || text).trim();
+      return { text, markdown };
+    }
+
+    const textBlocks: string[] = [];
+    const markdownBlocks: string[] = [];
+    for (const block of blocks) {
+      const text = String(chatgptMarkdown.extractRenderedText?.(block.node) || '').trim();
+      if (!text) continue;
+      textBlocks.push(text);
+      const markdown =
+        block.kind === 'reasoning'
+          ? String(chatgptMarkdown.extractRenderedMarkdown?.(block.node) || text).trim()
+          : text;
+      markdownBlocks.push(markdown || text);
+    }
+    return {
+      text: joinContentBlocks(textBlocks),
+      markdown: joinContentBlocks(markdownBlocks),
+    };
+  }
+
+  function buttonCarriesRenderedSource(button: any): boolean {
+    const values = [
+      button?.getAttribute?.('data-clipboard-text'),
+      button?.getAttribute?.('data-copy-text'),
+      button?.getAttribute?.('data-code'),
+      button?.getAttribute?.('data-source'),
+      button?.getAttribute?.('data-mermaid'),
+      button?.getAttribute?.('data-mermaid-source'),
+    ];
+    return values.some((value) => {
+      const text = String(value || '');
+      return !!text && (text.includes('\n') || text.length > 120);
+    });
+  }
+
+  function pruneCotBodyClone(body: any): any | null {
+    if (!body?.cloneNode) return null;
+    let clone: any = null;
+    try {
+      clone = body.cloneNode(true);
+    } catch (_error) {
+      return null;
+    }
+    if (!clone?.querySelectorAll) return clone;
+
+    for (const toggle of Array.from(clone.querySelectorAll("button[aria-controls][aria-expanded='false']")) as any[]) {
+      const controlledId = String(toggle?.getAttribute?.('aria-controls') || '').trim();
+      if (!controlledId) continue;
+      const controlled = (Array.from(clone.querySelectorAll('[id]')) as any[]).find(
+        (node) => String(node?.getAttribute?.('id') || '') === controlledId,
+      );
+      try {
+        controlled?.remove?.();
+      } catch (_error) {
+        // ignore
+      }
+    }
+
+    for (const node of Array.from(clone.querySelectorAll('svg, path')) as any[]) {
+      try {
+        node.remove?.();
+      } catch (_error) {
+        // ignore
+      }
+    }
+    for (const button of Array.from(clone.querySelectorAll('button')) as any[]) {
+      if (buttonCarriesRenderedSource(button)) continue;
+      try {
+        button.remove?.();
+      } catch (_error) {
+        // ignore
+      }
+    }
+    return clone;
+  }
+
+  function hasReliableCotBodySignal(body: any): boolean {
+    if (!body?.querySelector) return false;
+    return (
+      String(body.getAttribute?.('data-item-anchor') || '') !== '' &&
+      String(body.getAttribute?.('data-dimension') || '') === 'height'
+    );
+  }
+
+  function snapshotCotBody(body: any, includeOuterHtml: boolean): CotAssociation | null {
+    if (!hasReliableCotBodySignal(body)) return null;
+    const clone = pruneCotBodyClone(body);
+    if (!clone) return null;
+    const content = extractCotContent(clone);
+    const semanticText = String(content.text || '').trim();
+    if (!semanticText) return null;
+    return {
+      semanticText,
+      outerHtml: includeOuterHtml ? String(clone.outerHTML || '') : '',
+    };
+  }
+
+  function messageGroupRoot(wrapper: any): any | null {
+    const modern = wrapper?.closest?.(MODERN_TURN_SELECTOR);
+    if (modern) return modern;
+    return wrapper?.closest?.('.agent-turn') || null;
+  }
+
+  function buildCotAssociations(wrappers: any[], includeOuterHtml: boolean): Map<any, CotAssociation> {
+    const wrappersByGroup = new Map<any, any[]>();
+    for (const wrapper of wrappers) {
+      const group = messageGroupRoot(wrapper);
+      if (!group) continue;
+      const groupWrappers = wrappersByGroup.get(group) || [];
+      groupWrappers.push(wrapper);
+      wrappersByGroup.set(group, groupWrappers);
+    }
+
+    const pending = new Map<any, { semanticParts: string[]; htmlParts: string[] }>();
+    for (const [group, groupWrappers] of wrappersByGroup) {
+      const assistants = groupWrappers.filter((wrapper) => roleFromWrapper(wrapper) === 'assistant');
+      if (!assistants.length || !group?.querySelectorAll) continue;
+      const candidates = (Array.from(group.querySelectorAll("button[aria-expanded='true']")) as any[])
+        .filter((button) => !String(button?.getAttribute?.('aria-controls') || '').trim())
+        .filter((button) => !button?.closest?.('[data-message-author-role]'))
+        .filter(
+          (button) =>
+            !groupWrappers.some(
+              (wrapper) => wrapper !== group && typeof wrapper?.contains === 'function' && wrapper.contains(button),
+            ),
+        )
+        .sort(compareDocumentOrder);
+
+      for (const button of candidates) {
+        const body = button?.nextElementSibling;
+        if (!body || body?.closest?.('[data-message-author-role]')) continue;
+        const owner = assistants.find(
+          (wrapper) =>
+            wrapper !== group &&
+            !body?.contains?.(wrapper) &&
+            compareDocumentOrder(body, wrapper) < 0,
+        );
+        if (!owner) continue;
+        const snapshot = snapshotCotBody(body, includeOuterHtml);
+        if (!snapshot) continue;
+        const bucket = pending.get(owner) || { semanticParts: [], htmlParts: [] };
+        bucket.semanticParts.push(snapshot.semanticText);
+        if (includeOuterHtml && snapshot.outerHtml) bucket.htmlParts.push(snapshot.outerHtml);
+        pending.set(owner, bucket);
+      }
+    }
+
+    const result = new Map<any, CotAssociation>();
+    for (const [owner, bucket] of pending) {
+      result.set(owner, {
+        semanticText: joinContentBlocks(bucket.semanticParts),
+        outerHtml: includeOuterHtml ? bucket.htmlParts.join('\n') : '',
+      });
+    }
+    return result;
+  }
+
+  function extractCotContentFromHtml(html: string): CotContent {
+    const holder = env.document.createElement('div');
+    holder.innerHTML = String(html || '');
+    const roots = Array.from(holder.children) as any[];
+    if (!roots.length) return { text: '', markdown: '' };
+    const parts = roots.map((root) => extractCotContent(root));
+    return {
+      text: joinContentBlocks(parts.map((part) => part.text)),
+      markdown: joinContentBlocks(parts.map((part) => part.markdown)),
+    };
+  }
+
   function compactFingerprintPart(value: string): string {
     const normalized = String(value || '');
     return env.normalize?.fnv1a32 ? String(env.normalize.fnv1a32(normalized)) : normalized;
@@ -370,13 +613,16 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
     role: string;
     key: string;
     text: string;
+    cotText: string;
     imageUrls: string[];
     iframeUrl: string;
   }): string {
     const imageRefs = input.imageUrls.join('|');
     const source = `${input.role}|${input.key}|${input.text.length}|${compactFingerprintPart(input.text)}|${
-      input.imageUrls.length
-    }|${compactFingerprintPart(imageRefs)}|${compactFingerprintPart(input.iframeUrl)}`;
+      input.cotText.length
+    }|${compactFingerprintPart(input.cotText)}|${input.imageUrls.length}|${compactFingerprintPart(
+      imageRefs,
+    )}|${compactFingerprintPart(input.iframeUrl)}`;
     return compactFingerprintPart(source);
   }
 
@@ -407,6 +653,7 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
     const inputsByKey = new Map<string, ChatgptExtractionInput>();
     if (!root) return { descriptors, inputsByKey };
     const wrappers = getTurnWrappers(root);
+    const cotByOwner = buildCotAssociations(wrappers, includeInputs);
     const perTurn = new Map<string, number>();
     for (const wrapper of wrappers) {
       const role = roleFromWrapper(wrapper);
@@ -420,12 +667,14 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
       const imageUrls = extractChatgptImageUrls(wrapper);
       const iframe = role === 'assistant' ? findDeepResearchIframe(wrapper) : null;
       const iframeUrl = String(iframe?.getAttribute?.('src') || '').trim();
+      const cot = role === 'assistant' && !iframe ? cotByOwner.get(wrapper) || null : null;
+      const cotText = String(cot?.semanticText || '');
       const descriptor: ChatgptDescriptor = {
         key,
         turnKey,
         withinTurn,
         role,
-        fingerprint: descriptorFingerprint({ role, key, text, imageUrls, iframeUrl }),
+        fingerprint: descriptorFingerprint({ role, key, text, cotText, imageUrls, iframeUrl }),
         hasDeepResearch: !!iframe,
         rendered: !!text || imageUrls.length > 0 || !!iframe,
         visible: isVisibleWindow(wrapper),
@@ -437,6 +686,7 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
           outerHtml: String(wrapper?.outerHTML || ''),
           imageUrls,
           iframeUrl,
+          cotOuterHtml: cot?.outerHtml || '',
         });
       }
     }
@@ -470,6 +720,10 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
       const placeholder = input.iframeUrl ? `Deep Research (iframe): ${input.iframeUrl}` : 'Deep Research (iframe)';
       contentText = placeholder;
       baseMarkdown = placeholder;
+    } else if (input.role === 'assistant' && input.cotOuterHtml) {
+      const cot = extractCotContentFromHtml(input.cotOuterHtml);
+      contentText = joinContentBlocks([cot.text, contentText]);
+      baseMarkdown = joinContentBlocks([cot.markdown || cot.text, baseMarkdown]);
     }
     if (!contentText && !input.imageUrls.length) return null;
     return {

--- a/src/collectors/chatgpt/chatgpt-markdown.ts
+++ b/src/collectors/chatgpt/chatgpt-markdown.ts
@@ -276,8 +276,7 @@ function getAssistantContentRoot(wrapper: any): any {
   return wrapper;
 }
 
-function sanitizeAssistantClone(wrapper: any): any {
-  const root = getAssistantContentRoot(wrapper);
+function sanitizeRenderedClone(root: any): any {
   if (!root || !root.cloneNode) return null;
   try {
     const cloned = root.cloneNode(true);
@@ -545,16 +544,24 @@ function htmlToMarkdown(root: any): any {
   return normalizeMarkdown(renderNode(root, { listDepth: 0 }));
 }
 
-function extractAssistantMarkdown(wrapper: any): any {
-  const cloned = sanitizeAssistantClone(wrapper);
+function extractRenderedMarkdown(root: any): any {
+  const cloned = sanitizeRenderedClone(root);
   if (!cloned) return '';
   return htmlToMarkdown(cloned) || '';
 }
 
-function extractAssistantText(wrapper: any): any {
-  const cloned = sanitizeAssistantClone(wrapper);
+function extractRenderedText(root: any): any {
+  const cloned = sanitizeRenderedClone(root);
   if (!cloned) return '';
   return normalizeText(extractTextFromSanitizedClone(cloned));
+}
+
+function extractAssistantMarkdown(wrapper: any): any {
+  return extractRenderedMarkdown(getAssistantContentRoot(wrapper));
+}
+
+function extractAssistantText(wrapper: any): any {
+  return extractRenderedText(getAssistantContentRoot(wrapper));
 }
 
 const api = {
@@ -562,6 +569,8 @@ const api = {
   normalizeMarkdown,
   extractTextFromSanitizedClone,
   htmlToMarkdown,
+  extractRenderedMarkdown,
+  extractRenderedText,
   extractAssistantMarkdown,
   extractAssistantText,
 };

--- a/tests/collectors/chatgpt-collector.test.ts
+++ b/tests/collectors/chatgpt-collector.test.ts
@@ -511,6 +511,314 @@ describe('chatgpt-collector', () => {
   });
 });
 
+describe('chatgpt expanded COT manual capture', () => {
+  const hiddenToolDetail = `${'hidden tool detail '.repeat(12)}\n\n\`\`\`ts\nconst secret = true;\n\`\`\``;
+
+  function expandedCotBody(options: {
+    firstReasoning?: string;
+    firstTool?: string;
+    secondReasoning?: string;
+    secondTool?: string;
+    transitionClass?: string;
+    transitionStyle?: string;
+    direction?: string;
+  } = {}) {
+    const firstReasoning = options.firstReasoning || 'Reasoning <strong>block one</strong>.';
+    const firstTool = options.firstTool || 'Visible tool summary one';
+    const secondReasoning = options.secondReasoning || 'Reasoning block two.';
+    const secondTool = options.secondTool || 'Visible tool summary two';
+    return `
+      <div
+        data-testid="cot-top-body"
+        data-item-anchor="start"
+        data-dimension="height"
+        data-direction="${options.direction || 'in'}"
+        class="${options.transitionClass || 'transition-body'}"
+        style="${options.transitionStyle || '--transition-progress: 1'}"
+      >
+        <div class="markdown prose"><p>${firstReasoning}</p></div>
+        <div class="tool-row">
+          <button
+            type="button"
+            aria-label="Nested tool chrome should not be saved"
+            aria-controls="cot-hidden-tool-1"
+            aria-expanded="false"
+          ></button>
+          <div class="tool-summary">
+            <span data-testid="cot-v5-tool-icon-pile"><svg aria-hidden="true"><path d="M0 0" /></svg></span>
+            <span>${firstTool}</span>
+            <svg aria-hidden="true"><path d="M1 1" /></svg>
+          </div>
+          <div id="cot-hidden-tool-1" aria-hidden="true">
+            <pre class="sr-only" aria-hidden="true"><code class="language-ts">${hiddenToolDetail}</code></pre>
+          </div>
+        </div>
+        <div class="markdown prose"><p>${secondReasoning}</p></div>
+        <div class="tool-row">
+          <button
+            type="button"
+            aria-label="Second nested tool chrome should not be saved"
+            aria-controls="cot-hidden-tool-2"
+            aria-expanded="false"
+          ></button>
+          <div class="tool-summary">
+            <span data-testid="cot-v5-tool-icon-pile"><svg aria-hidden="true"><path d="M2 2" /></svg></span>
+            <span>${secondTool}</span>
+          </div>
+          <div id="cot-hidden-tool-2" aria-hidden="true">
+            <div>${'another hidden detail '.repeat(10)}</div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  function modernCotDom(expanded = true) {
+    return setupChatgptDom(
+      `
+        <article data-testid="conversation-turn-1" data-turn-id="turn_cot_modern">
+          <div data-message-author-role="user" data-message-id="m_user_cot">
+            <div class="whitespace-pre-wrap">Question</div>
+          </div>
+          <div data-message-author-role="assistant" data-message-id="m_assistant_first" class="text-message">
+            <div class="markdown prose"><p>First assistant answer.</p></div>
+          </div>
+          <button data-testid="cot-top-toggle" type="button" aria-expanded="${expanded ? 'true' : 'false'}">
+            TOP_TOGGLE_CHROME
+            <svg aria-hidden="true"><path d="M3 3" /></svg>
+          </button>
+          ${expanded ? expandedCotBody() : ''}
+          <div data-message-author-role="assistant" data-message-id="m_assistant_second" class="text-message">
+            <div class="markdown prose"><p>Final assistant answer.</p></div>
+          </div>
+        </article>
+      `,
+      'https://chatgpt.com/c/conv_cot_modern',
+    );
+  }
+
+  function buildCotDef(dom: JSDOM) {
+    (dom.window as any).scrollTo = vi.fn();
+    return createChatgptCollectorDef(
+      createCollectorEnv({
+        window: dom.window as any,
+        document: dom.window.document as any,
+        location: dom.window.location as any,
+        normalize: normalizeApi,
+      }),
+    ) as any;
+  }
+
+  it('associates an expanded modern-turn COT only with the following assistant and keeps ordered visible blocks', async () => {
+    const dom = modernCotDom(true);
+    const snap = (await capturePrepared(buildCotDef(dom))) as any;
+    expect(snap).toBeTruthy();
+
+    const byKey = new Map(snap.messages.map((message: any) => [message.messageKey, message]));
+    expect(byKey.get('m_user_cot')?.contentText).toBe('Question');
+    expect(byKey.get('m_assistant_first')?.contentText).toBe('First assistant answer.');
+
+    const owner = byKey.get('m_assistant_second') as any;
+    expect(owner).toBeTruthy();
+    expect(owner.contentText).toBe(
+      [
+        'Reasoning block one.',
+        'Visible tool summary one',
+        'Reasoning block two.',
+        'Visible tool summary two',
+        'Final assistant answer.',
+      ].join('\n\n'),
+    );
+    expect(owner.contentMarkdown).toBe(
+      [
+        'Reasoning **block one**.',
+        'Visible tool summary one',
+        'Reasoning block two.',
+        'Visible tool summary two',
+        'Final assistant answer.',
+      ].join('\n\n'),
+    );
+    expect(owner.contentText).not.toContain('TOP_TOGGLE_CHROME');
+    expect(owner.contentText).not.toContain('Nested tool chrome should not be saved');
+    expect(owner.contentText).not.toContain('hidden tool detail');
+    expect(owner.contentMarkdown).not.toContain('const secret');
+  });
+
+  it('uses the same following-assistant ownership rule for the .agent-turn fallback', async () => {
+    const dom = setupChatgptDom(
+      `
+        <div class="agent-turn" data-turn-id="turn_cot_agent">
+          <div data-message-author-role="assistant" data-message-id="m_agent_first">
+            <div class="markdown prose"><p>Agent first.</p></div>
+          </div>
+          <button type="button" aria-expanded="true">Top COT chrome</button>
+          ${expandedCotBody({ firstReasoning: 'Agent reasoning.', firstTool: 'Agent tool summary' })}
+          <div data-message-author-role="assistant" data-message-id="m_agent_second">
+            <div class="markdown prose"><p>Agent second.</p></div>
+          </div>
+        </div>
+      `,
+      'https://chatgpt.com/c/conv_cot_agent',
+    );
+    const snap = (await capturePrepared(buildCotDef(dom))) as any;
+    const first = snap.messages.find((message: any) => message.messageKey === 'm_agent_first');
+    const second = snap.messages.find((message: any) => message.messageKey === 'm_agent_second');
+    expect(first.contentText).toBe('Agent first.');
+    expect(second.contentText).toContain('Agent reasoning.');
+    expect(second.contentText).toContain('Agent tool summary');
+    expect(second.contentText).toMatch(/Agent reasoning\.[\s\S]*Agent second\./);
+  });
+
+  it('keeps collapsed top COT answer-only', async () => {
+    const dom = modernCotDom(false);
+    const snap = (await capturePrepared(buildCotDef(dom))) as any;
+    const owner = snap.messages.find((message: any) => message.messageKey === 'm_assistant_second');
+    expect(owner.contentText).toBe('Final assistant answer.');
+    expect(owner.contentMarkdown).toBe('Final assistant answer.');
+  });
+
+  it('fingerprints only visible COT semantics, not hidden tool details or transition attributes', () => {
+    const dom = modernCotDom(true);
+    const def = buildCotDef(dom);
+    const adapter = def.collector.__test.manualAdapter;
+    const beforeWindow = adapter.readWindow();
+    const beforeByKey = new Map(beforeWindow.descriptors.map((descriptor: any) => [descriptor.key, descriptor]));
+    const ownerBefore: any = beforeByKey.get('m_assistant_second');
+    const firstBefore: any = beforeByKey.get('m_assistant_first');
+    const userBefore: any = beforeByKey.get('m_user_cot');
+    const ownerInput = beforeWindow.inputsByKey.get('m_assistant_second');
+
+    expect(ownerInput.cotOuterHtml).toEqual(expect.any(String));
+    expect(ownerInput.cotOuterHtml).not.toContain('cot-hidden-tool-1');
+    expect(ownerInput.cotOuterHtml).not.toContain('hidden tool detail');
+    expect(JSON.parse(JSON.stringify(ownerInput))).toEqual(ownerInput);
+    expect(Object.values(ownerInput).some((value) => value instanceof dom.window.Element)).toBe(false);
+
+    const hidden = dom.window.document.querySelector('#cot-hidden-tool-1 code') as HTMLElement;
+    hidden.textContent = `${'changed hidden detail '.repeat(20)}\nconst hiddenChanged = true;`;
+    const body = dom.window.document.querySelector('[data-testid="cot-top-body"]') as HTMLElement;
+    body.className = 'completely-different-transition-class';
+    body.style.cssText = '--transition-progress: 0.42; opacity: 0.5';
+    body.setAttribute('data-direction', 'out');
+
+    const cosmeticByKey = new Map(adapter.readDescriptors().map((descriptor: any) => [descriptor.key, descriptor]));
+    expect((cosmeticByKey.get('m_assistant_second') as any).fingerprint).toBe(ownerBefore.fingerprint);
+    expect((cosmeticByKey.get('m_assistant_first') as any).fingerprint).toBe(firstBefore.fingerprint);
+    expect((cosmeticByKey.get('m_user_cot') as any).fingerprint).toBe(userBefore.fingerprint);
+
+    const toggle = dom.window.document.querySelector('[data-testid="cot-top-toggle"]') as HTMLElement;
+    toggle.setAttribute('aria-expanded', 'false');
+    const collapsedByKey = new Map(adapter.readDescriptors().map((descriptor: any) => [descriptor.key, descriptor]));
+    expect((collapsedByKey.get('m_assistant_second') as any).fingerprint).not.toBe(ownerBefore.fingerprint);
+    expect((collapsedByKey.get('m_assistant_first') as any).fingerprint).toBe(firstBefore.fingerprint);
+    expect((collapsedByKey.get('m_user_cot') as any).fingerprint).toBe(userBefore.fingerprint);
+  });
+
+  it('fails safe for unrelated expanded accordions, user collapse controls, and assistant-internal accordions', async () => {
+    const dom = setupChatgptDom(
+      `
+        <article data-testid="conversation-turn-1" data-turn-id="turn_negative_cot">
+          <button type="button" aria-expanded="true">Unrelated accordion</button>
+          <div><div class="markdown prose"><p>UNRELATED_ACCORDION_CONTENT</p></div></div>
+
+          <button
+            type="button"
+            data-testid="collapsible-user-message-toggle"
+            aria-controls="user-long-message"
+            aria-expanded="true"
+          >Show less</button>
+          <div id="user-long-message"><p>USER_COLLAPSE_CONTENT</p></div>
+
+          <div data-message-author-role="assistant" data-message-id="m_negative_owner">
+            <button type="button" aria-expanded="true">Internal accordion</button>
+            <div data-item-anchor="start" data-dimension="height">
+              <p>INTERNAL_ACCORDION_CONTENT</p>
+            </div>
+            <div class="markdown prose"><p>Safe final answer.</p></div>
+          </div>
+        </article>
+      `,
+      'https://chatgpt.com/c/conv_negative_cot',
+    );
+    const snap = (await capturePrepared(buildCotDef(dom))) as any;
+    expect(snap.messages).toHaveLength(1);
+    expect(snap.messages[0].contentText).toBe('Safe final answer.');
+    expect(snap.messages[0].contentText).not.toContain('UNRELATED_ACCORDION_CONTENT');
+    expect(snap.messages[0].contentText).not.toContain('USER_COLLAPSE_CONTENT');
+    expect(snap.messages[0].contentText).not.toContain('INTERNAL_ACCORDION_CONTENT');
+  });
+
+  it('supports the verified transition-body fallback without broad accordion matching', async () => {
+    const dom = setupChatgptDom(
+      `
+        <article data-testid="conversation-turn-1" data-turn-id="turn_fallback_cot">
+          <button type="button" aria-expanded="true">Top COT chrome</button>
+          <div data-item-anchor="start" data-dimension="height"><p>Markerless reasoning summary.</p></div>
+          <div data-message-author-role="assistant" data-message-id="m_fallback_cot">
+            <div class="markdown prose"><p>Fallback final answer.</p></div>
+          </div>
+        </article>
+      `,
+      'https://chatgpt.com/c/conv_fallback_cot',
+    );
+    const snap = (await capturePrepared(buildCotDef(dom))) as any;
+    expect(snap.messages[0].contentText).toBe('Markerless reasoning summary.\n\nFallback final answer.');
+  });
+
+  it('keeps COT snapshot and fingerprint empty for Deep Research placeholders', async () => {
+    const reportUrl = 'https://connector_openai_deep_research.web-sandbox.oaiusercontent.com/report-cot';
+    const dom = setupChatgptDom(
+      `
+        <article data-testid="conversation-turn-1" data-turn-id="turn_dr_cot">
+          <button data-testid="cot-top-toggle" type="button" aria-expanded="true">Top COT chrome</button>
+          ${expandedCotBody({ firstReasoning: 'Reasoning that must not alter Deep Research.' })}
+          <div data-message-author-role="assistant" data-message-id="m_dr_cot">
+            <iframe title="internal://deep-research" src="${reportUrl}"></iframe>
+          </div>
+        </article>
+      `,
+      'https://chatgpt.com/c/conv_dr_cot',
+    );
+    const def = buildCotDef(dom);
+    const before = def.collector.__test.manualAdapter.readWindow();
+    const descriptorBefore = before.descriptors.find((descriptor: any) => descriptor.key === 'm_dr_cot');
+    const inputBefore = before.inputsByKey.get('m_dr_cot');
+    expect(inputBefore.cotOuterHtml).toBe('');
+
+    const reasoning = dom.window.document.querySelector('[data-testid="cot-top-body"] .markdown p') as HTMLElement;
+    reasoning.textContent = 'Changed COT that Deep Research must ignore.';
+    const descriptorAfter = def.collector.__test.manualAdapter
+      .readDescriptors()
+      .find((descriptor: any) => descriptor.key === 'm_dr_cot');
+    expect(descriptorAfter.fingerprint).toBe(descriptorBefore.fingerprint);
+
+    const snap = (await capturePrepared(def)) as any;
+    expect(snap.messages[0].contentText).toBe(`Deep Research (iframe): ${reportUrl}`);
+    expect(snap.messages[0].contentMarkdown).toBe(`Deep Research (iframe): ${reportUrl}`);
+  });
+
+  it('keeps prepared COT capture plain-data and JSON round-trippable', async () => {
+    const dom = modernCotDom(true);
+    const def = buildCotDef(dom);
+    const prepared = await def.collector.prepareManualCapture({
+      stableSamples: 1,
+      pollMs: 0,
+      sleep: async () => {},
+    });
+    expect(prepared).toBeTruthy();
+    expect(JSON.parse(JSON.stringify(prepared))).toEqual(prepared);
+
+    const containsElement = (value: any): boolean => {
+      if (value instanceof dom.window.Element) return true;
+      if (!value || typeof value !== 'object') return false;
+      return Object.values(value).some((child) => containsElement(child));
+    };
+    expect(containsElement(prepared)).toBe(false);
+    const ownerRecord = prepared.records.find((record: any) => record.key === 'm_assistant_second');
+    expect(ownerRecord.payload.contentText).toContain('Reasoning block one.');
+  });
+});
+
 describe('chatgpt turn identity primitive', () => {
   it('resolves the same turn UUID from a role node and its shell', () => {
     const dom = new JSDOM(`<!DOCTYPE html><html><body>

--- a/tests/collectors/chatgpt-collector.test.ts
+++ b/tests/collectors/chatgpt-collector.test.ts
@@ -514,15 +514,17 @@ describe('chatgpt-collector', () => {
 describe('chatgpt expanded COT manual capture', () => {
   const hiddenToolDetail = `${'hidden tool detail '.repeat(12)}\n\n\`\`\`ts\nconst secret = true;\n\`\`\``;
 
-  function expandedCotBody(options: {
-    firstReasoning?: string;
-    firstTool?: string;
-    secondReasoning?: string;
-    secondTool?: string;
-    transitionClass?: string;
-    transitionStyle?: string;
-    direction?: string;
-  } = {}) {
+  function expandedCotBody(
+    options: {
+      firstReasoning?: string;
+      firstTool?: string;
+      secondReasoning?: string;
+      secondTool?: string;
+      transitionClass?: string;
+      transitionStyle?: string;
+      direction?: string;
+    } = {},
+  ) {
     const firstReasoning = options.firstReasoning || 'Reasoning <strong>block one</strong>.';
     const firstTool = options.firstTool || 'Visible tool summary one';
     const secondReasoning = options.secondReasoning || 'Reasoning block two.';
@@ -782,9 +784,7 @@ describe('chatgpt expanded COT manual capture', () => {
     expect(preparedOwner.payload.contentText).toContain('Reasoning same source.');
     expect(preparedOwner.payload.contentMarkdown).toContain('[same source](https://example.com/source-a)');
 
-    const link = dom.window.document.querySelector(
-      '[data-testid="cot-top-body"] .markdown a',
-    ) as HTMLAnchorElement;
+    const link = dom.window.document.querySelector('[data-testid="cot-top-body"] .markdown a') as HTMLAnchorElement;
     link.setAttribute('href', 'https://example.com/source-b');
     const liveOwner = adapter.readDescriptors().find((descriptor: any) => descriptor.key === 'm_assistant_second');
     expect(liveOwner.fingerprint).not.toBe(preparedOwner.fingerprint);

--- a/tests/collectors/chatgpt-collector.test.ts
+++ b/tests/collectors/chatgpt-collector.test.ts
@@ -817,6 +817,112 @@ describe('chatgpt expanded COT manual capture', () => {
     const ownerRecord = prepared.records.find((record: any) => record.key === 'm_assistant_second');
     expect(ownerRecord.payload.contentText).toContain('Reasoning block one.');
   });
+
+  it('updates only the owner record when COT becomes expanded between prepare and final capture', async () => {
+    const dom = modernCotDom(false);
+    const def = buildCotDef(dom);
+    const adapter = def.collector.__test.manualAdapter;
+    const prepared = await def.collector.prepareManualCapture({
+      stableSamples: 1,
+      pollMs: 0,
+      sleep: async () => {},
+    });
+    expect(prepared.completeness).toBe('complete');
+    const preparedOwner = prepared.records.find((record: any) => record.key === 'm_assistant_second');
+    expect(preparedOwner.payload.contentText).toBe('Final assistant answer.');
+    const extractionCountAfterPrepare = adapter.getExtractionCount();
+
+    const toggle = dom.window.document.querySelector('[data-testid="cot-top-toggle"]') as HTMLElement;
+    toggle.setAttribute('aria-expanded', 'true');
+    toggle.insertAdjacentHTML('afterend', expandedCotBody());
+    const liveOwner = adapter.readDescriptors().find((descriptor: any) => descriptor.key === 'm_assistant_second');
+    expect(liveOwner.fingerprint).not.toBe(preparedOwner.fingerprint);
+
+    const snapshot = await def.collector.capture({ manual: true, preparedCapture: prepared });
+    expect(adapter.getExtractionCount()).toBe(extractionCountAfterPrepare + 1);
+    const owner = snapshot.messages.find((message: any) => message.messageKey === 'm_assistant_second');
+    expect(owner.contentText).toContain('Reasoning block one.');
+    expect(owner.contentText).toMatch(/Visible tool summary two[\s\S]*Final assistant answer\./);
+    expect(snapshot.captureMeta).toMatchObject({ completeness: 'partial' });
+    expect(snapshot.captureMeta.reasons).toContain('final_live_changed');
+  });
+
+  it('removes non-sticky COT when it becomes collapsed between prepare and final capture', async () => {
+    const dom = modernCotDom(true);
+    const def = buildCotDef(dom);
+    const adapter = def.collector.__test.manualAdapter;
+    const prepared = await def.collector.prepareManualCapture({
+      stableSamples: 1,
+      pollMs: 0,
+      sleep: async () => {},
+    });
+    expect(prepared.completeness).toBe('complete');
+    const preparedOwner = prepared.records.find((record: any) => record.key === 'm_assistant_second');
+    expect(preparedOwner.payload.contentText).toContain('Reasoning block one.');
+    const extractionCountAfterPrepare = adapter.getExtractionCount();
+
+    const toggle = dom.window.document.querySelector('[data-testid="cot-top-toggle"]') as HTMLElement;
+    toggle.setAttribute('aria-expanded', 'false');
+    const liveOwner = adapter.readDescriptors().find((descriptor: any) => descriptor.key === 'm_assistant_second');
+    expect(liveOwner.fingerprint).not.toBe(preparedOwner.fingerprint);
+
+    const snapshot = await def.collector.capture({ manual: true, preparedCapture: prepared });
+    expect(adapter.getExtractionCount()).toBe(extractionCountAfterPrepare + 1);
+    const owner = snapshot.messages.find((message: any) => message.messageKey === 'm_assistant_second');
+    expect(owner.messageKey).toBe(preparedOwner.key);
+    expect(owner.contentText).toBe('Final assistant answer.');
+    expect(owner.contentMarkdown).toBe('Final assistant answer.');
+    expect(snapshot.captureMeta).toMatchObject({ completeness: 'partial' });
+    expect(snapshot.captureMeta.reasons).toContain('final_live_changed');
+  });
+
+  it('does not create a final-live update for cosmetic or hidden-detail changes', async () => {
+    const dom = modernCotDom(true);
+    const def = buildCotDef(dom);
+    const adapter = def.collector.__test.manualAdapter;
+    const prepared = await def.collector.prepareManualCapture({
+      stableSamples: 1,
+      pollMs: 0,
+      sleep: async () => {},
+    });
+    expect(prepared.completeness).toBe('complete');
+    const extractionCountAfterPrepare = adapter.getExtractionCount();
+
+    const body = dom.window.document.querySelector('[data-testid="cot-top-body"]') as HTMLElement;
+    body.className = 'changed-transition-class';
+    body.style.cssText = '--transition-progress: 0.1; transform: translateY(1px)';
+    body.setAttribute('data-direction', 'out');
+    const hidden = dom.window.document.querySelector('#cot-hidden-tool-1 code') as HTMLElement;
+    hidden.textContent = `${'mutated hidden detail '.repeat(30)}\nconst shouldStayInvisible = true;`;
+
+    const snapshot = await def.collector.capture({ manual: true, preparedCapture: prepared });
+    expect(adapter.getExtractionCount()).toBe(extractionCountAfterPrepare);
+    expect(snapshot.captureMeta).toMatchObject({ completeness: 'complete' });
+    expect(snapshot.captureMeta.reasons).not.toContain('final_live_changed');
+    const owner = snapshot.messages.find((message: any) => message.messageKey === 'm_assistant_second');
+    expect(owner.contentText).toContain('Reasoning block one.');
+    expect(owner.contentText).not.toContain('mutated hidden detail');
+  });
+
+  it('never clicks or dispatches events on the live COT toggle', async () => {
+    const dom = modernCotDom(true);
+    const def = buildCotDef(dom);
+    const toggle = dom.window.document.querySelector('[data-testid="cot-top-toggle"]') as HTMLButtonElement;
+    const clickSpy = vi.spyOn(toggle, 'click');
+    const dispatchSpy = vi.spyOn(toggle, 'dispatchEvent');
+
+    const prepared = await def.collector.prepareManualCapture({
+      stableSamples: 1,
+      pollMs: 0,
+      sleep: async () => {},
+    });
+    const snapshot = await def.collector.capture({ manual: true, preparedCapture: prepared });
+
+    expect(snapshot).toBeTruthy();
+    expect(clickSpy).not.toHaveBeenCalled();
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+  });
 });
 
 describe('chatgpt turn identity primitive', () => {

--- a/tests/collectors/chatgpt-collector.test.ts
+++ b/tests/collectors/chatgpt-collector.test.ts
@@ -220,6 +220,41 @@ describe('chatgpt-collector', () => {
     expect(assistant.contentText).not.toContain('复制');
   });
 
+  it('extracts arbitrary rendered roots with the same semantic cleanup as assistant content', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><html><body>
+      <div id="rendered-root">
+        <section>
+          <h2>Rendered heading</h2>
+          <p>First sibling with <strong>bold text</strong>.</p>
+        </section>
+        <section>
+          <ul><li>Second sibling item</li></ul>
+          <pre><code class="language-ts">const value = 1;</code></pre>
+          <p>Formula <span class="math-block" data-math="x^2"></span></p>
+          <button type="button">Copy chrome</button>
+        </section>
+      </div>
+    </body></html>`);
+    const root = dom.window.document.querySelector('#rendered-root');
+
+    const markdown = chatgptMarkdown.extractRenderedMarkdown(root);
+    const text = chatgptMarkdown.extractRenderedText(root);
+
+    expect(markdown).toContain('## Rendered heading');
+    expect(markdown).toContain('First sibling with **bold text**.');
+    expect(markdown).toContain('- Second sibling item');
+    expect(markdown).toContain('```ts');
+    expect(markdown).toContain('const value = 1;');
+    expect(markdown).toContain('x^2');
+    expect(markdown).not.toContain('Copy chrome');
+    expect(text).toContain('Rendered heading');
+    expect(text).toContain('First sibling with bold text.');
+    expect(text).toContain('Second sibling item');
+    expect(text).toContain('const value = 1;');
+    expect(text).toContain('x^2');
+    expect(text).not.toContain('Copy chrome');
+  });
+
   it('keeps ChatGPT source links while omitting their Google favicon images', async () => {
     const html = `
       <article data-testid="conversation-turn-1" data-turn-id="turn_favicon">

--- a/tests/collectors/chatgpt-collector.test.ts
+++ b/tests/collectors/chatgpt-collector.test.ts
@@ -748,12 +748,12 @@ describe('chatgpt expanded COT manual capture', () => {
     expect(snap.messages[0].contentText).not.toContain('INTERNAL_ACCORDION_CONTENT');
   });
 
-  it('supports the verified transition-body fallback without broad accordion matching', async () => {
+  it('fails safe for markerless transition bodies instead of treating generic transition UI as COT', async () => {
     const dom = setupChatgptDom(
       `
         <article data-testid="conversation-turn-1" data-turn-id="turn_fallback_cot">
-          <button type="button" aria-expanded="true">Top COT chrome</button>
-          <div data-item-anchor="start" data-dimension="height"><p>Markerless reasoning summary.</p></div>
+          <button type="button" aria-expanded="true">Unconfirmed transition accordion</button>
+          <div data-item-anchor="start" data-dimension="height"><p>MARKERLESS_TRANSITION_CONTENT</p></div>
           <div data-message-author-role="assistant" data-message-id="m_fallback_cot">
             <div class="markdown prose"><p>Fallback final answer.</p></div>
           </div>
@@ -762,7 +762,89 @@ describe('chatgpt expanded COT manual capture', () => {
       'https://chatgpt.com/c/conv_fallback_cot',
     );
     const snap = (await capturePrepared(buildCotDef(dom))) as any;
-    expect(snap.messages[0].contentText).toBe('Markerless reasoning summary.\n\nFallback final answer.');
+    expect(snap.messages[0].contentText).toBe('Fallback final answer.');
+    expect(snap.messages[0].contentMarkdown).toBe('Fallback final answer.');
+    expect(snap.messages[0].contentText).not.toContain('MARKERLESS_TRANSITION_CONTENT');
+  });
+
+  it('updates COT fingerprint and final markdown when only a visible link target changes', async () => {
+    const dom = modernCotDom(true);
+    const reasoning = dom.window.document.querySelector('[data-testid="cot-top-body"] .markdown p') as HTMLElement;
+    reasoning.innerHTML = 'Reasoning <a href="https://example.com/source-a">same source</a>.';
+    const def = buildCotDef(dom);
+    const adapter = def.collector.__test.manualAdapter;
+    const prepared = await def.collector.prepareManualCapture({
+      stableSamples: 1,
+      pollMs: 0,
+      sleep: async () => {},
+    });
+    const preparedOwner = prepared.records.find((record: any) => record.key === 'm_assistant_second');
+    expect(preparedOwner.payload.contentText).toContain('Reasoning same source.');
+    expect(preparedOwner.payload.contentMarkdown).toContain('[same source](https://example.com/source-a)');
+
+    const link = dom.window.document.querySelector(
+      '[data-testid="cot-top-body"] .markdown a',
+    ) as HTMLAnchorElement;
+    link.setAttribute('href', 'https://example.com/source-b');
+    const liveOwner = adapter.readDescriptors().find((descriptor: any) => descriptor.key === 'm_assistant_second');
+    expect(liveOwner.fingerprint).not.toBe(preparedOwner.fingerprint);
+
+    const snapshot = await def.collector.capture({ manual: true, preparedCapture: prepared });
+    const owner = snapshot.messages.find((message: any) => message.messageKey === 'm_assistant_second');
+    expect(owner.contentText).toContain('Reasoning same source.');
+    expect(owner.contentMarkdown).toContain('[same source](https://example.com/source-b)');
+    expect(owner.contentMarkdown).not.toContain('https://example.com/source-a');
+    expect(snapshot.captureMeta.reasons).toContain('final_live_changed');
+  });
+
+  it('keeps image-only reasoning in COT markdown even when it has no text contribution', async () => {
+    const imageUrl = 'https://example.com/cot-diagram.png';
+    const dom = setupChatgptDom(
+      `
+        <article data-testid="conversation-turn-1" data-turn-id="turn_cot_image_only">
+          <button type="button" aria-expanded="true">Top COT chrome</button>
+          <div data-item-anchor="start" data-dimension="height">
+            <div class="markdown prose"><img src="${imageUrl}" /></div>
+          </div>
+          <div data-message-author-role="assistant" data-message-id="m_cot_image_only">
+            <div class="markdown prose"><p>Final image answer.</p></div>
+          </div>
+        </article>
+      `,
+      'https://chatgpt.com/c/conv_cot_image_only',
+    );
+    const snap = (await capturePrepared(buildCotDef(dom))) as any;
+    expect(snap.messages[0].contentText).toBe('Final image answer.');
+    expect(snap.messages[0].contentMarkdown).toBe(`![](${imageUrl})\n\nFinal image answer.`);
+  });
+
+  it('keeps COT math and code-source recovery on the shared rendered-content sanitizer path', async () => {
+    const dom = setupChatgptDom(
+      `
+        <article data-testid="conversation-turn-1" data-turn-id="turn_cot_rich_content">
+          <button type="button" aria-expanded="true">Top COT chrome</button>
+          <div data-item-anchor="start" data-dimension="height">
+            <div class="markdown prose">
+              <p>Formula <mjx-container class="MathJax"><svg><text>SVG_ONLY_FORMULA</text></svg></mjx-container></p>
+              <div class="mermaid">
+                <svg aria-hidden="true"><path d="M0 0" /></svg>
+                <button type="button" data-code="graph TD&#10;  A[Start] --> B[Done]">Copy source</button>
+              </div>
+            </div>
+          </div>
+          <div data-message-author-role="assistant" data-message-id="m_cot_rich_content">
+            <div class="markdown prose"><p>Final rich answer.</p></div>
+          </div>
+        </article>
+      `,
+      'https://chatgpt.com/c/conv_cot_rich_content',
+    );
+    const snap = (await capturePrepared(buildCotDef(dom))) as any;
+    expect(snap.messages[0].contentText).toContain('SVG_ONLY_FORMULA');
+    expect(snap.messages[0].contentMarkdown).toContain('SVG_ONLY_FORMULA');
+    expect(snap.messages[0].contentMarkdown).toContain('```mermaid');
+    expect(snap.messages[0].contentMarkdown).toContain('A[Start] --> B[Done]');
+    expect(snap.messages[0].contentMarkdown).toContain('Final rich answer.');
   });
 
   it('keeps COT snapshot and fingerprint empty for Deep Research placeholders', async () => {

--- a/tests/smoke/current-page-capture-integrity.test.ts
+++ b/tests/smoke/current-page-capture-integrity.test.ts
@@ -77,6 +77,49 @@ describe('current page capture integrity routing', () => {
     });
   });
 
+  it('preserves COT plus answer through final-live partial append with default replace semantics', async () => {
+    const contentText = 'Visible reasoning summary\n\nFinal assistant answer';
+    const contentMarkdown = '**Visible reasoning summary**\n\nFinal assistant answer';
+    const snapshot = {
+      ...chatSnapshot({ completeness: 'partial' }),
+      messages: [
+        {
+          messageKey: 'assistant-stable-key',
+          role: 'assistant',
+          contentText,
+          contentMarkdown,
+          sequence: 4,
+        },
+      ],
+      captureMeta: {
+        completeness: 'partial' as const,
+        identityVerified: true,
+        reasons: ['final_live_changed'],
+      },
+    };
+    const harness = createHarness({ collectorId: 'chatgpt', snapshot });
+
+    const result = await harness.service.captureCurrentPage();
+
+    expect(result).toMatchObject({
+      captureCompleteness: 'partial',
+      captureReasons: ['final_live_changed'],
+    });
+    const sync = harness.calls.find((call) => call.type === 'syncConversationMessages');
+    expect(sync?.payload).toMatchObject({
+      mode: 'append',
+      diff: { added: ['assistant-stable-key'], updated: [], removed: [] },
+    });
+    expect(sync?.payload.messages).toHaveLength(1);
+    expect(sync?.payload.messages[0]).toMatchObject({
+      messageKey: 'assistant-stable-key',
+      contentText,
+      contentMarkdown,
+      captureSequencePolicy: 'preserve-existing-tail',
+      captureMergePolicy: 'replace',
+    });
+  });
+
   it.each([
     ['unverified', chatSnapshot({ verified: false })],
     ['missing metadata', { ...chatSnapshot(), captureMeta: undefined }],


### PR DESCRIPTION
## Related issue

Closes #516

## Why

ChatGPT 的思考摘要只有在用户手动展开后才会实际渲染到当前 DOM。原有 ChatGPT collector 只提取最终回答的 assistant Markdown，因此即使思考摘要已经在页面上可见，SyncNos 抓取后仍会遗漏这部分内容。

本 PR 将抓取语义收敛为“当前 DOM 有什么就保存什么”：用户已展开且已渲染的 COT 会进入同一条 assistant 回复；折叠或不存在时继续只保存最终回答。collector 不主动改变 ChatGPT 页面状态。

## What changed

- 抽取通用的 ChatGPT rendered-root Text/Markdown 提取原语，让最终回答与已渲染 COT 共用同一套公式、Mermaid、代码与非正文清洗逻辑。
- 删除已经没有生产消费者的旧 ChatGPT live extraction 路径，避免并行实现继续漂移。
- 在 manual virtualized window scan 中建立 COT 与同一 turn 内后继 assistant 的归属关系：
  - 只读取 `aria-expanded=true` 且已实际 hydrate 的顶层 COT；
  - 不依赖“思考了 / Thought for”等本地化文案；
  - 精确剔除 `aria-controls` 指向的 nested collapsed tool detail；
  - 按 DOM 顺序合并 reasoning blocks、当前可见工具摘要与最终回答。
- COT semantic fingerprint 同时覆盖 text 与 Markdown，使链接目标、Markdown 内容、image-only COT 变化也能触发 final-live 更新。
- Deep Research message 明确隔离 COT signal，继续维持现有 placeholder/hydrator 协议。
- 增加状态切换、零 UI 副作用、virtualized final-live 与 capture-integrity 同 stable key 持久化回归。

## Scope and non-goals

- 不主动展开/折叠 COT，不等待折叠内容 hydration，不恢复 UI 状态，因为 collector 从不修改 UI。
- 不新增 reasoning 字段、独立 reasoning message、IndexedDB schema、Reader UI 或设置项。
- 不递归展开 nested tool details；只保存当前 DOM 已经呈现的内容。
- 不改变 ChatGPT manual-only virtualized sweep，也不把 ChatGPT 加回自动保存。
- 不改变 Deep Research iframe 抓取协议。

## Validation

- `npm run gate:ci`: PASS — ESLint、Prettier、TypeScript compile、259/259 test files、1523/1523 tests 全部通过。
- `npm run gate`: N/A — 本 PR 未修改 manifest、权限、打包或发布配置。
- Targeted tests or boundary scans:
  - ChatGPT collector: 45/45 PASS
  - ChatGPT + Deep Research + capture-integrity 跨模块回归: 84/84 PASS
  - `npm run build`: PASS — Chrome MV3 production build 成功
  - CodeGraph/静态扫描确认 ChatGPT 仍位于 `VIRTUALIZED_MANUAL_CAPTURE_COLLECTOR_IDS`，并继续被 `AI_CHAT_AUTO_SAVE_COLLECTOR_IDS` 排除。
  - 旧 `extractMessageFromWrapper` / `__test.collectMessages` 等 ChatGPT live extraction 路径已删除且未回流。

Manual validation:

| Browser / surface | Scenario | Result |
| --- | --- | --- |
| ChatGPT 页面 / 手动抓取 | 用户手动展开 COT 后重新抓取，确认当前可见思考摘要进入 AI 回复且抓取体验正常 | PASS（用户手动验收） |

## Architecture, data, and permissions

- Affected layers / dependency boundaries: 仅 `src/collectors/chatgpt/**` 的站点采集逻辑，以及 capture-integrity 的既有生产路径 smoke test；没有引入逆向依赖。
- Local storage, schema, backup/restore, or migration impact: 无 schema / migration 变更；COT 直接写入现有 `contentText/contentMarkdown`。
- Browser permission or external-network impact: 无新增权限、无新增外部网络请求。
- Failure path: COT 不存在、折叠、未 hydrate 或无法可靠识别时 fail-safe 为 answer-only；final-live 变化继续通过现有 verified partial append + stable-key replace 更新，不新增持久化旁路。

## UI evidence

N/A — SyncNos 本身没有视觉 UI 改动；本 PR 只改变 ChatGPT 手动抓取时写入的对话内容。

## Risks and tradeoffs

- ChatGPT DOM 属于外部站点契约。实现刻意采用 fail-safe locator，并避免本地化文案与 hash class；未来若 ChatGPT 改变顶层 COT DOM 结构，需要更新对应 synthetic contract tests。
- 本 PR 有意不自动展开 COT，因此用户没有展开的思考摘要不会被 SyncNos 主动获取。

## Documentation and cleanup

- [x] Canonical documentation made stale by this change is updated, or no documentation change is required.
- [x] Replaced production paths, dead compatibility branches, and outdated test assumptions are removed, or none were introduced/replaced.
- [x] I reviewed the final diff from top to bottom before requesting review.
