### PR TITLE
fix: 过滤 ChatGPT ecosystem 应用图标

### DIFF
--- a/src/collectors/chatgpt/chatgpt-collector.ts
+++ b/src/collectors/chatgpt/chatgpt-collector.ts
@@ -1,7 +1,7 @@
 import type { CollectorDefinition } from '@collectors/collector-contract.ts';
 import type { CollectorEnv } from '@collectors/collector-env.ts';
 import { appendImageMarkdown, extractImageUrlsFromElement } from '@collectors/collector-utils.ts';
-import chatgptMarkdown, { isGoogleFaviconUrl } from '@collectors/chatgpt/chatgpt-markdown.ts';
+import chatgptMarkdown, { isChatgptNonContentImageUrl } from '@collectors/chatgpt/chatgpt-markdown.ts';
 import {
   addPreparedReason,
   createPreparedAccumulator,
@@ -281,7 +281,7 @@ export function createChatgptCollectorDef(env: CollectorEnv): CollectorDefinitio
   }
 
   function extractChatgptImageUrls(element: ParentNode | null): string[] {
-    return extractImageUrlsFromElement(element).filter((url) => !isGoogleFaviconUrl(url));
+    return extractImageUrlsFromElement(element).filter((url) => !isChatgptNonContentImageUrl(url));
   }
 
   type ChatgptDescriptor = {

--- a/src/collectors/chatgpt/chatgpt-markdown.ts
+++ b/src/collectors/chatgpt/chatgpt-markdown.ts
@@ -145,6 +145,14 @@ export function isGoogleFaviconUrl(src: unknown): boolean {
   return /^https:\/\/www\.google\.com\/s2\/favicons(?:[?#]|$)/i.test(String(src || '').trim());
 }
 
+export function isChatgptNonContentImageUrl(src: unknown): boolean {
+  const value = String(src || '').trim();
+  return (
+    isGoogleFaviconUrl(value) ||
+    /^https:\/\/chatgpt\.com\/images\/ecosystem\/apps\/[^/?#]+\/icon\.png(?:[?#]|$)/i.test(value)
+  );
+}
+
 function removeNonContentNodes(container: any): any {
   if (!container || !container.querySelectorAll) return container;
 
@@ -509,7 +517,7 @@ function htmlToMarkdown(root: any): any {
 
     if (tag === 'img') {
       const src = node.getAttribute ? String(node.getAttribute('src') || '').trim() : '';
-      if (isGoogleFaviconUrl(src)) return '';
+      if (isChatgptNonContentImageUrl(src)) return '';
       if (/^https?:\/\//i.test(src)) return `![](${src})`;
       return '';
     }

--- a/tests/collectors/chatgpt-collector.test.ts
+++ b/tests/collectors/chatgpt-collector.test.ts
@@ -255,7 +255,7 @@ describe('chatgpt-collector', () => {
     expect(text).not.toContain('Copy chrome');
   });
 
-  it('keeps ChatGPT source links while omitting their Google favicon images', async () => {
+  it('keeps ChatGPT content images while omitting non-content source and app icons', async () => {
     const html = `
       <article data-testid="conversation-turn-1" data-turn-id="turn_favicon">
         <div data-message-author-role="assistant" data-message-id="m_ai_favicon">
@@ -266,6 +266,7 @@ describe('chatgpt-collector', () => {
                 <span>arXiv</span>
               </a>
             </p>
+            <img src="https://chatgpt.com/images/ecosystem/apps/github/icon.png" />
             <img src="https://example.com/chart.png" />
           </div>
         </div>
@@ -284,6 +285,7 @@ describe('chatgpt-collector', () => {
     const assistant = snap.messages.find((message: any) => message.role === 'assistant');
     expect(assistant.contentMarkdown).toContain('[arXiv](https://arxiv.org/abs/2312.10997)');
     expect(assistant.contentMarkdown).not.toContain('www.google.com/s2/favicons');
+    expect(assistant.contentMarkdown).not.toContain('chatgpt.com/images/ecosystem/apps/github/icon.png');
     expect(assistant.contentMarkdown).toContain('![](https://example.com/chart.png)');
   });
 


### PR DESCRIPTION
## Related issue

N/A — targeted ChatGPT collector bug fix requested directly; no separate issue was created.

## Why

ChatGPT can render ecosystem app icons such as `https://chatgpt.com/images/ecosystem/apps/github/icon.png` inside conversation turns. SyncNos previously treated every HTTP image in the turn as conversation content, so these UI/tool icons could be appended to message Markdown and later fetched into the conversation image cache.

The collector should preserve actual conversation images while excluding known ChatGPT chrome/non-content images before they reach the shared image inlining/download path.

## Scope

### In scope

- Filter ChatGPT ecosystem app icons under `/images/ecosystem/apps/<app>/icon.png` from captured message images.
- Reuse the existing ChatGPT non-content image filtering path that already excludes Google favicons.
- Keep normal HTTP content images unchanged.
- Add a regression case for the GitHub ecosystem app icon URL.

### Non-goals

- No generic cross-site image filtering policy.
- No deletion or migration of ecosystem icon assets already persisted by older captures.
- No changes to the shared image downloader/cache behavior.

## What changed

- Expanded the existing ChatGPT-specific non-content image predicate to include ecosystem app icons.
- Applied that predicate in both ChatGPT rendered Markdown conversion and the additional image URL extraction path, so the icon cannot re-enter through `appendImageMarkdown`.
- Extended the existing favicon regression test to assert that the ecosystem app icon is omitted while a real content image is retained.

## Architecture / invariants

The change stays inside `src/collectors/chatgpt/**` and reuses the existing collector-specific filtering boundary. No dependency direction or AGENTS.md product invariant is changed.

## Data, migration & recovery

No schema, IndexedDB, revision, backup, or migration behavior changes. New captures no longer enqueue these icons for image caching. Existing message/image-cache rows created by older versions are left untouched; recapturing the conversation will apply the new filter to newly collected content.

## Permissions & privacy

N/A — no manifest permissions, host permissions, OAuth scopes, secrets, or network destinations are added. The change only prevents an unnecessary ChatGPT image request.

## Compatibility

ChatGPT collector only. Existing Google favicon filtering remains unchanged, and ordinary ChatGPT content images continue to be captured.

## Demo

N/A — no visual behavior changed.

## Drawbacks / risks

The rule intentionally matches ChatGPT's current ecosystem icon URL shape. If ChatGPT moves these UI assets to a different path, that new path would need to be classified separately. Existing persisted icon rows are not retroactively removed.

## Tests & validation

### Automated

- `npm run gate:ci` — passed.
- Result: 261 test files passed, 1765 tests passed.
- Targeted ChatGPT collector regression includes `https://chatgpt.com/images/ecosystem/apps/github/icon.png` and verifies it is omitted while `https://example.com/chart.png` remains.

### Manual

Not run against a live ChatGPT page in this change. The affected DOM/image URL behavior is covered by the targeted ChatGPT collector regression fixture.

## Documentation

N/A — no canonical documentation became stale; this is an implementation-level ChatGPT DOM filtering correction.
