### PR TITLE
fix: 修复 GitHub Device Flow 授权状态恢复

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -36,6 +36,7 @@ GitHub 的 repository 与 branch 属于非敏感配置，可按现有 storage ba
 
 - GitHub auth/pending state 存在 `chrome.storage.local` 的 `github_auth_state_v1`，属于 secret/runtime state，不进入 Zip backup。
 - pending Device Flow 的 remote-state discovery 不得把单个 UI timer 当成 correctness 唯一来源。设置页面在重新可见、重新获得焦点或 pageshow 时，只在持久化 `nextPollAt` 已到期后补做 reconcile；poll interval、`slow_down`、expiry 与跨调用 claim 仍由 Device Flow service 和 durable auth state 最终裁决。timer / lifecycle wake 的并发触发必须合并，且授权收敛不得因无关设置操作而长期阻塞。
+- mount hydration、auth storage wake 与 poll-error recovery 可能并发读取 GitHub safe auth snapshot；较旧响应不得覆盖更新的已应用 auth 状态。较新的读取失败只保留 last-good，不得把失败解释成 disconnected，也不能让乱序响应把 connected 回退为 pending。
 - GitHub remote cleanup outbox 存在 IndexedDB 的 `github_cleanup_outbox`，用于在删除、identity move 或网络失败后恢复受管远端路径清理；它是派生恢复状态，不进入 Zip backup，也不应通过导入恢复为另一台设备上的待执行远端操作。
 - GitHub sync mapping 可以进入既有 mapping backup，因为它描述本地内容与派生远端 projection 的连续性；它不能携带 access/refresh/device secret。
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -35,6 +35,7 @@ GitHub 的 repository 与 branch 属于非敏感配置，可按现有 storage ba
 ## GitHub 恢复状态
 
 - GitHub auth/pending state 存在 `chrome.storage.local` 的 `github_auth_state_v1`，属于 secret/runtime state，不进入 Zip backup。
+- pending Device Flow 的 remote-state discovery 不得把单个 UI timer 当成 correctness 唯一来源。设置页面在重新可见、重新获得焦点或 pageshow 时，只在持久化 `nextPollAt` 已到期后补做 reconcile；poll interval、`slow_down`、expiry 与跨调用 claim 仍由 Device Flow service 和 durable auth state 最终裁决。timer / lifecycle wake 的并发触发必须合并，且授权收敛不得因无关设置操作而长期阻塞。
 - GitHub remote cleanup outbox 存在 IndexedDB 的 `github_cleanup_outbox`，用于在删除、identity move 或网络失败后恢复受管远端路径清理；它是派生恢复状态，不进入 Zip backup，也不应通过导入恢复为另一台设备上的待执行远端操作。
 - GitHub sync mapping 可以进入既有 mapping backup，因为它描述本地内容与派生远端 projection 的连续性；它不能携带 access/refresh/device secret。
 

--- a/src/services/sync/github/auth/device-flow.ts
+++ b/src/services/sync/github/auth/device-flow.ts
@@ -10,7 +10,7 @@ import {
   type GithubSafeAuthSummary,
 } from '@services/sync/github/auth/auth-store';
 
-export type GithubDeviceFlowErrorCode =
+type GithubDeviceFlowErrorCode =
   | 'github_device_start_failed'
   | 'github_device_poll_failed'
   | 'github_device_not_pending'
@@ -20,7 +20,7 @@ export type GithubDeviceFlowErrorCode =
   | 'github_device_disabled'
   | 'github_device_invalid';
 
-export class GithubDeviceFlowError extends Error {
+class GithubDeviceFlowError extends Error {
   constructor(readonly code: GithubDeviceFlowErrorCode) {
     super(code);
     this.name = 'GithubDeviceFlowError';
@@ -45,10 +45,6 @@ function positiveNumber(value: unknown): number | null {
 
 function nonEmptyString(value: unknown): string | null {
   return typeof value === 'string' && value.length > 0 && value === value.trim() ? value : null;
-}
-
-function formBody(fields: Record<string, string>): URLSearchParams {
-  return new URLSearchParams(fields);
 }
 
 async function parseJsonResponse(response: Response, code: GithubDeviceFlowErrorCode): Promise<any> {
@@ -139,7 +135,7 @@ async function startDeviceFlowRequest({
         Accept: 'application/json',
         'Content-Type': 'application/x-www-form-urlencoded',
       },
-      body: formBody({ client_id: GITHUB_APP_CONFIG.clientId }),
+      body: new URLSearchParams({ client_id: GITHUB_APP_CONFIG.clientId }),
     });
   } catch (_error) {
     throw new GithubDeviceFlowError('github_device_start_failed');
@@ -213,7 +209,7 @@ export async function pollDeviceFlowOnce({
         Accept: 'application/json',
         'Content-Type': 'application/x-www-form-urlencoded',
       },
-      body: formBody({
+      body: new URLSearchParams({
         client_id: GITHUB_APP_CONFIG.clientId,
         device_code: deviceCode,
         grant_type: 'urn:ietf:params:oauth:grant-type:device_code',

--- a/src/viewmodels/settings/useSettingsSceneController.ts
+++ b/src/viewmodels/settings/useSettingsSceneController.ts
@@ -336,6 +336,10 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
   const [githubRepositoriesLoading, setGithubRepositoriesLoading] = useState(false);
   const [githubRepositoryDiscoveryError, setGithubRepositoryDiscoveryError] = useState('');
   const githubRepositoryDiscoveryGenerationRef = useRef(0);
+  // GET_SETTINGS auth reads can overlap: reject responses older than the latest successful/direct auth update,
+  // but let an older successful read become last-good when a newer read failed.
+  const githubAuthRequestSeqRef = useRef(0);
+  const githubAuthAppliedSeqRef = useRef(0);
   // ponytail: 这里只合并同一时刻的 Device Flow poll；poll interval 与跨调用并发仍由 service 层持久化状态最终门禁。
   const githubDevicePollInFlightRef = useRef<Promise<void> | null>(null);
   const [githubRepository, setGithubRepository] = useState('');
@@ -448,14 +452,22 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
   }, []);
 
   const applyGithubAuth = useCallback(
-    (value: unknown) => {
+    (value: unknown, snapshotRequestSeq?: number) => {
+      if (snapshotRequestSeq == null) {
+        const directSeq = githubAuthRequestSeqRef.current + 1;
+        githubAuthRequestSeqRef.current = directSeq;
+        githubAuthAppliedSeqRef.current = directSeq;
+      } else {
+        if (snapshotRequestSeq <= githubAuthAppliedSeqRef.current) return;
+        githubAuthAppliedSeqRef.current = snapshotRequestSeq;
+      }
+
       const next = normalizeGithubAuthSummary(value);
       setGithubAuth(next);
       if (next.state !== 'connected') {
         setGithubConnectionTest({ status: 'idle' });
         clearGithubRepositoryDiscovery();
       }
-      return next;
     },
     [clearGithubRepositoryDiscovery],
   );
@@ -469,7 +481,7 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
   }, []);
 
   const applyGithubSettingsResponse = useCallback(
-    (value: any) => {
+    (value: any, authSnapshotRequestSeq?: number) => {
       const settings = value?.settings || {};
       const app = value?.app || {};
       applyGithubTargetSettings(settings);
@@ -477,7 +489,7 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
       setGithubAppUrl(String(app.appUrl || ''));
       setGithubInstallUrl(String(app.installUrl || ''));
       setGithubConnectionTest({ status: 'idle' });
-      return applyGithubAuth(value?.auth);
+      applyGithubAuth(value?.auth, authSnapshotRequestSeq);
     },
     [applyGithubAuth, applyGithubTargetSettings],
   );
@@ -537,15 +549,19 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
   }, []);
 
   const refreshGithubAuthFromStorageSignal = useCallback(async () => {
+    const requestSeq = githubAuthRequestSeqRef.current + 1;
+    githubAuthRequestSeqRef.current = requestSeq;
     try {
       const snapshot = unwrap(await send<ApiResponse<any>>(GITHUB_MESSAGE_TYPES.GET_SETTINGS, {}));
-      applyGithubAuth(snapshot?.auth);
+      applyGithubAuth(snapshot?.auth, requestSeq);
     } catch (_error) {
       // Storage changes are only a wake signal. Keep the current safe UI snapshot if rehydration fails.
     }
   }, [applyGithubAuth]);
 
   const refreshInternal = useCallback(async () => {
+    const githubAuthRequestSeq = githubAuthRequestSeqRef.current + 1;
+    githubAuthRequestSeqRef.current = githubAuthRequestSeq;
     const [notionRes, feishuRes, local, obsidianRes, githubRes, antiHotlinkRulesDraft] = await Promise.all([
       send<ApiResponse<any>>(NOTION_MESSAGE_TYPES.GET_AUTH_STATUS, {}),
       send<ApiResponse<any>>(FEISHU_MESSAGE_TYPES.GET_AUTH_STATUS, {}),
@@ -660,7 +676,7 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
     setObsidianStatus(t('statusIdle'));
 
     const githubSettings = unwrap(githubRes);
-    applyGithubSettingsResponse(githubSettings);
+    applyGithubSettingsResponse(githubSettings, githubAuthRequestSeq);
   }, [applyGithubSettingsResponse, articleDbSpec.storageKey, chatDbSpec.storageKey, videoDbSpec.storageKey]);
 
   const refresh = useCallback(async () => {
@@ -1020,7 +1036,7 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
     );
   }, [applyGithubAuth, runTask]);
 
-  const onPollGithubDeviceFlow = useCallback(() => {
+  const pollGithubDeviceFlow = useCallback(() => {
     if (githubDevicePollInFlightRef.current) return githubDevicePollInFlightRef.current;
 
     const poll = (async () => {
@@ -1031,8 +1047,10 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
         // A failed poll may still advance nextPollAt or clear a terminal flow. Rehydrate the safe durable state
         // before surfacing the original error so every later timer/lifecycle reconcile follows canonical timing.
         try {
+          const requestSeq = githubAuthRequestSeqRef.current + 1;
+          githubAuthRequestSeqRef.current = requestSeq;
           const snapshot = unwrap(await send<ApiResponse<any>>(GITHUB_MESSAGE_TYPES.GET_SETTINGS, {}));
-          applyGithubSettingsResponse(snapshot);
+          applyGithubAuth(snapshot?.auth, requestSeq);
         } catch (_refreshError) {
           // GET_SETTINGS is recovery only; do not replace the original poll failure.
         }
@@ -1044,16 +1062,16 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
 
     githubDevicePollInFlightRef.current = poll;
     return poll;
-  }, [applyGithubAuth, applyGithubSettingsResponse]);
+  }, [applyGithubAuth]);
 
   useEffect(() => {
     if (githubAuth.state !== 'pending') return;
     const delay = Math.max(0, githubAuth.nextPollAt - Date.now());
     const timer = setTimeout(() => {
-      void onPollGithubDeviceFlow();
+      void pollGithubDeviceFlow();
     }, delay);
     return () => clearTimeout(timer);
-  }, [githubAuth, onPollGithubDeviceFlow]);
+  }, [githubAuth, pollGithubDeviceFlow]);
 
   useEffect(() => {
     if (githubAuth.state !== 'pending') return;
@@ -1061,7 +1079,7 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
     const reconcileIfDue = () => {
       if (globalThis.document?.visibilityState === 'hidden') return;
       if (Date.now() < githubAuth.nextPollAt) return;
-      void onPollGithubDeviceFlow();
+      void pollGithubDeviceFlow();
     };
     const onVisibilityChange = () => {
       if (globalThis.document?.visibilityState !== 'hidden') reconcileIfDue();
@@ -1077,7 +1095,7 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
       windowLike?.removeEventListener('focus', reconcileIfDue);
       windowLike?.removeEventListener('pageshow', reconcileIfDue);
     };
-  }, [githubAuth, onPollGithubDeviceFlow]);
+  }, [githubAuth, pollGithubDeviceFlow]);
 
   const onCancelGithubDeviceFlow = useCallback(async () => {
     await runTask(
@@ -2077,7 +2095,6 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
     onToggleGithubAutoSyncEnabled,
     githubConnectionTest,
     onGithubConnect,
-    onPollGithubDeviceFlow,
     onCancelGithubDeviceFlow,
     onDisconnectGithub,
     onRefreshGithubRepositories,

--- a/src/viewmodels/settings/useSettingsSceneController.ts
+++ b/src/viewmodels/settings/useSettingsSceneController.ts
@@ -336,6 +336,8 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
   const [githubRepositoriesLoading, setGithubRepositoriesLoading] = useState(false);
   const [githubRepositoryDiscoveryError, setGithubRepositoryDiscoveryError] = useState('');
   const githubRepositoryDiscoveryGenerationRef = useRef(0);
+  // ponytail: 这里只合并同一时刻的 Device Flow poll；poll interval 与跨调用并发仍由 service 层持久化状态最终门禁。
+  const githubDevicePollInFlightRef = useRef<Promise<void> | null>(null);
   const [githubRepository, setGithubRepository] = useState('');
   const [githubBranch, setGithubBranch] = useState('');
   const githubPersistedBranchRef = useRef('');
@@ -1018,27 +1020,31 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
     );
   }, [applyGithubAuth, runTask]);
 
-  const onPollGithubDeviceFlow = useCallback(async () => {
-    await runTask(
-      async () => {
+  const onPollGithubDeviceFlow = useCallback(() => {
+    if (githubDevicePollInFlightRef.current) return githubDevicePollInFlightRef.current;
+
+    const poll = (async () => {
+      try {
+        const data = unwrap(await send<ApiResponse<any>>(GITHUB_MESSAGE_TYPES.POLL_DEVICE_FLOW, {}));
+        applyGithubAuth(data?.auth);
+      } catch (error) {
+        // A failed poll may still advance nextPollAt or clear a terminal flow. Rehydrate the safe durable state
+        // before surfacing the original error so every later timer/lifecycle reconcile follows canonical timing.
         try {
-          const data = unwrap(await send<ApiResponse<any>>(GITHUB_MESSAGE_TYPES.POLL_DEVICE_FLOW, {}));
-          applyGithubAuth(data?.auth);
-        } catch (error) {
-          // P2 may have advanced nextPollAt or cleared a terminal flow before returning an error.
-          // Rehydrate only the safe local DTO so the timer follows the persisted state instead of stale React state.
-          try {
-            const snapshot = unwrap(await send<ApiResponse<any>>(GITHUB_MESSAGE_TYPES.GET_SETTINGS, {}));
-            applyGithubSettingsResponse(snapshot);
-          } catch (_refreshError) {
-            // Keep the original poll error; GET_SETTINGS is recovery, not a replacement failure surface.
-          }
-          throw error;
+          const snapshot = unwrap(await send<ApiResponse<any>>(GITHUB_MESSAGE_TYPES.GET_SETTINGS, {}));
+          applyGithubSettingsResponse(snapshot);
+        } catch (_refreshError) {
+          // GET_SETTINGS is recovery only; do not replace the original poll failure.
         }
-      },
-      { useBusy: false, clearError: false, fallbackMessage: 'github_device_poll_failed' },
-    );
-  }, [applyGithubAuth, applyGithubSettingsResponse, runTask]);
+        setError(toErrorMessage(error, 'github_device_poll_failed'));
+      }
+    })().finally(() => {
+      if (githubDevicePollInFlightRef.current === poll) githubDevicePollInFlightRef.current = null;
+    });
+
+    githubDevicePollInFlightRef.current = poll;
+    return poll;
+  }, [applyGithubAuth, applyGithubSettingsResponse]);
 
   useEffect(() => {
     if (githubAuth.state !== 'pending') return;
@@ -1047,6 +1053,30 @@ export function useSettingsSceneController(args: UseSettingsSceneControllerArgs)
       void onPollGithubDeviceFlow();
     }, delay);
     return () => clearTimeout(timer);
+  }, [githubAuth, onPollGithubDeviceFlow]);
+
+  useEffect(() => {
+    if (githubAuth.state !== 'pending') return;
+
+    const reconcileIfDue = () => {
+      if (globalThis.document?.visibilityState === 'hidden') return;
+      if (Date.now() < githubAuth.nextPollAt) return;
+      void onPollGithubDeviceFlow();
+    };
+    const onVisibilityChange = () => {
+      if (globalThis.document?.visibilityState !== 'hidden') reconcileIfDue();
+    };
+
+    const documentLike = globalThis.document;
+    const windowLike = globalThis.window;
+    documentLike?.addEventListener('visibilitychange', onVisibilityChange);
+    windowLike?.addEventListener('focus', reconcileIfDue);
+    windowLike?.addEventListener('pageshow', reconcileIfDue);
+    return () => {
+      documentLike?.removeEventListener('visibilitychange', onVisibilityChange);
+      windowLike?.removeEventListener('focus', reconcileIfDue);
+      windowLike?.removeEventListener('pageshow', reconcileIfDue);
+    };
   }, [githubAuth, onPollGithubDeviceFlow]);
 
   const onCancelGithubDeviceFlow = useCallback(async () => {

--- a/tests/unit/settings-controller-github.test.ts
+++ b/tests/unit/settings-controller-github.test.ts
@@ -59,6 +59,7 @@ vi.mock('@i18n', () => ({
 type Snapshot = ReturnType<typeof useSettingsSceneController>;
 type SettingsSection = Parameters<typeof useSettingsSceneController>[0]['activeSection'];
 type ApiResponse = { ok: boolean; data: any; error: any };
+type PollResponse = ApiResponse | Promise<ApiResponse> | (() => ApiResponse | Promise<ApiResponse>);
 type RepositoryResponse = ApiResponse | Promise<ApiResponse> | (() => ApiResponse | Promise<ApiResponse>);
 
 const ACCESS_TOKEN = 'sentinel_access_token';
@@ -79,7 +80,7 @@ let disconnectResponse: ApiResponse;
 let testConnectionResponse: ApiResponse;
 let initializeRepositoryResponse: ApiResponse;
 let saveSettingsResponse: ApiResponse | null;
-let pollResponses: Array<ApiResponse | (() => ApiResponse)> = [];
+let pollResponses: PollResponse[] = [];
 let repositoryResponses: RepositoryResponse[] = [];
 
 const ok = (data: any): ApiResponse => ({ ok: true, data, error: null });
@@ -216,6 +217,10 @@ async function advance(ms: number) {
 
 function callCount(type: string) {
   return runtimeMocks.send.mock.calls.filter(([messageType]) => messageType === type).length;
+}
+
+function setVisibilityState(value: 'hidden' | 'visible') {
+  Object.defineProperty(document, 'visibilityState', { configurable: true, value });
 }
 
 beforeEach(() => {
@@ -379,6 +384,157 @@ describe('Settings controller GitHub Device Flow', () => {
     });
     expect(latestSnapshot?.githubAccount?.login).toBe('octocat');
     expect(latestSnapshot?.githubRepositories.map((item) => item.fullName)).toEqual(['owner/repo']);
+  });
+
+  it('reconciles a due pending flow when the settings page becomes visible again', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(20_000);
+    githubSettingsData = githubSettings({
+      state: 'pending',
+      userCode: 'ABCD-EFGH',
+      verificationUri: 'https://github.com/login/device',
+      expiresAt: 60_000,
+      nextPollAt: 15_000,
+    });
+    pollResponses = [ok({ auth: { state: 'connected' } })];
+    setVisibilityState('hidden');
+
+    await renderController();
+    expect(callCount(GITHUB_MESSAGE_TYPES.POLL_DEVICE_FLOW)).toBe(0);
+
+    setVisibilityState('visible');
+    act(() => document.dispatchEvent(new window.Event('visibilitychange')));
+    await flushReact();
+
+    expect(callCount(GITHUB_MESSAGE_TYPES.POLL_DEVICE_FLOW)).toBe(1);
+    expect(latestSnapshot?.githubAuth).toEqual({ state: 'connected' });
+    expect(callCount(GITHUB_MESSAGE_TYPES.LIST_REPOSITORIES)).toBe(1);
+  });
+
+  it.each(['focus', 'pageshow'] as const)('reconciles a due pending flow on window %s', async (eventType) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(20_000);
+    githubSettingsData = githubSettings({
+      state: 'pending',
+      userCode: 'ABCD-EFGH',
+      verificationUri: 'https://github.com/login/device',
+      expiresAt: 60_000,
+      nextPollAt: 15_000,
+    });
+    pollResponses = [
+      ok({
+        auth: {
+          state: 'pending',
+          userCode: 'ABCD-EFGH',
+          verificationUri: 'https://github.com/login/device',
+          expiresAt: 60_000,
+          nextPollAt: 30_000,
+        },
+      }),
+    ];
+
+    await renderController();
+    act(() => window.dispatchEvent(new window.Event(eventType)));
+    await flushReact();
+
+    expect(callCount(GITHUB_MESSAGE_TYPES.POLL_DEVICE_FLOW)).toBe(1);
+    expect(latestSnapshot?.githubAuth).toMatchObject({ state: 'pending', nextPollAt: 30_000 });
+  });
+
+  it('does not poll early when lifecycle signals arrive before nextPollAt', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    githubSettingsData = githubSettings({
+      state: 'pending',
+      userCode: 'ABCD-EFGH',
+      verificationUri: 'https://github.com/login/device',
+      expiresAt: 60_000,
+      nextPollAt: 15_000,
+    });
+    pollResponses = [
+      ok({
+        auth: {
+          state: 'pending',
+          userCode: 'ABCD-EFGH',
+          verificationUri: 'https://github.com/login/device',
+          expiresAt: 60_000,
+          nextPollAt: 25_000,
+        },
+      }),
+    ];
+    setVisibilityState('hidden');
+
+    await renderController();
+    setVisibilityState('visible');
+    act(() => {
+      document.dispatchEvent(new window.Event('visibilitychange'));
+      window.dispatchEvent(new window.Event('focus'));
+      window.dispatchEvent(new window.Event('pageshow'));
+    });
+    await flushReact();
+    expect(callCount(GITHUB_MESSAGE_TYPES.POLL_DEVICE_FLOW)).toBe(0);
+
+    await advance(4_999);
+    expect(callCount(GITHUB_MESSAGE_TYPES.POLL_DEVICE_FLOW)).toBe(0);
+    await advance(1);
+    expect(callCount(GITHUB_MESSAGE_TYPES.POLL_DEVICE_FLOW)).toBe(1);
+  });
+
+  it('coalesces reactivation signals and polls outside the global settings task queue', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(20_000);
+    githubSettingsData = githubSettings({
+      state: 'pending',
+      userCode: 'ABCD-EFGH',
+      verificationUri: 'https://github.com/login/device',
+      expiresAt: 60_000,
+      nextPollAt: 15_000,
+    });
+    setVisibilityState('hidden');
+
+    const blockedSettingsTask = deferred<void>();
+    gateMocks.setSyncProviderEnabled.mockImplementation(() => blockedSettingsTask.promise);
+    const pendingPoll = deferred<ApiResponse>();
+    pollResponses = [pendingPoll.promise];
+
+    await renderController();
+
+    let blockedAction!: Promise<unknown>;
+    act(() => {
+      blockedAction = latestSnapshot!.onToggleGithubSyncEnabled(false);
+    });
+    await flushReact();
+    expect(gateMocks.setSyncProviderEnabled).toHaveBeenCalledWith('github', false);
+    expect(latestSnapshot?.busy).toBe(true);
+
+    setVisibilityState('visible');
+    act(() => {
+      document.dispatchEvent(new window.Event('visibilitychange'));
+      window.dispatchEvent(new window.Event('focus'));
+      window.dispatchEvent(new window.Event('pageshow'));
+    });
+    await flushReact();
+
+    expect(callCount(GITHUB_MESSAGE_TYPES.POLL_DEVICE_FLOW)).toBe(1);
+
+    await act(async () => {
+      pendingPoll.resolve(
+        ok({
+          auth: {
+            state: 'pending',
+            userCode: 'ABCD-EFGH',
+            verificationUri: 'https://github.com/login/device',
+            expiresAt: 60_000,
+            nextPollAt: 30_000,
+          },
+        }),
+      );
+      await pendingPoll.promise;
+      blockedSettingsTask.resolve();
+      await blockedAction;
+    });
+    expect(callCount(GITHUB_MESSAGE_TYPES.POLL_DEVICE_FLOW)).toBe(1);
+    expect(latestSnapshot?.githubAuth).toMatchObject({ state: 'pending', nextPollAt: 30_000 });
   });
 
   it('rehydrates persisted pending state after a poll error instead of retrying from stale timing', async () => {

--- a/tests/unit/settings-controller-github.test.ts
+++ b/tests/unit/settings-controller-github.test.ts
@@ -59,6 +59,7 @@ vi.mock('@i18n', () => ({
 type Snapshot = ReturnType<typeof useSettingsSceneController>;
 type SettingsSection = Parameters<typeof useSettingsSceneController>[0]['activeSection'];
 type ApiResponse = { ok: boolean; data: any; error: any };
+type SettingsResponse = ApiResponse | Promise<ApiResponse> | (() => ApiResponse | Promise<ApiResponse>);
 type PollResponse = ApiResponse | Promise<ApiResponse> | (() => ApiResponse | Promise<ApiResponse>);
 type RepositoryResponse = ApiResponse | Promise<ApiResponse> | (() => ApiResponse | Promise<ApiResponse>);
 
@@ -80,6 +81,7 @@ let disconnectResponse: ApiResponse;
 let testConnectionResponse: ApiResponse;
 let initializeRepositoryResponse: ApiResponse;
 let saveSettingsResponse: ApiResponse | null;
+let settingsResponses: SettingsResponse[] = [];
 let pollResponses: PollResponse[] = [];
 let repositoryResponses: RepositoryResponse[] = [];
 
@@ -251,6 +253,7 @@ beforeEach(() => {
     target: { repository: 'owner/repo', branch: 'main', remoteKey: 'github.com/owner/repo@main', installationId: 1 },
   });
   saveSettingsResponse = null;
+  settingsResponses = [];
   pollResponses = [];
   repositoryResponses = [];
 
@@ -285,7 +288,10 @@ beforeEach(() => {
         videoFolder: '',
       });
     }
-    if (type === GITHUB_MESSAGE_TYPES.GET_SETTINGS) return ok(githubSettingsData);
+    if (type === GITHUB_MESSAGE_TYPES.GET_SETTINGS) {
+      const next = settingsResponses.shift();
+      return typeof next === 'function' ? next() : (next ?? ok(githubSettingsData));
+    }
     if (type === GITHUB_MESSAGE_TYPES.LIST_REPOSITORIES) {
       const next = repositoryResponses.shift();
       if (next != null) return typeof next === 'function' ? next() : next;
@@ -601,9 +607,10 @@ describe('Settings controller GitHub Device Flow', () => {
 
     githubSettingsData = githubSettings({ state: 'connected' });
     await invoke(() => latestSnapshot!.onGithubConnect());
-    // START remains a Device Flow operation; emulate a completed connection through the safe poll action.
-    pollResponses = [ok({ auth: { state: 'connected' } })];
-    await invoke(() => latestSnapshot!.onPollGithubDeviceFlow());
+    act(() => {
+      storageListener?.({ [GITHUB_AUTH_STATE_KEY]: { oldValue: {}, newValue: {} } }, 'local');
+    });
+    await flushReact();
     expect(latestSnapshot?.githubAuth).toEqual({ state: 'connected' });
 
     const repositoryBeforeDisconnect = latestSnapshot?.githubRepository;
@@ -816,8 +823,10 @@ describe('Settings controller GitHub Device Flow', () => {
     expect(latestSnapshot?.githubRepositories).toEqual([]);
 
     githubSettingsData = githubSettings({ state: 'connected' });
-    pollResponses = [ok({ auth: { state: 'connected' } })];
-    await invoke(() => latestSnapshot!.onPollGithubDeviceFlow());
+    act(() => {
+      storageListener?.({ [GITHUB_AUTH_STATE_KEY]: { oldValue: {}, newValue: {} } }, 'local');
+    });
+    await flushReact();
     expect(latestSnapshot?.githubAuth).toEqual({ state: 'connected' });
 
     const stale = deferred<ApiResponse>();
@@ -1039,6 +1048,217 @@ describe('Settings controller GitHub Device Flow', () => {
 
     expect(latestSnapshot?.githubConnectionTest).toEqual({ status: 'idle' });
     expect(latestSnapshot?.githubTargetUnavailable).toBe(true);
+  });
+
+  it('does not let stale poll-error recovery overwrite a newer GitHub auth wake', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    githubSettingsData = githubSettings({
+      state: 'pending',
+      userCode: 'ABCD-EFGH',
+      verificationUri: 'https://github.com/login/device',
+      expiresAt: 60_000,
+      nextPollAt: 15_000,
+    });
+    await renderController();
+
+    const staleRecovery = deferred<ApiResponse>();
+    const latestWake = deferred<ApiResponse>();
+    settingsResponses = [staleRecovery.promise, latestWake.promise];
+    pollResponses = [fail('github_device_poll_failed', { code: 'github_device_poll_failed' })];
+
+    await advance(5_000);
+    expect(callCount(GITHUB_MESSAGE_TYPES.POLL_DEVICE_FLOW)).toBe(1);
+
+    act(() => {
+      storageListener?.({ [GITHUB_AUTH_STATE_KEY]: { oldValue: {}, newValue: {} } }, 'local');
+    });
+    await flushReact();
+
+    await act(async () => {
+      latestWake.resolve(ok(githubSettings({ state: 'connected' })));
+      await latestWake.promise;
+    });
+    expect(latestSnapshot?.githubAuth).toEqual({ state: 'connected' });
+
+    await act(async () => {
+      staleRecovery.resolve(
+        ok(
+          githubSettings({
+            state: 'pending',
+            userCode: 'ABCD-EFGH',
+            verificationUri: 'https://github.com/login/device',
+            expiresAt: 60_000,
+            nextPollAt: 30_000,
+          }),
+        ),
+      );
+      await staleRecovery.promise;
+      for (let index = 0; index < 10; index += 1) await Promise.resolve();
+    });
+
+    expect(latestSnapshot?.githubAuth).toEqual({ state: 'connected' });
+  });
+
+  it('does not let stale initial GitHub hydration overwrite a newer auth wake', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    const staleHydration = deferred<ApiResponse>();
+    const latestWake = deferred<ApiResponse>();
+    settingsResponses = [staleHydration.promise, latestWake.promise];
+
+    await renderController();
+    expect(latestSnapshot?.githubAuth).toEqual({ state: 'disconnected' });
+
+    act(() => {
+      storageListener?.({ [GITHUB_AUTH_STATE_KEY]: { oldValue: {}, newValue: {} } }, 'local');
+    });
+    await flushReact();
+
+    await act(async () => {
+      latestWake.resolve(ok(githubSettings({ state: 'connected' })));
+      await latestWake.promise;
+    });
+    expect(latestSnapshot?.githubAuth).toEqual({ state: 'connected' });
+
+    await act(async () => {
+      staleHydration.resolve(
+        ok(
+          githubSettings({
+            state: 'pending',
+            userCode: 'ABCD-EFGH',
+            verificationUri: 'https://github.com/login/device',
+            expiresAt: 60_000,
+            nextPollAt: 30_000,
+          }),
+        ),
+      );
+      await staleHydration.promise;
+      for (let index = 0; index < 10; index += 1) await Promise.resolve();
+    });
+
+    expect(latestSnapshot?.githubAuth).toEqual({ state: 'connected' });
+  });
+
+  it('keeps the latest auth snapshot when overlapping GitHub storage wakes resolve out of order', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    githubSettingsData = githubSettings({
+      state: 'pending',
+      userCode: 'ABCD-EFGH',
+      verificationUri: 'https://github.com/login/device',
+      expiresAt: 60_000,
+      nextPollAt: 15_000,
+    });
+    await renderController();
+    expect(latestSnapshot?.githubAuth).toMatchObject({ state: 'pending' });
+
+    const stale = deferred<ApiResponse>();
+    const latest = deferred<ApiResponse>();
+    settingsResponses = [stale.promise, latest.promise];
+
+    act(() => {
+      storageListener?.({ [GITHUB_AUTH_STATE_KEY]: { oldValue: {}, newValue: {} } }, 'local');
+      storageListener?.({ [GITHUB_AUTH_STATE_KEY]: { oldValue: {}, newValue: {} } }, 'local');
+    });
+    await flushReact();
+
+    await act(async () => {
+      latest.resolve(ok(githubSettings({ state: 'connected' })));
+      await latest.promise;
+    });
+    expect(latestSnapshot?.githubAuth).toEqual({ state: 'connected' });
+
+    await act(async () => {
+      stale.resolve(
+        ok(
+          githubSettings({
+            state: 'pending',
+            userCode: 'ABCD-EFGH',
+            verificationUri: 'https://github.com/login/device',
+            expiresAt: 60_000,
+            nextPollAt: 30_000,
+          }),
+        ),
+      );
+      await stale.promise;
+    });
+
+    expect(latestSnapshot?.githubAuth).toEqual({ state: 'connected' });
+  });
+
+  it('keeps an older successful auth snapshot when a newer overlapping wake fails', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    githubSettingsData = githubSettings({
+      state: 'pending',
+      userCode: 'ABCD-EFGH',
+      verificationUri: 'https://github.com/login/device',
+      expiresAt: 60_000,
+      nextPollAt: 15_000,
+    });
+    await renderController();
+
+    const olderSuccess = deferred<ApiResponse>();
+    const newerFailure = deferred<ApiResponse>();
+    settingsResponses = [olderSuccess.promise, newerFailure.promise];
+    act(() => {
+      storageListener?.({ [GITHUB_AUTH_STATE_KEY]: { oldValue: {}, newValue: {} } }, 'local');
+      storageListener?.({ [GITHUB_AUTH_STATE_KEY]: { oldValue: {}, newValue: {} } }, 'local');
+    });
+    await flushReact();
+
+    await act(async () => {
+      newerFailure.resolve(fail('github_settings_load_failed'));
+      await newerFailure.promise;
+    });
+    expect(latestSnapshot?.githubAuth).toMatchObject({ state: 'pending' });
+
+    await act(async () => {
+      olderSuccess.resolve(ok(githubSettings({ state: 'connected' })));
+      await olderSuccess.promise;
+    });
+    expect(latestSnapshot?.githubAuth).toEqual({ state: 'connected' });
+  });
+
+  it('does not let a stale storage snapshot overwrite a later successful Device Flow poll', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    githubSettingsData = githubSettings({
+      state: 'pending',
+      userCode: 'ABCD-EFGH',
+      verificationUri: 'https://github.com/login/device',
+      expiresAt: 60_000,
+      nextPollAt: 15_000,
+    });
+    await renderController();
+
+    const staleWake = deferred<ApiResponse>();
+    settingsResponses = [staleWake.promise];
+    act(() => {
+      storageListener?.({ [GITHUB_AUTH_STATE_KEY]: { oldValue: {}, newValue: {} } }, 'local');
+    });
+    await flushReact();
+
+    pollResponses = [ok({ auth: { state: 'connected' } })];
+    await advance(5_000);
+    expect(latestSnapshot?.githubAuth).toEqual({ state: 'connected' });
+
+    await act(async () => {
+      staleWake.resolve(
+        ok(
+          githubSettings({
+            state: 'pending',
+            userCode: 'ABCD-EFGH',
+            verificationUri: 'https://github.com/login/device',
+            expiresAt: 60_000,
+            nextPollAt: 30_000,
+          }),
+        ),
+      );
+      await staleWake.promise;
+    });
+    expect(latestSnapshot?.githubAuth).toEqual({ state: 'connected' });
   });
 
   it('rehydrates a safe disconnected auth summary when GitHub secret storage changes externally', async () => {


### PR DESCRIPTION
## Related issue

N/A — 本次修复来自已复现并完成真实浏览器验证的 GitHub Device Flow 设置页授权恢复缺陷；现有 #514 明确将 Device Flow 列为非目标，因此不做错误关联。

## What changed

- 为 GitHub pending Device Flow 增加 reactivation reconcile：设置页重新 visible、window focus 或 pageshow 时，在 `nextPollAt` 已到期后主动推进现有 Device Flow poll。
- 将 Device Flow poll 从 Settings 全局 task queue 中隔离，并用独立 in-flight 合并 timer / lifecycle 并发触发，避免无关设置操作长期阻塞授权收敛。
- 对 mount hydration、auth storage wake、poll-error recovery 的 safe auth snapshot 增加成功结果顺序保护：旧 snapshot 不能覆盖更新的已应用 auth；较新的读取失败仍保留 last-good，不会把 connected 回退为 pending。
- 保持 `pollDeviceFlowOnce()` 为唯一协议实现；poll interval、`slow_down`、expiry 与 durable claim 仍由 service 层最终裁决，没有新增第二套 OAuth 状态机、token storage、background alarm 或消息协议。
- 清理未被生产 UI 消费的 `onPollGithubDeviceFlow` controller 公共出口；将 Device Flow error 类型/类收回模块内部，并删除只转发到 `URLSearchParams` 的 `formBody()` wrapper。
- 更新 `docs/storage.md`，固化 pending Device Flow 生命周期恢复和 auth snapshot 乱序/last-good 契约。

## Drawbacks

- 有意不把 Device Flow 迁移为长期后台 alarm：如果设置页长期关闭，本 PR 不承诺在后台持续完成授权；本次只保证设置页重新可交互后可靠收敛。
- 无 storage/schema migration、权限变更、GitHub App permission 变更或兼容性双轨。

## Tests & validation

- `npm run gate:ci`：通过（ESLint、Prettier、TypeScript、261 test files / 1765 tests）。
- GitHub 定向验证：`github-device-flow`、`settings-controller-github`、`background-router-github-settings` 共 51/51 通过。
- 新增乱序覆盖：storage wake ↔ storage wake、initial hydration ↔ auth wake、poll-error recovery ↔ auth wake、newer-read failure 保留 older last-good、direct connected poll 拒绝旧 storage snapshot 回退。
- 架构专项扫描：`ui/viewmodels -> platform` 与 `services -> ui/viewmodels` 均无违规 import。
- 文档机械审计：无断链；canonical 归属仍在 `docs/storage.md`。
- 真实浏览器人工验证：在 GitHub Device Flow 页面完成授权后直接切回 SyncNos Settings，不执行 Cmd+R / Cmd+Shift+R、不切换 section，授权状态能够自动收敛为 connected。
