### PR TITLE
修复导入后会话列表统计读取旧缓存的问题

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug report
 description: Report something that isn't working in SyncNos
-title: "[Bug]: "
-labels: ["bug"]
+title: '[Bug]: '
+labels: ['bug']
 body:
   - type: checkboxes
     id: existing-search
@@ -10,7 +10,6 @@ body:
       options:
         - label: I searched open and closed issues and didn't find this already reported
           required: false
-
   - type: textarea
     id: what-happened
     attributes:
@@ -20,7 +19,6 @@ body:
         A short recording beats a paragraph.
     validations:
       required: true
-
   - type: textarea
     id: repro-steps
     attributes:
@@ -31,7 +29,6 @@ body:
         3.
     validations:
       required: true
-
   - type: textarea
     id: screenshots
     attributes:
@@ -39,7 +36,6 @@ body:
       description: Drag and drop images or a screen recording here. Optional but speeds up triage.
     validations:
       required: false
-
   - type: input
     id: version
     attributes:
@@ -47,7 +43,6 @@ body:
       placeholder: 1.9.0 or commit SHA
     validations:
       required: true
-
   - type: input
     id: environment
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature request
 description: Suggest an idea
-title: "[Feature]: "
-labels: ["enhancement"]
+title: '[Feature]: '
+labels: ['enhancement']
 body:
   - type: textarea
     id: what
@@ -9,7 +9,6 @@ body:
       label: What should it do?
     validations:
       required: true
-
   - type: textarea
     id: why
     attributes:

--- a/src/services/conversations/data/storage-idb.ts
+++ b/src/services/conversations/data/storage-idb.ts
@@ -1162,7 +1162,9 @@ async function readConversationListPage(input: {
     cursor,
   });
   const summaryPromise = (async () => {
-    if (conversationListStatsCacheKey === statsKey && conversationListStatsCacheValue) {
+    // A bootstrap starts a fresh list snapshot and must observe IndexedDB writes from other extension contexts
+    // (for example backup import). Reuse cached stats only while continuing the same paginated snapshot.
+    if (cursor && conversationListStatsCacheKey === statsKey && conversationListStatsCacheValue) {
       return conversationListStatsCacheValue;
     }
     const computed = await readConversationListSummaryAndFacets({ store: stores.conversations, query });

--- a/tests/storage/conversations-pagination.test.ts
+++ b/tests/storage/conversations-pagination.test.ts
@@ -186,6 +186,39 @@ describe('conversations pagination storage-idb', () => {
     expect(filtered.items.every((item) => item.listSiteKey === 'domain:example.com')).toBe(true);
   });
 
+  it('recomputes summary on a fresh bootstrap after an external IndexedDB write', async () => {
+    const initial = await getConversationListBootstrap({ sourceKey: 'all', siteKey: 'all', limit: 20 });
+    expect(initial.items).toEqual([]);
+    expect(initial.summary).toEqual({ totalCount: 0, todayCount: 0 });
+
+    const rawDb = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open('webclipper');
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+    const rawTx = rawDb.transaction(['conversations'], 'readwrite');
+    rawTx.objectStore('conversations').add({
+      sourceType: 'chat',
+      source: 'chatgpt',
+      conversationKey: 'externally-imported',
+      title: 'Externally imported',
+      url: 'https://chatgpt.com/c/externally-imported',
+      lastCapturedAt: Date.now(),
+      listSourceKey: 'chatgpt',
+      listSiteKey: 'chatgpt',
+    });
+    await new Promise<void>((resolve, reject) => {
+      rawTx.oncomplete = () => resolve();
+      rawTx.onerror = () => reject(rawTx.error);
+      rawTx.onabort = () => reject(rawTx.error);
+    });
+    rawDb.close();
+
+    const refreshed = await getConversationListBootstrap({ sourceKey: 'all', siteKey: 'all', limit: 20 });
+    expect(refreshed.items.map((item) => item.conversationKey)).toEqual(['externally-imported']);
+    expect(refreshed.summary).toEqual({ totalCount: 1, todayCount: 1 });
+  });
+
   it('finds open target by source+conversationKey and by id', async () => {
     const inserted = await upsertConversation({
       sourceType: 'chat',


### PR DESCRIPTION
## Related issue

N/A（用户现场反馈，未单独创建 issue）

## What changed

- 修复 Conversation List 的统计缓存生命周期：只有携带 `cursor`、继续同一分页快照时才复用 `summary/facets` 缓存。
- fresh bootstrap 现在会重新从当前 IndexedDB 计算统计，避免备份导入等“其他扩展上下文直接写库”后仍读到后台内存中的旧 `0/0`。
- 增加回归测试，直接绕过 canonical storage API 写入 IndexedDB，模拟跨上下文导入；验证列表项与 `summary` 在下一次 bootstrap 中保持一致。

这次改动刻意不增加 import-specific 的跨上下文补丁消息，而是修正 bootstrap 本身的快照语义。分页继续加载仍保留原有缓存优化。

## Demo

使用全新 Helium profile + 当前 Chrome MV3 构建进行真实冷启动验收：

- 导入前：`今日 0 · 总计 0`
- 导入真实 57 MB 备份：新增 1604 个对话、17168 条消息、421 条评论、1600 条映射
- 不执行任何网页 / AI 对话 / 视频字幕 fetch
- 在同一个 background/service worker 生命周期中重新加载 App
- ListView 首次 bootstrap 立即显示：`今日 8 · 总计 1604`

说明：本 PR 解决的是 fresh bootstrap 被旧统计缓存污染的问题；“导入/同步完成后当前已挂载 UI 是否应立即响应而无需 reload”属于更广泛的状态失效/跨上下文刷新问题，不在本提交中混入处理。

## Drawbacks

fresh bootstrap 会重新扫描当前查询的统计与 facets，因此不再复用上一次 bootstrap 的统计缓存；但带 `cursor` 的分页 continuation 仍复用缓存，保留原有 load-more 性能优化。

## Tests & validation

- `npx vitest run tests/storage/conversations-pagination.test.ts`：6/6 通过
- `npm run compile && npm run test`：250 个 test files、1541 个 tests 全部通过
- `npm run build && node .github/scripts/webclipper/check-dist.mjs --root=.output/chrome-mv3`：通过
- `npx prettier --check src/services/conversations/data/storage-idb.ts tests/storage/conversations-pagination.test.ts`：通过
- `git diff --check`：通过
- Helium 全新 profile + 真实备份手动验收：通过

补充：此前执行 `npm run gate:ci` 时，`lint` 通过，但仓库中两个未修改的 issue template 存在既有 Prettier 格式问题（`.github/ISSUE_TEMPLATE/bug_report.yml`、`.github/ISSUE_TEMPLATE/feature_request.yml`），因此全仓 `format:check` 会在这两个无关文件处停止；本 PR 修改文件自身的 Prettier 检查已通过。
