### PR TITLE
优化会话列表与评论存储性能

### DIFF
--- a/src/services/comments/background/handlers.ts
+++ b/src/services/comments/background/handlers.ts
@@ -3,7 +3,6 @@ import {
   addArticleComment,
   attachOrphanCommentsToConversation,
   deleteArticleCommentById,
-  getArticleCommentDeleteContextById,
   listArticleCommentsByCanonicalUrl,
   listArticleCommentsByConversationId,
   migrateArticleCommentsCanonicalUrl,
@@ -94,17 +93,16 @@ export function registerArticleCommentsHandlers(router: AnyRouter, deps: Article
   router.register(COMMENTS_MESSAGE_TYPES.DELETE_ARTICLE_COMMENT, async (msg) => {
     const id = Number(msg?.id);
     if (!Number.isFinite(id) || id <= 0) return router.err('invalid id');
-    const context = await getArticleCommentDeleteContextById(id);
-    const ok = await deleteArticleCommentById(id);
-    if (ok) {
-      const conversationId = Number(context?.conversationId);
+    const result = await deleteArticleCommentById(id);
+    if (result.deleted) {
+      const conversationId = Number(result.conversationId);
       if (Number.isFinite(conversationId) && conversationId > 0) {
         fireAndForget(
           deps.onConversationChanged(conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.articleCommentChanged),
         );
       }
     }
-    return router.ok({ ok });
+    return router.ok({ ok: result.deleted });
   });
 
   router.register(COMMENTS_MESSAGE_TYPES.ATTACH_ORPHAN_ARTICLE_COMMENTS, async (msg) => {

--- a/src/services/comments/data/storage-idb.ts
+++ b/src/services/comments/data/storage-idb.ts
@@ -12,11 +12,6 @@ export class ArticleCommentInvariantError extends Error {
   }
 }
 
-export type ArticleCommentDeleteContext = {
-  conversationId: number | null;
-  canonicalUrl: string;
-};
-
 function tx(
   db: IDBDatabase,
   storeNames: string[],
@@ -168,83 +163,67 @@ export async function listArticleCommentsByConversationId(conversationId: number
   return (Array.isArray(rows) ? rows : []).map(toComment);
 }
 
-function toDeleteContext(row: any): ArticleCommentDeleteContext {
-  return {
-    conversationId: normalizeConversationId(row?.conversationId),
-    canonicalUrl: normalizeCanonicalUrl(row?.canonicalUrl),
-  };
-}
+type ArticleCommentDeleteResult = {
+  deleted: boolean;
+  conversationId: number | null;
+};
 
-export async function getArticleCommentDeleteContextById(id: number): Promise<ArticleCommentDeleteContext | null> {
+export async function deleteArticleCommentById(id: number): Promise<ArticleCommentDeleteResult> {
   const commentId = Number(id);
-  if (!Number.isFinite(commentId) || commentId <= 0) return null;
-
-  const db = await openDb();
-  const { t, stores } = tx(db, ['article_comments'], 'readonly');
-  const rows = (await reqToPromise<any[]>(stores.article_comments.getAll() as any)) || [];
-  await txDone(t);
-
-  const byId = new Map<number, any>();
-  for (const row of rows) {
-    const rowId = Number(row?.id);
-    if (!Number.isFinite(rowId) || rowId <= 0) continue;
-    byId.set(rowId, row);
-  }
-
-  const target = byId.get(commentId);
-  if (!target) {
-    for (const row of rows) {
-      if (normalizeParentId(row?.parentId) !== commentId) continue;
-      return toDeleteContext(row);
-    }
-    return null;
-  }
-
-  const context = toDeleteContext(target);
-  if (context.conversationId != null && context.canonicalUrl) return context;
-
-  const parentId = normalizeParentId(target?.parentId);
-  if (parentId != null) {
-    const parent = byId.get(parentId);
-    if (parent) {
-      const parentContext = toDeleteContext(parent);
-      return {
-        conversationId: context.conversationId ?? parentContext.conversationId,
-        canonicalUrl: context.canonicalUrl || parentContext.canonicalUrl,
-      };
-    }
-  }
-  return context;
-}
-
-export async function deleteArticleCommentById(id: number): Promise<boolean> {
-  const commentId = Number(id);
-  if (!Number.isFinite(commentId) || commentId <= 0) return false;
+  if (!Number.isFinite(commentId) || commentId <= 0) return { deleted: false, conversationId: null };
 
   const db = await openDb();
   return runTrackedTransaction(
     { db, stores: ['article_comments'], revisionScopes: ['article_comments'] },
     async ({ stores, markChanged }) => {
-      const rows = (await reqToPromise<any[]>(stores.article_comments.getAll() as any)) || [];
-      const targetExists = rows.some((row) => Number(row?.id) === commentId);
-      if (!targetExists) return false;
+      const store = stores.article_comments;
+      const rows = (await reqToPromise<any[]>(store.getAll() as any)) || [];
+      const byId = new Map<number, any>();
+      const childrenByParentId = new Map<number, number[]>();
 
-      const descendants = new Set<number>([commentId]);
-      let changed = true;
-      while (changed) {
-        changed = false;
-        for (const row of rows) {
-          const rowId = Number(row?.id);
-          const parentId = normalizeParentId(row?.parentId);
-          if (!Number.isFinite(rowId) || rowId <= 0 || parentId == null) continue;
-          if (!descendants.has(parentId) || descendants.has(rowId)) continue;
-          descendants.add(rowId);
-          changed = true;
+      for (const row of rows) {
+        const rowId = Number(row?.id);
+        if (!Number.isSafeInteger(rowId) || rowId <= 0) continue;
+        byId.set(rowId, row);
+
+        const parentId = normalizeParentId(row?.parentId);
+        if (parentId == null) continue;
+        const children = childrenByParentId.get(parentId) || [];
+        children.push(rowId);
+        childrenByParentId.set(parentId, children);
+      }
+
+      const target = byId.get(commentId);
+      if (!target) return { deleted: false, conversationId: null };
+
+      let conversationId = normalizeConversationId(target?.conversationId);
+      if (conversationId == null) {
+        const visitedAncestors = new Set<number>([commentId]);
+        let parentId = normalizeParentId(target?.parentId);
+        while (parentId != null && !visitedAncestors.has(parentId)) {
+          visitedAncestors.add(parentId);
+          const parent = byId.get(parentId);
+          if (!parent) break;
+          conversationId = normalizeConversationId(parent?.conversationId);
+          if (conversationId != null) break;
+          parentId = normalizeParentId(parent?.parentId);
         }
       }
-      for (const rowId of descendants) await reqToPromise(stores.article_comments.delete(rowId) as any);
+
+      const descendants = new Set<number>();
+      const pending = [commentId];
+      while (pending.length) {
+        const rowId = pending.pop();
+        if (rowId == null || descendants.has(rowId)) continue;
+        descendants.add(rowId);
+        for (const childId of childrenByParentId.get(rowId) || []) {
+          if (!descendants.has(childId)) pending.push(childId);
+        }
+      }
+
+      await Promise.all([...descendants].map((rowId) => reqToPromise(store.delete(rowId) as any)));
       markChanged('article_comments');
-      return true;
+      return { deleted: true, conversationId };
     },
   );
 }

--- a/src/services/comments/data/storage.ts
+++ b/src/services/comments/data/storage.ts
@@ -13,10 +13,6 @@ export async function listArticleCommentsByConversationId(conversationId: number
   return await idb.listArticleCommentsByConversationId(conversationId);
 }
 
-export async function getArticleCommentDeleteContextById(id: number) {
-  return await idb.getArticleCommentDeleteContextById(id);
-}
-
 export async function deleteArticleCommentById(id: number) {
   return await idb.deleteArticleCommentById(id);
 }

--- a/src/services/conversations/data/storage-idb.ts
+++ b/src/services/conversations/data/storage-idb.ts
@@ -1142,12 +1142,7 @@ function buildListTimestampRange(
       true,
     );
   }
-  return keyRangeApi.bound(
-    [startInclusive, MIN_ID] as any,
-    [endExclusive, MIN_ID] as any,
-    false,
-    true,
-  );
+  return keyRangeApi.bound([startInclusive, MIN_ID] as any, [endExclusive, MIN_ID] as any, false, true);
 }
 
 async function hydrateConversationListArticleCommentThreadCounts(
@@ -1173,10 +1168,7 @@ async function hydrateConversationListArticleCommentThreadCounts(
       keyRangeApi && Number.isSafeInteger(conversationId) && conversationId > 0
         ? reqToPromise<any[]>(
             byConversation.getAll(
-              keyRangeApi.bound(
-                [conversationId, -Infinity] as any,
-                [conversationId, Infinity] as any,
-              ),
+              keyRangeApi.bound([conversationId, -Infinity] as any, [conversationId, Infinity] as any),
             ) as any,
           )
         : Promise.resolve([]);
@@ -1187,10 +1179,7 @@ async function hydrateConversationListArticleCommentThreadCounts(
       if (!orphanRowsByCanonicalUrl.has(canonicalUrl)) {
         orphanRows = reqToPromise<any[]>(
           byCanonicalUrl.getAll(
-            keyRangeApi.bound(
-              [canonicalUrl, -Infinity] as any,
-              [canonicalUrl, Infinity] as any,
-            ),
+            keyRangeApi.bound([canonicalUrl, -Infinity] as any, [canonicalUrl, Infinity] as any),
           ) as any,
         );
         orphanRowsByCanonicalUrl.set(canonicalUrl, orphanRows);

--- a/src/services/conversations/data/storage-idb.ts
+++ b/src/services/conversations/data/storage-idb.ts
@@ -153,18 +153,6 @@ function invalidateConversationListStatsCache(): void {
   conversationListStatsCacheValue = null;
 }
 
-function isSameLocalDayTimestamp(ts: number, now: Date): boolean {
-  if (!Number.isFinite(ts) || ts <= 0) return false;
-  try {
-    const date = new Date(ts);
-    return (
-      date.getFullYear() === now.getFullYear() && date.getMonth() === now.getMonth() && date.getDate() === now.getDate()
-    );
-  } catch (_e) {
-    return false;
-  }
-}
-
 function sortFacetItems(items: Array<{ key: string; label: string; count: number }>): Array<{
   key: string;
   label: string;
@@ -1117,6 +1105,51 @@ function buildListPageRange(
   };
 }
 
+function buildListTimestampRange(
+  query: ReturnType<typeof normalizeConversationListQuery>,
+  indexName: ReturnType<typeof buildListPageRange>['indexName'],
+  startInclusive: number,
+  endExclusive: number,
+): IDBKeyRange | null {
+  const keyRangeApi = globalThis.IDBKeyRange;
+  if (!keyRangeApi) return null;
+
+  const sourceKey = normalizeListKey(query.sourceKey, LIST_SOURCE_KEY_ALL);
+  const siteKey = normalizeConversationListSiteFilterKey(query.siteKey);
+  const MIN_ID = 0;
+
+  if (indexName === 'by_listSourceKey_listSiteKey_lastCapturedAt_id') {
+    return keyRangeApi.bound(
+      [sourceKey, siteKey, startInclusive, MIN_ID] as any,
+      [sourceKey, siteKey, endExclusive, MIN_ID] as any,
+      false,
+      true,
+    );
+  }
+  if (indexName === 'by_listSourceKey_lastCapturedAt_id') {
+    return keyRangeApi.bound(
+      [sourceKey, startInclusive, MIN_ID] as any,
+      [sourceKey, endExclusive, MIN_ID] as any,
+      false,
+      true,
+    );
+  }
+  if (indexName === 'by_listSiteKey_lastCapturedAt_id') {
+    return keyRangeApi.bound(
+      [siteKey, startInclusive, MIN_ID] as any,
+      [siteKey, endExclusive, MIN_ID] as any,
+      false,
+      true,
+    );
+  }
+  return keyRangeApi.bound(
+    [startInclusive, MIN_ID] as any,
+    [endExclusive, MIN_ID] as any,
+    false,
+    true,
+  );
+}
+
 async function readConversationListPageItems(input: {
   store: IDBObjectStore;
   articleCommentsStore: IDBObjectStore;
@@ -1189,52 +1222,80 @@ async function readConversationListSummaryAndFacets(input: {
 }): Promise<{ summary: ConversationListSummary; facets: ConversationListFacets }> {
   const { store, query } = input;
   const sourceFilter = normalizeListKey(query.sourceKey, LIST_SOURCE_KEY_ALL);
-  const siteFilter = normalizeConversationListSiteFilterKey(query.siteKey);
+  const siteFacetSourceScope = sourceFilter === LIST_SOURCE_KEY_ALL ? 'web' : sourceFilter;
   const sourceFacetMap = new Map<string, { key: string; label: string; count: number }>();
   const siteFacetMap = new Map<string, { key: string; label: string; count: number }>();
-  const siteFacetSourceScope = sourceFilter === LIST_SOURCE_KEY_ALL ? 'web' : sourceFilter;
 
-  const now = new Date();
-  let totalCount = 0;
-  let todayCount = 0;
+  const summaryRange = buildListPageRange(query, null);
+  const summaryIndex = store.index(summaryRange.indexName);
+  const totalCountPromise = reqToPromise<number>(summaryIndex.count((summaryRange.range || undefined) as any));
 
-  const request = store.openCursor();
-  await new Promise<void>((resolve, reject) => {
-    request.onerror = () => reject(request.error || new Error('cursor failed'));
-    request.onsuccess = () => {
-      const cursor = request.result;
+  const todayStart = new Date();
+  todayStart.setHours(0, 0, 0, 0);
+  const tomorrowStart = new Date(todayStart);
+  tomorrowStart.setDate(tomorrowStart.getDate() + 1);
+  const todayRange = buildListTimestampRange(
+    query,
+    summaryRange.indexName,
+    todayStart.getTime(),
+    tomorrowStart.getTime(),
+  );
+  const todayCountPromise = todayRange
+    ? reqToPromise<number>(summaryIndex.count(todayRange as any))
+    : Promise.resolve(0);
+
+  const sourceFacetRequest = store.index('by_listSourceKey_lastCapturedAt_id').openKeyCursor();
+  const sourceFacetsPromise = new Promise<void>((resolve, reject) => {
+    sourceFacetRequest.onerror = () => reject(sourceFacetRequest.error || new Error('source facet cursor failed'));
+    sourceFacetRequest.onsuccess = () => {
+      const cursor = sourceFacetRequest.result;
       if (!cursor) return resolve();
-      const raw = (cursor.value || {}) as any;
-      const normalized = normalizeConversationListRecord(raw);
-      const rowSourceKey = normalizeListKey(normalized.listSourceKey, 'unknown');
-      const rowSiteKey = normalizeConversationListSiteFilterKey(normalized.listSiteKey);
-      const rowSiteLabel = rowSiteKey.startsWith('domain:') ? rowSiteKey.slice('domain:'.length) : rowSiteKey;
+      const key = Array.isArray(cursor.key) ? cursor.key : [];
+      const rowSourceKey = normalizeListKey(key[0], 'unknown');
+      const facet = sourceFacetMap.get(rowSourceKey) || { key: rowSourceKey, label: rowSourceKey, count: 0 };
+      facet.count += 1;
+      sourceFacetMap.set(rowSourceKey, facet);
+      cursor.continue();
+    };
+  });
 
-      const sourceFacet = sourceFacetMap.get(rowSourceKey) || { key: rowSourceKey, label: rowSourceKey, count: 0 };
-      sourceFacet.count += 1;
-      sourceFacetMap.set(rowSourceKey, sourceFacet);
-
+  const siteFacetIndex = store.index('by_listSourceKey_listSiteKey_lastCapturedAt_id');
+  const siteFacetRange = globalThis.IDBKeyRange?.bound
+    ? globalThis.IDBKeyRange.bound(
+        [siteFacetSourceScope, '', 0, 0] as any,
+        [siteFacetSourceScope, '\uffff', Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER] as any,
+      )
+    : null;
+  const siteFacetRequest = siteFacetIndex.openKeyCursor((siteFacetRange || null) as any);
+  const siteFacetsPromise = new Promise<void>((resolve, reject) => {
+    siteFacetRequest.onerror = () => reject(siteFacetRequest.error || new Error('site facet cursor failed'));
+    siteFacetRequest.onsuccess = () => {
+      const cursor = siteFacetRequest.result;
+      if (!cursor) return resolve();
+      const key = Array.isArray(cursor.key) ? cursor.key : [];
+      const rowSourceKey = normalizeListKey(key[0], 'unknown');
       if (rowSourceKey === siteFacetSourceScope) {
-        const siteFacet = siteFacetMap.get(rowSiteKey) || { key: rowSiteKey, label: rowSiteLabel, count: 0 };
-        siteFacet.count += 1;
-        siteFacetMap.set(rowSiteKey, siteFacet);
-      }
-
-      const sourceMatch = sourceFilter === LIST_SOURCE_KEY_ALL || rowSourceKey === sourceFilter;
-      const siteMatch = siteFilter === LIST_SITE_KEY_ALL || rowSiteKey === siteFilter;
-      if (sourceMatch && siteMatch) {
-        totalCount += 1;
-        const ts = Number(raw.lastCapturedAt) || 0;
-        if (isSameLocalDayTimestamp(ts, now)) todayCount += 1;
+        const rowSiteKey = normalizeConversationListSiteFilterKey(key[1]);
+        const rowSiteLabel = rowSiteKey.startsWith('domain:') ? rowSiteKey.slice('domain:'.length) : rowSiteKey;
+        const facet = siteFacetMap.get(rowSiteKey) || { key: rowSiteKey, label: rowSiteLabel, count: 0 };
+        facet.count += 1;
+        siteFacetMap.set(rowSiteKey, facet);
       }
       cursor.continue();
     };
   });
 
+  const [totalCount, todayCount] = await Promise.all([
+    totalCountPromise,
+    todayCountPromise,
+    sourceFacetsPromise,
+    siteFacetsPromise,
+  ]);
+
   return {
     summary: {
-      totalCount,
-      todayCount,
+      totalCount: Number(totalCount) || 0,
+      todayCount: Number(todayCount) || 0,
     },
     facets: {
       sources: sortFacetItems(Array.from(sourceFacetMap.values())),

--- a/src/services/conversations/data/storage-idb.ts
+++ b/src/services/conversations/data/storage-idb.ts
@@ -1150,6 +1150,66 @@ function buildListTimestampRange(
   );
 }
 
+async function hydrateConversationListArticleCommentThreadCounts(
+  items: Conversation[],
+  articleCommentsStore: IDBObjectStore,
+): Promise<void> {
+  const keyRangeApi = globalThis.IDBKeyRange;
+  const byConversation = articleCommentsStore.index('by_conversationId_createdAt');
+  const byCanonicalUrl = articleCommentsStore.index('by_canonicalUrl_createdAt');
+  const orphanRowsByCanonicalUrl = new Map<string, Promise<any[]>>();
+  const reads: Array<{
+    item: Conversation;
+    linkedRows: Promise<any[]>;
+    orphanRows: Promise<any[]>;
+  }> = [];
+
+  for (const item of items) {
+    if (safeString((item as any).sourceType).toLowerCase() !== 'article') continue;
+
+    const conversationId = Number((item as any).id);
+    const canonicalUrl = canonicalizeArticleUrl((item as any).url);
+    const linkedRows =
+      keyRangeApi && Number.isSafeInteger(conversationId) && conversationId > 0
+        ? reqToPromise<any[]>(
+            byConversation.getAll(
+              keyRangeApi.bound(
+                [conversationId, -Infinity] as any,
+                [conversationId, Infinity] as any,
+              ),
+            ) as any,
+          )
+        : Promise.resolve([]);
+
+    let orphanRows = Promise.resolve<any[]>([]);
+    if (keyRangeApi && canonicalUrl) {
+      orphanRows = orphanRowsByCanonicalUrl.get(canonicalUrl) || Promise.resolve([]);
+      if (!orphanRowsByCanonicalUrl.has(canonicalUrl)) {
+        orphanRows = reqToPromise<any[]>(
+          byCanonicalUrl.getAll(
+            keyRangeApi.bound(
+              [canonicalUrl, -Infinity] as any,
+              [canonicalUrl, Infinity] as any,
+            ),
+          ) as any,
+        );
+        orphanRowsByCanonicalUrl.set(canonicalUrl, orphanRows);
+      }
+    }
+
+    reads.push({ item, linkedRows, orphanRows });
+  }
+
+  await Promise.all(
+    reads.map(async ({ item, linkedRows, orphanRows }) => {
+      const [linked, byUrl] = await Promise.all([linkedRows, orphanRows]);
+      const comments = [...(Array.isArray(linked) ? linked : [])];
+      comments.push(...(Array.isArray(byUrl) ? byUrl.filter((row) => row?.conversationId == null) : []));
+      (item as any).commentThreadCount = computeArticleCommentThreadCount(comments);
+    }),
+  );
+}
+
 async function readConversationListPageItems(input: {
   store: IDBObjectStore;
   articleCommentsStore: IDBObjectStore;
@@ -1176,30 +1236,7 @@ async function readConversationListPageItems(input: {
 
   const hasMore = rows.length > safeLimit;
   const pageItems = hasMore ? rows.slice(0, safeLimit) : rows;
-  const byConversation = articleCommentsStore.index('by_conversationId_createdAt');
-  const byCanonicalUrl = articleCommentsStore.index('by_canonicalUrl_createdAt');
-  for (const item of pageItems) {
-    if (safeString((item as any).sourceType).toLowerCase() !== 'article') continue;
-    const conversationId = Number((item as any).id);
-    const canonicalUrl = canonicalizeArticleUrl((item as any).url);
-    const comments: any[] = [];
-    if (globalThis.IDBKeyRange?.bound && Number.isSafeInteger(conversationId) && conversationId > 0) {
-      const byConversationRange = globalThis.IDBKeyRange.bound(
-        [conversationId, -Infinity] as any,
-        [conversationId, Infinity] as any,
-      );
-      comments.push(...((await reqToPromise<any[]>(byConversation.getAll(byConversationRange) as any)) || []));
-    }
-    if (globalThis.IDBKeyRange?.bound && canonicalUrl) {
-      const byUrlRange = globalThis.IDBKeyRange.bound(
-        [canonicalUrl, -Infinity] as any,
-        [canonicalUrl, Infinity] as any,
-      );
-      const urlRows = (await reqToPromise<any[]>(byCanonicalUrl.getAll(byUrlRange) as any)) || [];
-      comments.push(...urlRows.filter((row) => row?.conversationId == null));
-    }
-    (item as any).commentThreadCount = computeArticleCommentThreadCount(comments);
-  }
+  await hydrateConversationListArticleCommentThreadCounts(pageItems as Conversation[], articleCommentsStore);
 
   const tail = pageItems.length ? pageItems[pageItems.length - 1] : null;
   const nextCursor =

--- a/tests/integration/reload-free-data-consistency.test.ts
+++ b/tests/integration/reload-free-data-consistency.test.ts
@@ -432,7 +432,10 @@ describe('reload-free data consistency production chain', () => {
 
     commentsConsumer.failNext();
     const vectorBeforeDelete = await readDataRevisionSnapshot();
-    await expect(deleteArticleCommentById(Number(root?.id))).resolves.toBe(true);
+    await expect(deleteArticleCommentById(Number(root?.id))).resolves.toEqual({
+      deleted: true,
+      conversationId: articleId,
+    });
     const vectorAfterDelete = await readDataRevisionSnapshot();
     expect(vectorAfterDelete.article_comments).toBe(vectorBeforeDelete.article_comments + 1);
 

--- a/tests/smoke/background-router-article-comments.test.ts
+++ b/tests/smoke/background-router-article-comments.test.ts
@@ -7,7 +7,6 @@ const storageMocks = vi.hoisted(() => ({
   addArticleComment: vi.fn(),
   attachOrphanCommentsToConversation: vi.fn(),
   deleteArticleCommentById: vi.fn(),
-  getArticleCommentDeleteContextById: vi.fn(),
   listArticleCommentsByCanonicalUrl: vi.fn(),
   listArticleCommentsByConversationId: vi.fn(),
   migrateArticleCommentsCanonicalUrl: vi.fn(),
@@ -38,6 +37,47 @@ beforeEach(() => {
 });
 
 describe('article comments background handler mutation side effects', () => {
+  it('returns ok and schedules auto-sync from the committed delete result owner', async () => {
+    storageMocks.deleteArticleCommentById.mockResolvedValue({ deleted: true, conversationId: 31 });
+    const onConversationChanged = vi.fn();
+    const { router, handlers } = createRouter();
+    registerArticleCommentsHandlers(router, { onConversationChanged });
+
+    const response = await handlers.get(COMMENTS_MESSAGE_TYPES.DELETE_ARTICLE_COMMENT)?.({ id: 7 });
+
+    expect(response).toEqual({ ok: true, data: { ok: true }, error: null });
+    expect(storageMocks.deleteArticleCommentById).toHaveBeenCalledWith(7);
+    expect(onConversationChanged).toHaveBeenCalledTimes(1);
+    expect(onConversationChanged).toHaveBeenCalledWith(
+      31,
+      AUTO_SYNC_CONVERSATION_CHANGED_REASONS.articleCommentChanged,
+    );
+  });
+
+  it('returns ok=false for a missing delete without scheduling auto-sync', async () => {
+    storageMocks.deleteArticleCommentById.mockResolvedValue({ deleted: false, conversationId: null });
+    const onConversationChanged = vi.fn();
+    const { router, handlers } = createRouter();
+    registerArticleCommentsHandlers(router, { onConversationChanged });
+
+    const response = await handlers.get(COMMENTS_MESSAGE_TYPES.DELETE_ARTICLE_COMMENT)?.({ id: 8 });
+
+    expect(response).toEqual({ ok: true, data: { ok: false }, error: null });
+    expect(onConversationChanged).not.toHaveBeenCalled();
+  });
+
+  it('does not invent an auto-sync target for a deleted orphan-only comment', async () => {
+    storageMocks.deleteArticleCommentById.mockResolvedValue({ deleted: true, conversationId: null });
+    const onConversationChanged = vi.fn();
+    const { router, handlers } = createRouter();
+    registerArticleCommentsHandlers(router, { onConversationChanged });
+
+    const response = await handlers.get(COMMENTS_MESSAGE_TYPES.DELETE_ARTICLE_COMMENT)?.({ id: 9 });
+
+    expect(response).toEqual({ ok: true, data: { ok: true }, error: null });
+    expect(onConversationChanged).not.toHaveBeenCalled();
+  });
+
   it('keeps attach updated=0 successful without auto-sync', async () => {
     storageMocks.attachOrphanCommentsToConversation.mockResolvedValue({ updated: 0 });
     const onConversationChanged = vi.fn();

--- a/tests/storage/article-comments-idb.test.ts
+++ b/tests/storage/article-comments-idb.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { IDBKeyRange, indexedDB } from 'fake-indexeddb';
+import { IDBKeyRange, IDBObjectStore, indexedDB } from 'fake-indexeddb';
 import { closeDbForTests, openDb } from '@platform/idb/schema';
 import { readDataRevision } from '@services/data-revisions/storage-idb';
 
@@ -294,7 +294,16 @@ describe('article comments storage-idb', () => {
     expect(byId.get(reply1.id)?.parentId).toBe(root.id);
 
     const beforeDeleteRevision = await readDataRevision('article_comments');
-    expect(await deleteArticleCommentById(root.id)).toEqual({ deleted: true, conversationId: null });
+    const getAllSpy = vi.spyOn(IDBObjectStore.prototype, 'getAll');
+    try {
+      expect(await deleteArticleCommentById(root.id)).toEqual({ deleted: true, conversationId: null });
+      const articleCommentMaterializations = getAllSpy.mock.contexts.filter(
+        (context) => String((context as any)?.name || '') === 'article_comments',
+      );
+      expect(articleCommentMaterializations).toHaveLength(1);
+    } finally {
+      getAllSpy.mockRestore();
+    }
     expect(await readDataRevision('article_comments')).toBe(beforeDeleteRevision + 1);
     const after = await listArticleCommentsByCanonicalUrl(url);
     expect(after.length).toBe(0);

--- a/tests/storage/article-comments-idb.test.ts
+++ b/tests/storage/article-comments-idb.test.ts
@@ -100,9 +100,9 @@ describe('article comments storage-idb', () => {
     const before = await readDataRevision('article_comments');
     expect(await deleteArticleCommentById(999_999)).toEqual({ deleted: false, conversationId: null });
     expect(await readDataRevision('article_comments')).toBe(before);
-    expect((await listArticleCommentsByCanonicalUrl('https://example.com/missing-parent')).map((item) => item.id)).toEqual([
-      childId,
-    ]);
+    expect(
+      (await listArticleCommentsByCanonicalUrl('https://example.com/missing-parent')).map((item) => item.id),
+    ).toEqual([childId]);
   });
 
   it('round-trips author metadata and V1/V2 locators without field loss', async () => {

--- a/tests/storage/article-comments-idb.test.ts
+++ b/tests/storage/article-comments-idb.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { IDBKeyRange, indexedDB } from 'fake-indexeddb';
-import { closeDbForTests } from '@platform/idb/schema';
+import { closeDbForTests, openDb } from '@platform/idb/schema';
 import { readDataRevision } from '@services/data-revisions/storage-idb';
 
 import {
@@ -22,11 +22,7 @@ function reqToPromise<T = unknown>(request: IDBRequest<T>): Promise<T> {
 }
 
 async function insertRawArticleComment(row: Record<string, unknown>): Promise<number> {
-  const db = await new Promise<IDBDatabase>((resolve, reject) => {
-    const request = indexedDB.open('webclipper');
-    request.onsuccess = () => resolve(request.result);
-    request.onerror = () => reject(request.error);
-  });
+  const db = await openDb();
   const transaction = db.transaction(['article_comments'], 'readwrite');
   const id = await reqToPromise<number>(transaction.objectStore('article_comments').add(row) as IDBRequest<number>);
   await new Promise<void>((resolve, reject) => {
@@ -34,7 +30,6 @@ async function insertRawArticleComment(row: Record<string, unknown>): Promise<nu
     transaction.onerror = () => reject(transaction.error);
     transaction.onabort = () => reject(transaction.error);
   });
-  db.close();
   return id;
 }
 
@@ -83,17 +78,31 @@ describe('article comments storage-idb', () => {
     const byConvo = await listArticleCommentsByConversationId(123);
     expect(byConvo.map((c) => c.id)).toEqual([c2.id]);
 
-    const ok = await deleteArticleCommentById(c1.id);
-    expect(ok).toBe(true);
+    const result = await deleteArticleCommentById(c1.id);
+    expect(result).toEqual({ deleted: true, conversationId: null });
 
     const after = await listArticleCommentsByCanonicalUrl('https://example.com/a');
     expect(after.map((c) => c.id)).toEqual([c2.id]);
   });
 
-  it('returns false without revision churn when deleting a missing comment id', async () => {
+  it('returns a stable missing result without revision churn or guessing context from malformed children', async () => {
+    const childId = await insertRawArticleComment({
+      parentId: 999_999,
+      conversationId: 77,
+      canonicalUrl: 'https://example.com/missing-parent',
+      authorName: '',
+      quoteText: '',
+      commentText: 'historical child',
+      locator: null,
+      createdAt: 1,
+      updatedAt: 1,
+    });
     const before = await readDataRevision('article_comments');
-    expect(await deleteArticleCommentById(999_999)).toBe(false);
+    expect(await deleteArticleCommentById(999_999)).toEqual({ deleted: false, conversationId: null });
     expect(await readDataRevision('article_comments')).toBe(before);
+    expect((await listArticleCommentsByCanonicalUrl('https://example.com/missing-parent')).map((item) => item.id)).toEqual([
+      childId,
+    ]);
   });
 
   it('round-trips author metadata and V1/V2 locators without field loss', async () => {
@@ -170,6 +179,96 @@ describe('article comments storage-idb', () => {
     ).rejects.toThrow('parent_context_mismatch');
   });
 
+  it('returns the deleted row owner and prefers a reply own conversationId', async () => {
+    const root = await addArticleComment({
+      conversationId: 41,
+      canonicalUrl: 'https://example.com/owners',
+      commentText: 'root',
+      createdAt: 1,
+    });
+    const reply = await addArticleComment({
+      parentId: root.id,
+      conversationId: 41,
+      canonicalUrl: 'https://example.com/owners',
+      commentText: 'reply',
+      createdAt: 2,
+    });
+
+    expect(await deleteArticleCommentById(reply.id)).toEqual({ deleted: true, conversationId: 41 });
+    expect((await listArticleCommentsByCanonicalUrl('https://example.com/owners')).map((item) => item.id)).toEqual([
+      root.id,
+    ]);
+    expect(await deleteArticleCommentById(root.id)).toEqual({ deleted: true, conversationId: 41 });
+  });
+
+  it('resolves the nearest valid owner through malformed deep ancestors and terminates ancestor cycles', async () => {
+    const url = 'https://example.com/historical-owner';
+    const rootId = await insertRawArticleComment({
+      id: 5001,
+      parentId: null,
+      conversationId: 51,
+      canonicalUrl: url,
+      authorName: '',
+      quoteText: '',
+      commentText: 'root owner',
+      locator: null,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    const middleId = await insertRawArticleComment({
+      id: 5002,
+      parentId: rootId,
+      conversationId: null,
+      canonicalUrl: url,
+      authorName: '',
+      quoteText: '',
+      commentText: 'middle without owner',
+      locator: null,
+      createdAt: 2,
+      updatedAt: 2,
+    });
+    const targetId = await insertRawArticleComment({
+      id: 5003,
+      parentId: middleId,
+      conversationId: null,
+      canonicalUrl: url,
+      authorName: '',
+      quoteText: '',
+      commentText: 'target without owner',
+      locator: null,
+      createdAt: 3,
+      updatedAt: 3,
+    });
+    expect(await deleteArticleCommentById(targetId)).toEqual({ deleted: true, conversationId: 51 });
+
+    await insertRawArticleComment({
+      id: 5101,
+      parentId: 5102,
+      conversationId: null,
+      canonicalUrl: url,
+      authorName: '',
+      quoteText: '',
+      commentText: 'cycle a',
+      locator: null,
+      createdAt: 4,
+      updatedAt: 4,
+    });
+    await insertRawArticleComment({
+      id: 5102,
+      parentId: 5101,
+      conversationId: null,
+      canonicalUrl: url,
+      authorName: '',
+      quoteText: '',
+      commentText: 'cycle b',
+      locator: null,
+      createdAt: 5,
+      updatedAt: 5,
+    });
+    expect(await deleteArticleCommentById(5101)).toEqual({ deleted: true, conversationId: null });
+    expect((await listArticleCommentsByCanonicalUrl(url)).map((item) => item.id)).toEqual([rootId, middleId]);
+  });
+
   it('supports replies and cascades delete on root', async () => {
     const url = 'https://example.com/thread';
     const root = await addArticleComment({
@@ -195,16 +294,17 @@ describe('article comments storage-idb', () => {
     expect(byId.get(reply1.id)?.parentId).toBe(root.id);
 
     const beforeDeleteRevision = await readDataRevision('article_comments');
-    await deleteArticleCommentById(root.id);
+    expect(await deleteArticleCommentById(root.id)).toEqual({ deleted: true, conversationId: null });
     expect(await readDataRevision('article_comments')).toBe(beforeDeleteRevision + 1);
     const after = await listArticleCommentsByCanonicalUrl(url);
     expect(after.length).toBe(0);
   });
 
-  it('deletes all descendants from malformed historical deep reply graphs', async () => {
+  it('deletes deep descendants and target-connected cycles in one revision per delete', async () => {
     const url = 'https://example.com/deep-thread';
     const root = await addArticleComment({ conversationId: 1, canonicalUrl: url, commentText: 'root', createdAt: 1 });
     const childId = await insertRawArticleComment({
+      id: 6001,
       parentId: root.id,
       conversationId: 1,
       canonicalUrl: url,
@@ -216,6 +316,7 @@ describe('article comments storage-idb', () => {
       updatedAt: 2,
     });
     await insertRawArticleComment({
+      id: 6002,
       parentId: childId,
       conversationId: 1,
       canonicalUrl: url,
@@ -226,7 +327,51 @@ describe('article comments storage-idb', () => {
       createdAt: 3,
       updatedAt: 3,
     });
-    await deleteArticleCommentById(root.id);
+    await insertRawArticleComment({
+      id: 6003,
+      parentId: 6004,
+      conversationId: 1,
+      canonicalUrl: url,
+      authorName: '',
+      quoteText: '',
+      commentText: 'cycle a',
+      locator: null,
+      createdAt: 4,
+      updatedAt: 4,
+    });
+    await insertRawArticleComment({
+      id: 6004,
+      parentId: 6003,
+      conversationId: 1,
+      canonicalUrl: url,
+      authorName: '',
+      quoteText: '',
+      commentText: 'cycle b',
+      locator: null,
+      createdAt: 5,
+      updatedAt: 5,
+    });
+    await insertRawArticleComment({
+      id: 6005,
+      parentId: 6004,
+      conversationId: 1,
+      canonicalUrl: url,
+      authorName: '',
+      quoteText: '',
+      commentText: 'cycle child',
+      locator: null,
+      createdAt: 6,
+      updatedAt: 6,
+    });
+
+    const before = await readDataRevision('article_comments');
+    expect(await deleteArticleCommentById(root.id)).toEqual({ deleted: true, conversationId: 1 });
+    expect(await readDataRevision('article_comments')).toBe(before + 1);
+    expect((await listArticleCommentsByCanonicalUrl(url)).map((item) => item.id)).toEqual([6003, 6004, 6005]);
+
+    const beforeCycleDelete = await readDataRevision('article_comments');
+    expect(await deleteArticleCommentById(6003)).toEqual({ deleted: true, conversationId: 1 });
+    expect(await readDataRevision('article_comments')).toBe(beforeCycleDelete + 1);
     expect(await listArticleCommentsByCanonicalUrl(url)).toEqual([]);
   });
 

--- a/tests/storage/conversations-pagination.test.ts
+++ b/tests/storage/conversations-pagination.test.ts
@@ -227,6 +227,33 @@ describe('conversations pagination storage-idb', () => {
     expect(chatgpt.facets.sites).toEqual([{ key: 'domain:chatgpt.com', label: 'chatgpt.com', count: 1 }]);
   });
 
+  it('counts today from inclusive local midnight to exclusive next local midnight', async () => {
+    const todayStart = new Date();
+    todayStart.setHours(0, 0, 0, 0);
+    const tomorrowStart = new Date(todayStart);
+    tomorrowStart.setDate(tomorrowStart.getDate() + 1);
+
+    const timestamps = [
+      todayStart.getTime() - 1,
+      todayStart.getTime(),
+      tomorrowStart.getTime() - 1,
+      tomorrowStart.getTime(),
+    ];
+    for (let index = 0; index < timestamps.length; index += 1) {
+      await upsertConversation({
+        sourceType: 'chat',
+        source: 'chatgpt',
+        conversationKey: `day-boundary-${index + 1}`,
+        title: `day boundary ${index + 1}`,
+        url: `https://chatgpt.com/c/day-boundary-${index + 1}`,
+        lastCapturedAt: timestamps[index],
+      });
+    }
+
+    const bootstrap = await getConversationListBootstrap({ sourceKey: 'all', siteKey: 'all', limit: 20 });
+    expect(bootstrap.summary).toEqual({ totalCount: 4, todayCount: 2 });
+  });
+
   it('does not persist derived-key repairs while reading a fresh bootstrap', async () => {
     await upsertConversation({
       sourceType: 'chat',

--- a/tests/storage/conversations-pagination.test.ts
+++ b/tests/storage/conversations-pagination.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { IDBKeyRange, indexedDB } from 'fake-indexeddb';
+import { IDBIndex, IDBKeyRange, indexedDB } from 'fake-indexeddb';
 import { closeDbForTests } from '@platform/idb/schema';
 import {
   __resetConversationStorageStateForTests,
@@ -76,6 +76,30 @@ describe('conversations pagination storage-idb', () => {
     expect(second.hasMore).toBe(false);
 
     expect(Number(a.id)).toBeLessThan(Number(b.id));
+  });
+
+  it('does not query article comment indexes for a non-article-only page', async () => {
+    await upsertConversation({
+      sourceType: 'chat',
+      source: 'chatgpt',
+      conversationKey: 'chat-only-comment-read',
+      title: 'chat only',
+      url: 'https://chatgpt.com/c/chat-only-comment-read',
+      lastCapturedAt: Date.now(),
+    });
+
+    const getAllSpy = vi.spyOn(IDBIndex.prototype, 'getAll');
+    try {
+      const page = await getConversationListBootstrap({ sourceKey: 'all', siteKey: 'all', limit: 10 });
+      expect(page.items).toHaveLength(1);
+      const commentIndexReads = getAllSpy.mock.contexts.filter((context) => {
+        const indexName = String((context as any)?.name || '');
+        return indexName === 'by_conversationId_createdAt' || indexName === 'by_canonicalUrl_createdAt';
+      });
+      expect(commentIndexReads).toHaveLength(0);
+    } finally {
+      getAllSpy.mockRestore();
+    }
   });
 
   it('does not duplicate or skip rows across pages', async () => {
@@ -598,18 +622,32 @@ describe('conversations pagination storage-idb', () => {
       createdAt: 3,
     });
 
-    const first = await getConversationListBootstrap({ sourceKey: 'all', siteKey: 'all', limit: 2 });
-    expect(first.items.map((item) => item.conversationKey)).toEqual([
-      'article:https://example.com/shared',
-      'article:historical-shared-copy',
-    ]);
-    expect(first.items.map((item) => item.commentThreadCount)).toEqual([2, 2]);
-    expect(first.hasMore).toBe(true);
-    expect(first.cursor).toEqual({ lastCapturedAt: now - 1, id: duplicateId });
+    const getAllSpy = vi.spyOn(IDBIndex.prototype, 'getAll');
+    try {
+      const first = await getConversationListBootstrap({ sourceKey: 'all', siteKey: 'all', limit: 2 });
+      expect(first.items.map((item) => item.conversationKey)).toEqual([
+        'article:https://example.com/shared',
+        'article:historical-shared-copy',
+      ]);
+      expect(first.items.map((item) => item.commentThreadCount)).toEqual([2, 2]);
+      expect(first.hasMore).toBe(true);
+      expect(first.cursor).toEqual({ lastCapturedAt: now - 1, id: duplicateId });
 
-    const second = await getConversationListPage({ sourceKey: 'all', siteKey: 'all', limit: 2 }, first.cursor!);
-    expect(second.items.map((item) => item.conversationKey)).toEqual(['after-shared']);
-    expect(second.items[0]?.commentThreadCount).toBeUndefined();
-    expect(second.hasMore).toBe(false);
+      const second = await getConversationListPage({ sourceKey: 'all', siteKey: 'all', limit: 2 }, first.cursor!);
+      expect(second.items.map((item) => item.conversationKey)).toEqual(['after-shared']);
+      expect(second.items[0]?.commentThreadCount).toBeUndefined();
+      expect(second.hasMore).toBe(false);
+
+      const commentReadIndexNames = getAllSpy.mock.contexts
+        .map((context) => String((context as any)?.name || ''))
+        .filter((name) => name === 'by_conversationId_createdAt' || name === 'by_canonicalUrl_createdAt');
+      expect(commentReadIndexNames).toEqual([
+        'by_conversationId_createdAt',
+        'by_canonicalUrl_createdAt',
+        'by_conversationId_createdAt',
+      ]);
+    } finally {
+      getAllSpy.mockRestore();
+    }
   });
 });

--- a/tests/storage/conversations-pagination.test.ts
+++ b/tests/storage/conversations-pagination.test.ts
@@ -452,7 +452,8 @@ describe('conversations pagination storage-idb', () => {
       request.onerror = () => reject(request.error);
     });
     const rawTx = rawDb.transaction(['article_comments'], 'readwrite');
-    rawTx.objectStore('article_comments').add({
+    const rawStore = rawTx.objectStore('article_comments');
+    rawStore.add({
       conversationId: Number(article.id),
       canonicalUrl: 'https://example.com/thread',
       authorName: '',
@@ -462,6 +463,30 @@ describe('conversations pagination storage-idb', () => {
       parentId: 999,
       createdAt: 3,
       updatedAt: 3,
+    });
+    rawStore.add({
+      id: 1001,
+      conversationId: Number(article.id),
+      canonicalUrl: 'https://example.com/thread',
+      authorName: '',
+      quoteText: '',
+      commentText: 'cycle a',
+      locator: null,
+      parentId: 1002,
+      createdAt: 4,
+      updatedAt: 4,
+    });
+    rawStore.add({
+      id: 1002,
+      conversationId: Number(article.id),
+      canonicalUrl: 'https://example.com/thread',
+      authorName: '',
+      quoteText: '',
+      commentText: 'cycle b',
+      locator: null,
+      parentId: 1001,
+      createdAt: 5,
+      updatedAt: 5,
     });
     await new Promise<void>((resolve, reject) => {
       rawTx.oncomplete = () => resolve();
@@ -474,7 +499,90 @@ describe('conversations pagination storage-idb', () => {
     const articleItem = page.items.find((item) => item.sourceType === 'article');
     const chatItem = page.items.find((item) => item.sourceType !== 'article');
 
-    expect(articleItem?.commentThreadCount).toBe(2);
+    expect(articleItem?.commentThreadCount).toBe(3);
     expect(chatItem?.commentThreadCount).toBeUndefined();
+  });
+
+  it('hydrates multiple article rows with shared orphan URL comments without mixing conversation-owned rows', async () => {
+    const now = Date.now();
+    const canonical = await upsertConversation({
+      sourceType: 'article',
+      source: 'web',
+      conversationKey: 'article:https://example.com/shared',
+      title: 'canonical',
+      url: 'https://example.com/shared',
+      lastCapturedAt: now,
+    });
+    await upsertConversation({
+      sourceType: 'chat',
+      source: 'chatgpt',
+      conversationKey: 'after-shared',
+      title: 'after',
+      url: 'https://chatgpt.com/c/after-shared',
+      lastCapturedAt: now - 2,
+    });
+
+    const rawDb = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open('webclipper');
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+    const rawTx = rawDb.transaction(['conversations'], 'readwrite');
+    const duplicateId = Number(
+      await reqToPromise(
+        rawTx.objectStore('conversations').add({
+          sourceType: 'article',
+          source: 'web',
+          conversationKey: 'article:historical-shared-copy',
+          title: 'historical duplicate',
+          url: 'https://example.com/shared#historical',
+          lastCapturedAt: now - 1,
+          listSourceKey: 'web',
+          listSiteKey: 'domain:example.com',
+        }),
+      ),
+    );
+    await new Promise<void>((resolve, reject) => {
+      rawTx.oncomplete = () => resolve();
+      rawTx.onerror = () => reject(rawTx.error);
+      rawTx.onabort = () => reject(rawTx.error);
+    });
+    rawDb.close();
+
+    await addArticleComment({
+      conversationId: Number(canonical.id),
+      canonicalUrl: 'https://example.com/shared',
+      commentText: 'canonical owned root',
+      parentId: null,
+      createdAt: 1,
+    });
+    await addArticleComment({
+      conversationId: duplicateId,
+      canonicalUrl: 'https://example.com/shared',
+      commentText: 'duplicate owned root',
+      parentId: null,
+      createdAt: 2,
+    });
+    await addArticleComment({
+      conversationId: null,
+      canonicalUrl: 'https://example.com/shared',
+      commentText: 'shared orphan root',
+      parentId: null,
+      createdAt: 3,
+    });
+
+    const first = await getConversationListBootstrap({ sourceKey: 'all', siteKey: 'all', limit: 2 });
+    expect(first.items.map((item) => item.conversationKey)).toEqual([
+      'article:https://example.com/shared',
+      'article:historical-shared-copy',
+    ]);
+    expect(first.items.map((item) => item.commentThreadCount)).toEqual([2, 2]);
+    expect(first.hasMore).toBe(true);
+    expect(first.cursor).toEqual({ lastCapturedAt: now - 1, id: duplicateId });
+
+    const second = await getConversationListPage({ sourceKey: 'all', siteKey: 'all', limit: 2 }, first.cursor!);
+    expect(second.items.map((item) => item.conversationKey)).toEqual(['after-shared']);
+    expect(second.items[0]?.commentThreadCount).toBeUndefined();
+    expect(second.hasMore).toBe(false);
   });
 });

--- a/tests/storage/conversations-pagination.test.ts
+++ b/tests/storage/conversations-pagination.test.ts
@@ -121,71 +121,110 @@ describe('conversations pagination storage-idb', () => {
     expect(new Set(allIds).size).toBe(expectedIds.length);
   });
 
-  it('returns summary and facets without relying on full list materialization in UI', async () => {
-    const now = Date.now();
-    const old = now - 3 * 24 * 60 * 60 * 1000;
-    await upsertConversation({
-      sourceType: 'article',
-      source: 'web',
-      conversationKey: 'article:https://example.com/a',
-      title: 'a',
-      url: 'https://example.com/a',
-      lastCapturedAt: now,
-    });
-    await upsertConversation({
-      sourceType: 'article',
-      source: 'web',
-      conversationKey: 'article:https://example.com/b',
-      title: 'b',
-      url: 'https://example.com/b',
-      lastCapturedAt: old,
-    });
-    await upsertConversation({
-      sourceType: 'article',
-      source: 'web',
-      conversationKey: 'article:no-url',
-      title: 'c',
-      url: '',
-      lastCapturedAt: now,
-    });
-    await upsertConversation({
-      sourceType: 'chat',
-      source: 'chatgpt',
-      conversationKey: 'chat-1',
-      title: 'chat',
-      url: 'https://chatgpt.com/c/1',
-      lastCapturedAt: now,
-    });
-    await upsertConversation({
-      sourceType: 'chat',
-      source: 'gemini',
-      conversationKey: 'gemini-1',
-      title: 'gemini',
-      url: 'https://gemini.google.com/app/1',
-      lastCapturedAt: old,
-    });
+  it('counts summary scopes and facets from persisted list indexes without treating future rows as today', async () => {
+    const today = new Date();
+    today.setHours(12, 0, 0, 0);
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+    const tomorrow = new Date(today);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+
+    const rows = [
+      {
+        sourceType: 'article',
+        source: 'web',
+        conversationKey: 'article:https://example.com/today',
+        title: 'example today',
+        url: 'https://example.com/today',
+        lastCapturedAt: today.getTime(),
+      },
+      {
+        sourceType: 'article',
+        source: 'web',
+        conversationKey: 'article:https://example.com/yesterday',
+        title: 'example yesterday',
+        url: 'https://example.com/yesterday',
+        lastCapturedAt: yesterday.getTime(),
+      },
+      {
+        sourceType: 'article',
+        source: 'web',
+        conversationKey: 'article:https://other.example/today',
+        title: 'other today',
+        url: 'https://other.example/today',
+        lastCapturedAt: today.getTime(),
+      },
+      {
+        sourceType: 'article',
+        source: 'web',
+        conversationKey: 'article:no-url',
+        title: 'unknown today',
+        url: '',
+        lastCapturedAt: today.getTime(),
+      },
+      {
+        sourceType: 'article',
+        source: 'web',
+        conversationKey: 'article:https://future.example/tomorrow',
+        title: 'future',
+        url: 'https://future.example/tomorrow',
+        lastCapturedAt: tomorrow.getTime(),
+      },
+      {
+        sourceType: 'chat',
+        source: 'chatgpt',
+        conversationKey: 'chat-1',
+        title: 'chat',
+        url: 'https://chatgpt.com/c/1',
+        lastCapturedAt: today.getTime(),
+      },
+      {
+        sourceType: 'chat',
+        source: 'gemini',
+        conversationKey: 'gemini-1',
+        title: 'gemini',
+        url: 'https://gemini.google.com/app/1',
+        lastCapturedAt: yesterday.getTime(),
+      },
+    ];
+    for (const row of rows) await upsertConversation(row);
 
     const all = await getConversationListBootstrap({ sourceKey: 'all', siteKey: 'all', limit: 20 });
-    expect(all.summary.totalCount).toBe(5);
-    expect(all.summary.todayCount).toBe(3);
+    expect(all.summary).toEqual({ totalCount: 7, todayCount: 4 });
+    expect(new Map(all.facets.sources.map((item) => [item.key, item.count]))).toEqual(
+      new Map([
+        ['web', 5],
+        ['chatgpt', 1],
+        ['gemini', 1],
+      ]),
+    );
+    expect(new Map(all.facets.sites.map((item) => [item.key, item.count]))).toEqual(
+      new Map([
+        ['domain:example.com', 2],
+        ['domain:future.example', 1],
+        ['domain:other.example', 1],
+        ['unknown', 1],
+      ]),
+    );
 
-    const sourceCounts = new Map(all.facets.sources.map((item) => [item.key, item.count]));
-    expect(sourceCounts.get('web')).toBe(3);
-    expect(sourceCounts.get('chatgpt')).toBe(1);
-    expect(sourceCounts.get('gemini')).toBe(1);
+    const sourceOnly = await getConversationListBootstrap({ sourceKey: 'web', siteKey: 'all', limit: 20 });
+    expect(sourceOnly.summary).toEqual({ totalCount: 5, todayCount: 3 });
 
-    const siteCounts = new Map(all.facets.sites.map((item) => [item.key, item.count]));
-    expect(siteCounts.get('domain:example.com')).toBe(2);
-    expect(siteCounts.get('unknown')).toBe(1);
-
-    const filtered = await getConversationListBootstrap({
+    const sourceAndSite = await getConversationListBootstrap({
       sourceKey: 'web',
       siteKey: 'Example.COM',
       limit: 20,
     });
-    expect(filtered.summary.totalCount).toBe(2);
-    expect(filtered.items.every((item) => item.listSourceKey === 'web')).toBe(true);
-    expect(filtered.items.every((item) => item.listSiteKey === 'domain:example.com')).toBe(true);
+    expect(sourceAndSite.summary).toEqual({ totalCount: 2, todayCount: 1 });
+    expect(sourceAndSite.items.every((item) => item.listSourceKey === 'web')).toBe(true);
+    expect(sourceAndSite.items.every((item) => item.listSiteKey === 'domain:example.com')).toBe(true);
+
+    const siteOnly = await getConversationListBootstrap({ sourceKey: 'all', siteKey: 'example.com', limit: 20 });
+    expect(siteOnly.summary).toEqual({ totalCount: 2, todayCount: 1 });
+
+    const chatgpt = await getConversationListBootstrap({ sourceKey: 'chatgpt', siteKey: 'all', limit: 20 });
+    expect(chatgpt.summary).toEqual({ totalCount: 1, todayCount: 1 });
+    expect(chatgpt.facets.sites).toEqual([{ key: 'domain:chatgpt.com', label: 'chatgpt.com', count: 1 }]);
   });
 
   it('does not persist derived-key repairs while reading a fresh bootstrap', async () => {
@@ -223,6 +262,8 @@ describe('conversations pagination storage-idb', () => {
       listSourceKey: 'chatgpt',
       listSiteKey: 'domain:chatgpt.com',
     });
+    expect(bootstrap.facets.sources).toEqual([{ key: 'stale-source', label: 'stale-source', count: 1 }]);
+    expect(bootstrap.facets.sites).toEqual([]);
 
     const verifyTx = rawDb.transaction(['conversations'], 'readonly');
     const persisted = await reqToPromise<any>(
@@ -255,6 +296,61 @@ describe('conversations pagination storage-idb', () => {
     const refreshed = await getConversationListBootstrap({ sourceKey: 'all', siteKey: 'all', limit: 20 });
     expect(refreshed.items.map((item) => item.conversationKey)).toEqual(['tracked-bootstrap']);
     expect(refreshed.summary.totalCount).toBe(1);
+  });
+
+  it('reuses bootstrap summary and facets for continuation pages in the same list scope', async () => {
+    const now = Date.now();
+    await upsertConversation({
+      sourceType: 'chat',
+      source: 'chatgpt',
+      conversationKey: 'cache-1',
+      title: 'cache 1',
+      url: 'https://chatgpt.com/c/cache-1',
+      lastCapturedAt: now,
+    });
+    await upsertConversation({
+      sourceType: 'chat',
+      source: 'chatgpt',
+      conversationKey: 'cache-2',
+      title: 'cache 2',
+      url: 'https://chatgpt.com/c/cache-2',
+      lastCapturedAt: now - 1,
+    });
+
+    const first = await getConversationListBootstrap({ sourceKey: 'all', siteKey: 'all', limit: 1 });
+    expect(first.summary.totalCount).toBe(2);
+    expect(first.hasMore).toBe(true);
+    expect(first.cursor).toBeTruthy();
+
+    const rawDb = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open('webclipper');
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+    const rawTx = rawDb.transaction(['conversations'], 'readwrite');
+    rawTx.objectStore('conversations').add({
+      sourceType: 'chat',
+      source: 'gemini',
+      conversationKey: 'cache-external-newer',
+      title: 'external newer',
+      url: 'https://gemini.google.com/app/cache-external-newer',
+      lastCapturedAt: now + 1,
+      listSourceKey: 'gemini',
+      listSiteKey: 'domain:gemini.google.com',
+    });
+    await new Promise<void>((resolve, reject) => {
+      rawTx.oncomplete = () => resolve();
+      rawTx.onerror = () => reject(rawTx.error);
+      rawTx.onabort = () => reject(rawTx.error);
+    });
+    rawDb.close();
+
+    const continued = await getConversationListPage({ sourceKey: 'all', siteKey: 'all', limit: 1 }, first.cursor!);
+    expect(continued.summary).toEqual(first.summary);
+    expect(continued.facets).toEqual(first.facets);
+
+    const fresh = await getConversationListBootstrap({ sourceKey: 'all', siteKey: 'all', limit: 20 });
+    expect(fresh.summary.totalCount).toBe(3);
   });
 
   it('recomputes summary on a fresh bootstrap after an external IndexedDB write', async () => {

--- a/tests/storage/data-revisions.test.ts
+++ b/tests/storage/data-revisions.test.ts
@@ -408,10 +408,10 @@ describe('data revision storage', () => {
       }),
     ).rejects.toThrow('parent_not_root');
     expect(await readDataRevision('article_comments')).toBe(2);
-    expect(await deleteArticleCommentById(999_999)).toBe(false);
+    expect(await deleteArticleCommentById(999_999)).toEqual({ deleted: false, conversationId: null });
     expect(await readDataRevision('article_comments')).toBe(2);
 
-    expect(await deleteArticleCommentById(root.id)).toBe(true);
+    expect(await deleteArticleCommentById(root.id)).toEqual({ deleted: true, conversationId: null });
     expect(await readDataRevision('article_comments')).toBe(3);
 
     await addArticleComment({ conversationId: null, canonicalUrl: url, commentText: 'orphan' });


### PR DESCRIPTION
## Related issue

N/A — 本分支按已确认并完成审计的本地 feature plan `.github/features/performance-refractor 2026-08-31/plan-p2.md` 实施；未单独建立 issue。

## Why

P2 聚焦会话列表与文章评论存储路径的读放大和重复扫描问题。原实现中列表统计依赖全量值扫描、文章列表评论计数容易产生重复索引读取，评论级联删除还存在删除前上下文读取与事务内再次全表物化的重复工作。该类路径会随本地数据量增长放大启动、分页和删除延迟。

本 PR 将这些路径收敛到现有 IndexedDB 索引和单事务数据流，并删除被替代的旧兼容/辅助路径，同时用 request-count 回归测试锁定性能契约。

## Scope

### In scope

- 使用现有列表 compound indexes 计算 total/today/source/site summary，避免恢复全量 conversation store 扫描。
- 列表页文章评论计数按当前页批量 hydrate，并对共享 canonical URL 去重读取。
- 评论级联删除在单个 tracked transaction 内只物化一次 `article_comments`，同时完成 owner 解析、descendant 删除和 revision 提交。
- 删除已被替代的评论删除 context helper/type 与旧 summary helper。
- 增加本地日边界、comment index request-count、single-materialization 等回归测试。

### Non-goals

- 不新增公开 batch comments API。
- 不改变会话列表 `bootstrap + loadMore` 分页协议。
- 不改变文章评论 thread graph 的业务语义。
- 不改变 background 对外删除协议，客户端仍只看到 `{ ok: boolean }`。
- 不新增运行时性能埋点或第二套缓存/一致性协议。

## What changed

- `readConversationListPage` 的 summary/facets 改为基于既有 compound indexes 的 `count()` / key cursor；today range 使用本地日 `[start, nextStart)` 边界并排除未来时间。
- `readConversationListPageItems` 在 page cursor 完成后一次性 hydrate 当前页 article comment counts；conversationId 仍逐会话读取，但 canonical URL 查询按唯一 URL 去重，同一 URL 的多个 article 复用一次结果。
- `deleteArticleCommentById` 现在在一个 `runTrackedTransaction` 中执行一次 `article_comments.getAll()`，构建 `byId` / `childrenByParentId` 后解析 owner 与 descendants，成功删除时只 bump 一次 revision；missing target 为 no-op。
- background handler 只在事务提交成功且存在合法 conversationId 时触发 post-commit auto-sync。
- 删除 `getArticleCommentDeleteContextById`、`ArticleCommentDeleteContext`、`toDeleteContext`、`isSameLocalDayTimestamp` 等被替代路径。

## Architecture / invariants

- 会话列表继续使用 `bootstrap + loadMore`，没有恢复全量读取。
- storage writer 仍复用 canonical IndexedDB connection；评论删除与 revision 在同一 tracked transaction 中提交，结果只在 transaction complete 后返回。
- UI/viewmodel/service 依赖方向未改变。
- 新增测试锁定 T2 comment index request count 与 T3 `article_comments.getAll()` 单次物化，防止未来 correctness 仍通过但性能退化。

## Data, migration & recovery

- 没有 schema version 或持久化格式变更。
- summary/facet 继续以已持久化的 `listSourceKey/listSiteKey` 为索引事实真源；没有新增运行时 repair fallback。
- 评论删除成功时业务数据与 revision 同事务提交；missing target 不 bump revision。
- 事务失败时不会返回成功结果，也不会提前触发 auto-sync。

## Permissions & privacy

N/A — manifest permissions、OAuth scopes、secret storage、网络目标和本地数据出站行为均未改变。

## Compatibility

- IndexedDB schema 与对外 conversation/comments message protocol 均保持兼容。
- Intentional cleanup：删除仅服务于旧双扫描删除流程的内部 context helper/type；无外部 API 依赖。

## Demo

N/A — no visual behavior changed。

## Drawbacks / risks

- 列表统计依赖现有 persisted index keys 的不变量；该不变量已由当前 writers/migrations/import 路径和 schema migration 测试覆盖。
- 评论计数仍按 article conversationId 读取一次；本阶段只消除共享 URL 的重复读取及非 article 无效读取，没有引入更大的公共 batch API。

## Tests & validation

### Automated

- P2 phase matrix：`10 files / 77 tests PASS`。
- P2 二次审计新增 request-count 回归：T2 锁定 comment index 读取次数；T3 锁定 successful cascade delete 仅一次 `article_comments.getAll()`。
- 本地在 rebase 到最新 `origin/main` 后重新执行 `npm run gate:ci`：ESLint PASS、Prettier PASS、TypeScript compile PASS、`265 files / 1894 tests PASS`。
- 此前 P2 审计还执行 `npm run gate`，Chrome MV3 production build PASS。

### Manual

N/A — 本 PR 不改变视觉交互；核心行为通过 IndexedDB storage、background router、provider/list integration tests 覆盖。

## Documentation

本地 feature evidence 已更新：`audit-p2.md` 最终 Gate=`Go`，F-01 至 F-05 均为 `Resolved`。feature 目录按仓库工作流被 `.gitignore` 忽略，因此不进入代码 diff。
