### PR TITLE
修复 Chromium 扩展页 modulepreload warning

### DIFF
--- a/tests/unit/wxt-config.test.ts
+++ b/tests/unit/wxt-config.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import type { ConfigEnv, TargetBrowser } from 'wxt';
+
+import wxtConfig from '../../wxt.config';
+
+function buildEnv(browser: TargetBrowser): ConfigEnv {
+  return {
+    mode: 'production',
+    command: 'build',
+    browser,
+    manifestVersion: 3,
+  };
+}
+
+async function resolveViteConfig(browser: TargetBrowser) {
+  if (!wxtConfig.vite) throw new Error('WXT vite config callback is missing');
+  return await wxtConfig.vite(buildEnv(browser));
+}
+
+describe('WXT browser-scoped Vite config', () => {
+  it('disables JS module preload only for Chrome builds', async () => {
+    const chrome = await resolveViteConfig('chrome');
+    const firefox = await resolveViteConfig('firefox');
+    const safari = await resolveViteConfig('safari');
+
+    expect(chrome.build?.modulePreload).toBe(false);
+    expect(firefox.build?.modulePreload).toBeUndefined();
+    expect(safari.build?.modulePreload).toBeUndefined();
+  });
+
+  it('keeps the shared chunk warning limit for every browser', async () => {
+    for (const browser of ['chrome', 'firefox', 'safari'] as const) {
+      const config = await resolveViteConfig(browser);
+      expect(config.build?.chunkSizeWarningLimit).toBe(2000);
+    }
+  });
+});

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -100,7 +100,7 @@ export default defineConfig({
   modules: ['@wxt-dev/module-react'],
   entrypointsDir: 'src/entrypoints',
   webExt: chromeBinary ? { binaries: { chrome: chromeBinary } } : undefined,
-  vite: () => ({
+  vite: (env) => ({
     define: {
       __SYNCNOS_FEISHU_OAUTH_CLIENT_ID__: JSON.stringify(process.env.SYNCNOS_FEISHU_OAUTH_CLIENT_ID ?? ''),
       __SYNCNOS_FEISHU_OAUTH_TOKEN_EXCHANGE_PROXY_URL__: JSON.stringify(
@@ -111,6 +111,9 @@ export default defineConfig({
       alias: viteAlias,
     },
     build: {
+      // Chromium 152 can reject extension-page modulepreload reuse as a cross-world resource mismatch.
+      // Firefox/Safari keep Vite's default preload behavior; real ESM imports are unchanged.
+      ...(env.browser === 'chrome' ? { modulePreload: false } : {}),
       // KaTeX/Recharts can legitimately push some chunks beyond Vite's default 500kB warning threshold.
       // Keep the warning signal meaningful by using a higher, extension-appropriate limit.
       chunkSizeWarningLimit: 2000,


### PR DESCRIPTION
## Related issue

N/A — 该 Helium/Chromium 扩展页 warning 已通过本地 feature plan 完成需求确认、根因审查和阶段审计；仓库中没有对应 GitHub Issue。

## Why

Helium 0.16.2.1（Chromium 152.0.7977.64）会把扩展自身页面中 Vite 自动生成的 `modulepreload` 判定为 cross-world extension resource mismatch。真实 ES module import 本身是有效的，但 preload 无法复用并继续触发 `preloaded but not used` warning。

修复应落在 WXT/Vite 构建边界，而不是 React、Tailwind、manifest 权限或生成后的 HTML。

## Scope

### In scope

- 仅在 Chrome/Chromium WXT build 中关闭 Vite 的 JS `modulepreload`。
- 保留 Firefox、Safari 和 Zen 的现有 preload 行为。
- 增加自动化回归测试，锁住 browser-scoped 配置。

### Non-goals

- 不修改 React/Tailwind/UI 逻辑。
- 不扩大 `web_accessible_resources` 或其它 manifest 权限。
- 不重命名或拆分共享 chunk。
- 不修改 `.output/**` 生成物。

## What changed

- 将 `wxt.config.ts` 的 `vite` 配置改为读取 `env.browser`。
- 对 `env.browser === 'chrome'` 设置 `build.modulePreload: false`；其它 browser target 保持 Vite 默认行为。
- 新增 `tests/unit/wxt-config.test.ts`，验证 Chrome 关闭 JS module preload，同时 Firefox/Safari 保持默认值，并确认既有 chunk warning limit 未被改变。

## Architecture / invariants

N/A — 未改变 `src/**` 分层、业务状态或 AGENTS.md 产品不变量。改动仅位于根级 WXT/Vite 构建配置与其测试。

## Data, migration & recovery

N/A — 不涉及 IndexedDB、schema、revision、备份、迁移或任何持久化数据。

## Permissions & privacy

N/A — manifest 权限、host permissions、OAuth scope、网络目标和本地数据出站行为均未变化。

## Compatibility

- Chrome/Chromium：取消 JS preload performance hint，保留真实静态/动态 ESM 加载。
- Edge：当前发布脚本复用 Chrome build，因此获得相同修复。
- Firefox/Safari：保持现有 Vite `modulepreload`。
- Zen：继承 Firefox build，已实际完成 production build 和 XPI 打包验证。

## Demo

N/A — no visual behavior changed.

## Drawbacks / risks

Chrome/Chromium 会失去 JS `modulepreload` 的性能提示；模块仍按正常 ESM 语义加载。该取舍用于规避当前 Chromium 152 extension-page cross-world preload 问题。未来受支持的最低 Chromium 版本确认不再复现后，可删除该 browser-scoped workaround 并恢复 Vite 默认 preload。

## Tests & validation

### Automated

- `npx vitest run tests/unit/wxt-config.test.ts` — 2 tests passed。
- `npm run gate` — PASS；lint、format、compile、262 test files / 1767 tests、Chrome production build 全部通过。
- `npm run build:firefox` — PASS。
- `npm run build:safari` — PASS。
- `npm run build:zen` — PASS，并成功生成 Zen XPI。
- production output 断言确认：Chrome app/popup 不含 `modulepreload`；Firefox/Safari 保留；Chrome app/popup 仍静态 import 共享 chunk；`markdown-math` 动态 JS import 与 CSS 依赖仍存在。

### Manual

在隔离的 Helium 0.16.2.1 / Chromium 152.0.7977.64 profile 中加载当前 Chrome production build：

- `app.html#/settings?section=aboutme` 正常挂载，JS/CSS 正常加载，`modulepreloads = 0`。
- `popup.html` 正常挂载，JS/CSS 正常加载，`modulepreloads = 0`。
- 两个页面 reload 后均未捕获 `modulepreload` / `cross-world extension resource mismatch` 相关 warning。

## Documentation

N/A — 本次改动没有使长期 canonical 文档失效。对应 feature 的 `idea.md` / `todo.toml` / `plan-p1.md` / `audit-p1.md` 按仓库 agent 流程保留为本地计划与证据链，没有提交到 Git。
