### PR TITLE
chore: 完善 Pull Request 审查模板

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,18 +2,60 @@
 
 Closes #
 
+<!-- Non-trivial behavior changes should link the agreed issue. Use `N/A — <reason>` only when the contribution rules allow it. -->
+
+## Why
+
+<!-- What user or architectural problem does this solve? Explain why the change belongs in SyncNos, not only which files changed. -->
+
+## Scope
+
+### In scope
+
+<!-- The behavior and surfaces this PR intentionally changes. -->
+
+### Non-goals
+
+<!-- What this PR intentionally does not change. Use `None` only when the scope is genuinely closed. -->
+
 ## What changed
 
-<!-- What it does and how it works. Call out anything non-obvious in the diff. -->
+<!-- Explain the implementation at the behavior/architecture level. Call out any non-obvious execution path or deleted superseded path. -->
+
+## Architecture / invariants
+
+<!-- Which AGENTS.md contracts or architectural boundaries are affected, and how are they preserved? Use `N/A — <reason>` if no architectural invariant is touched. -->
+
+## Data, migration & recovery
+
+<!-- Storage/schema/revision/backup/cache/migration impact. State what happens on partial failure, retry, repeated import, or external-target failure, and how existing local data remains recoverable. Use `N/A — <reason>` when no persisted data path changes. -->
+
+## Permissions & privacy
+
+<!-- Manifest/host permissions, OAuth scopes, secrets, network destinations, or whether previously local-only data can leave the device. Do not paste real credentials or private captured content. Use `N/A — <reason>` when unchanged. -->
+
+## Compatibility
+
+<!-- Affected browsers, sites, providers, or supported targets. State any intentional compatibility decision. Persisted-data compatibility belongs in the data section above. Use `N/A — <reason>` when not applicable. -->
 
 ## Demo
 
-<!-- Visual change: attach before/after screenshots or a short recording. Delete this section if nothing visual changed. -->
+<!-- Visual change: attach comparable before/after screenshots or a short recording using the same state/actions. Use `N/A — no visual behavior changed` when not applicable. -->
 
-## Drawbacks
+## Drawbacks / risks
 
-<!-- Tradeoffs made on purpose, compatibility/data/permission impact, and anything you're unsure about. "None" is a valid answer. -->
+<!-- Tradeoffs made on purpose, remaining risks, operational limits, or uncertainty. `None` is valid when there is genuinely no meaningful drawback. -->
 
 ## Tests & validation
 
-<!-- What you tested, which commands you ran, and any browser/site/sync path you exercised by hand. -->
+### Automated
+
+<!-- Commands and targeted tests actually run. Code PRs ready for review normally require `npm run gate:ci`; production build/manifest/permission/packaging changes require `npm run gate`. Include relevant architecture scans. Docs/GitHub-template-only changes may use `N/A — <reason>` when no runtime, build, or dependency file changed. -->
+
+### Manual
+
+<!-- Browser/site/surface and exact user flow exercised by hand. Say whether reload was used when reload-free behavior matters. Use `N/A — <reason>` only when manual validation is not required. -->
+
+## Documentation
+
+<!-- Which canonical docs were updated, or why no documentation became stale. Use `N/A — <reason>` when no documentation update is needed. -->


### PR DESCRIPTION
## Related issue

N/A — GitHub template-only maintenance; no runtime behavior or product feature issue is involved.

## Why

SyncNos already has detailed contribution, architecture, data-safety, and validation rules in `docs/CONTRIBUTING.md` and `AGENTS.md`, but the previous PR template asked only for issue, change summary, demo, drawbacks, and tests. Important review evidence therefore depended on authors remembering repository policy rather than the PR structure prompting for it.

## Scope

### In scope

- Make the PR template surface the repository's existing review requirements.
- Separate scope, architecture, persisted-data, permissions/privacy, compatibility, automated validation, manual validation, and documentation evidence.
- Preserve `N/A — <reason>` for genuinely inapplicable sections.

### Non-goals

- No new contribution policy or second source of truth.
- No CI enforcement or PR-body parser.
- No Tinycast-style memory table because SyncNos has no canonical equivalent measurement contract.

## What changed

Expanded `.github/PULL_REQUEST_TEMPLATE.md` so reviewers can directly see why a change exists, its explicit scope/non-goals, affected architecture invariants, data/recovery semantics, permissions/privacy impact, compatibility surface, risks, automated/manual validation, and documentation status.

The template keeps policy definitions in the existing canonical documents and only asks contributors to provide the evidence relevant to their change.

## Architecture / invariants

N/A — no runtime architecture changes. The template deliberately links review evidence back to the existing `AGENTS.md` contracts instead of duplicating those contracts into another policy document.

## Data, migration & recovery

N/A — no persisted-data, schema, revision, backup, cache, or migration path changes.

## Permissions & privacy

N/A — no manifest/host permissions, OAuth scopes, network destinations, or runtime data handling change. The template now explicitly reminds authors not to paste credentials or private captured content into PR evidence.

## Compatibility

N/A — no browser, site, provider, or supported-target behavior changes.

## Demo

N/A — no visual product behavior changed.

## Drawbacks / risks

The PR body is longer than before. This is intentional: sections that do not apply can be answered with a reasoned `N/A`, while complex changes no longer rely on contributors inventing their own structure. No automated enforcement is added, so the template remains guidance rather than a new merge gate.

## Tests & validation

### Automated

- Targeted Prettier check for `.github/PULL_REQUEST_TEMPLATE.md` — PASS.
- `git diff --check` — PASS.
- Change-scope verification — only `.github/PULL_REQUEST_TEMPLATE.md` differs from `main`.
- `npm run gate:ci` — N/A: this PR changes only a GitHub Markdown template and does not modify runtime, build, or dependency files, matching the documented exception in `docs/CONTRIBUTING.md`.

### Manual

Reviewed the rendered Markdown structure section by section against `docs/CONTRIBUTING.md`, `AGENTS.md`, current package scripts, WebClipper CI behavior, and recent SyncNos PR bodies to remove duplicated questions and keep each review concern owned by one section.

## Documentation

N/A — `docs/CONTRIBUTING.md` already defines the canonical contribution and validation rules this template references; duplicating or rewriting those rules would create a second source of truth.