### PR TITLE
优化图片资源批量读取与回填持久化性能

### DIFF
--- a/src/services/conversations/background/handlers.ts
+++ b/src/services/conversations/background/handlers.ts
@@ -316,21 +316,10 @@ export function registerConversationHandlers(router: AnyRouter, deps: Conversati
     const conversationId = Number(msg.conversationId);
     if (!Number.isFinite(conversationId) || conversationId <= 0) return router.err('invalid conversationId');
     const conversationUrl = String(msg?.conversationUrl || '').trim();
-    let progressEnqueued = false;
-    const res = await backfillConversationImages({
-      conversationId,
-      conversationUrl,
-      onProgress: async (progress) => {
-        const updatedMessages = Number(progress?.updatedMessages) || 0;
-        if (updatedMessages <= 0) return;
-        if (progressEnqueued) return;
-        progressEnqueued = true;
-        fireAndForget(
-          deps.onConversationChanged(conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.backfillImages),
-        );
-      },
-    });
-    fireAndForget(deps.onConversationChanged(conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.backfillImages));
+    const res = await backfillConversationImages({ conversationId, conversationUrl });
+    if (Number(res?.updatedMessages) > 0) {
+      fireAndForget(deps.onConversationChanged(conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.backfillImages));
+    }
     return router.ok(res);
   });
 

--- a/src/services/conversations/background/image-backfill-job.ts
+++ b/src/services/conversations/background/image-backfill-job.ts
@@ -1,4 +1,8 @@
-import { getMessagesByConversationId, syncConversationMessages } from '@services/conversations/data/storage-idb';
+import {
+  getMessagesByConversationId,
+  patchConversationMessageMarkdownBatch,
+  type ConversationMessageMarkdownPatch,
+} from '@services/conversations/data/storage-idb';
 import { inlineChatImagesInMessages } from '@services/conversations/data/image-inline';
 
 export type BackfillConversationImagesResult = {
@@ -11,21 +15,9 @@ export type BackfillConversationImagesResult = {
   warningFlags: string[];
 };
 
-export type BackfillConversationImagesProgress = {
-  scannedMessages: number;
-  updatedMessages: number;
-  inlinedCount: number;
-  fromCacheCount: number;
-  downloadedCount: number;
-  inlinedBytes: number;
-  warningFlags: string[];
-  latestMessageKey?: string;
-};
-
 export async function backfillConversationImages(input: {
   conversationId: number;
   conversationUrl?: string;
-  onProgress?: (progress: BackfillConversationImagesProgress) => Promise<void> | void;
 }): Promise<BackfillConversationImagesResult> {
   const conversationId = Number(input.conversationId);
   if (!Number.isFinite(conversationId) || conversationId <= 0) {
@@ -40,58 +32,29 @@ export async function backfillConversationImages(input: {
     beforeMarkdown.set(key, String((msg as any).contentMarkdown || ''));
   }
 
-  const progressCallback = typeof input.onProgress === 'function' ? input.onProgress : null;
-  const persistedUpdatedKeys = new Set<string>();
-
   const inlined = await inlineChatImagesInMessages({
     conversationId,
     conversationUrl: input.conversationUrl,
     messages: messages as any,
-    onMessageUpdated: progressCallback
-      ? async (update) => {
-          const key = String(update?.messageKey || '').trim();
-          if (!key) return;
-          if (persistedUpdatedKeys.has(key)) return;
-
-          await syncConversationMessages(conversationId, [update.message], {
-            mode: 'incremental',
-            diff: { added: [], updated: [key], removed: [] },
-          });
-          persistedUpdatedKeys.add(key);
-
-          await progressCallback({
-            scannedMessages: messages.length,
-            updatedMessages: persistedUpdatedKeys.size,
-            inlinedCount: Number(update?.inlinedCount) || 0,
-            fromCacheCount: Number(update?.fromCacheCount) || 0,
-            downloadedCount: Number(update?.downloadedCount) || 0,
-            inlinedBytes: Number(update?.inlinedBytes) || 0,
-            warningFlags: Array.isArray(update?.warningFlags) ? update.warningFlags : [],
-            latestMessageKey: key,
-          });
-        }
-      : undefined,
   });
 
-  const updatedKeys: string[] = [];
+  const patches: ConversationMessageMarkdownPatch[] = [];
   for (const msg of inlined.messages) {
     const key = msg && msg.messageKey ? String(msg.messageKey) : '';
-    if (!key) continue;
+    if (!key || !beforeMarkdown.has(key)) continue;
     const before = beforeMarkdown.get(key) ?? '';
     const after = String(msg.contentMarkdown || '');
-    if (after && after !== before) updatedKeys.push(key);
+    if (after === before) continue;
+    patches.push({ messageKey: key, beforeMarkdown: before, afterMarkdown: after });
   }
 
-  if (updatedKeys.length && !progressCallback) {
-    await syncConversationMessages(conversationId, inlined.messages, {
-      mode: 'incremental',
-      diff: { added: [], updated: updatedKeys, removed: [] },
-    });
-  }
+  const patchResult = patches.length
+    ? await patchConversationMessageMarkdownBatch(conversationId, patches)
+    : { updated: 0, conflicts: 0 };
 
   return {
     scannedMessages: messages.length,
-    updatedMessages: updatedKeys.length,
+    updatedMessages: patchResult.updated,
     inlinedCount: inlined.inlinedCount,
     fromCacheCount: inlined.fromCacheCount,
     downloadedCount: inlined.downloadedCount,

--- a/src/services/conversations/data/image-cache-read.ts
+++ b/src/services/conversations/data/image-cache-read.ts
@@ -122,23 +122,18 @@ function txDone(t: IDBTransaction): Promise<true> {
   });
 }
 
-export async function getImageCacheAssetById(input: {
+function normalizeImageCacheAsset(input: {
   id: number;
-  conversationId?: number | null;
-}): Promise<ImageCacheAsset | null> {
-  const id = Number(input.id);
-  if (!Number.isFinite(id) || id <= 0) return null;
-
-  const db = await openDb();
-  const { t, stores } = tx(db, ['image_cache'], 'readonly');
-  const row = (await reqToPromise(stores.image_cache.get(id as any) as any)) as ImageCacheRow | undefined;
-  await txDone(t);
-
+  row: ImageCacheRow | undefined;
+  expectedConversationId?: number | null;
+}): ImageCacheAsset | null {
+  const { id, row } = input;
   if (!row) return null;
+
   const conversationId = Number(row.conversationId);
   if (!Number.isFinite(conversationId) || conversationId <= 0) return null;
 
-  const expectedConversationId = Number(input.conversationId);
+  const expectedConversationId = Number(input.expectedConversationId);
   if (
     Number.isFinite(expectedConversationId) &&
     expectedConversationId > 0 &&
@@ -158,7 +153,7 @@ export async function getImageCacheAssetById(input: {
     const copy = new ArrayBuffer(view.byteLength);
     new Uint8Array(copy).set(new Uint8Array(view.buffer, view.byteOffset, view.byteLength));
     blob = new Blob([copy], { type: parseContentType(row.contentType) });
-  } else if (!blob && row.dataUrl) {
+  } else if (row.dataUrl) {
     blob = decodeDataImageUrlToBlob(row.dataUrl);
   }
 
@@ -178,4 +173,46 @@ export async function getImageCacheAssetById(input: {
     byteSize,
     contentType,
   };
+}
+
+export async function getImageCacheAssetsByIds(input: {
+  ids: Iterable<number>;
+  conversationId?: number | null;
+}): Promise<Map<number, ImageCacheAsset>> {
+  const ids: number[] = [];
+  const seen = new Set<number>();
+  for (const rawId of input.ids) {
+    const id = Number(rawId);
+    if (!Number.isFinite(id) || id <= 0 || seen.has(id)) continue;
+    seen.add(id);
+    ids.push(id);
+  }
+  if (!ids.length) return new Map();
+
+  const db = await openDb();
+  const { t, stores } = tx(db, ['image_cache'], 'readonly');
+  const done = txDone(t);
+  const rowRequests = ids.map((id) =>
+    reqToPromise(stores.image_cache.get(id as any) as IDBRequest<ImageCacheRow | undefined>).then(
+      (row) => [id, row] as const,
+    ),
+  );
+  const [rows] = await Promise.all([Promise.all(rowRequests), done]);
+
+  const assets = new Map<number, ImageCacheAsset>();
+  for (const [id, row] of rows) {
+    const asset = normalizeImageCacheAsset({ id, row, expectedConversationId: input.conversationId });
+    if (asset) assets.set(id, asset);
+  }
+  return assets;
+}
+
+export async function getImageCacheAssetById(input: {
+  id: number;
+  conversationId?: number | null;
+}): Promise<ImageCacheAsset | null> {
+  const id = Number(input.id);
+  if (!Number.isFinite(id) || id <= 0) return null;
+  const assets = await getImageCacheAssetsByIds({ ids: [id], conversationId: input.conversationId });
+  return assets.get(id) ?? null;
 }

--- a/src/services/conversations/data/image-inline.ts
+++ b/src/services/conversations/data/image-inline.ts
@@ -154,12 +154,15 @@ function utf8ToBytes(text: string): Uint8Array {
   return out;
 }
 
-function parseDataImageUrl(input: {
-  dataUrl: string;
-  maxBytes: number;
-}):
-  | { ok: true; blob: Blob; byteSize: number; contentType: string; cacheKey: string }
-  | { ok: false; reason: 'non_image' | 'empty' | 'too_large' | 'fetch' } {
+type DataImageFailure = { ok: false; reason: 'non_image' | 'empty' | 'too_large' | 'fetch' };
+type DataImageDescriptor =
+  | { ok: true; byteSize: number; contentType: string; cacheKey: string }
+  | DataImageFailure;
+type DecodedDataImage =
+  | { ok: true; bytes: Uint8Array; byteSize: number; contentType: string; cacheKey: string }
+  | DataImageFailure;
+
+function decodeDataImageUrl(input: { dataUrl: string; maxBytes: number }): DecodedDataImage {
   const safeDataUrl = String(input.dataUrl || '').trim();
   if (!isDataImageUrl(safeDataUrl)) return { ok: false, reason: 'non_image' };
 
@@ -197,20 +200,67 @@ function parseDataImageUrl(input: {
   }
   const hashHex = hash.toString(16).padStart(16, '0');
   const cacheKey = `data:${contentType};fnv1a64=${hashHex}`;
-
-  const blob = new Blob([Uint8Array.from(bytes)], { type: contentType });
-  return { ok: true, blob, byteSize, contentType, cacheKey };
+  return { ok: true, bytes, byteSize, contentType, cacheKey };
 }
 
-async function getCachedImage(conversationId: number, url: string): Promise<ImageCacheRow | null> {
-  const safeUrl = String(url || '').trim();
-  if (!safeUrl) return null;
+function describeDataImageUrl(input: { dataUrl: string; maxBytes: number }): DataImageDescriptor {
+  const decoded = decodeDataImageUrl(input);
+  if (!decoded.ok) return decoded;
+  return {
+    ok: true,
+    byteSize: decoded.byteSize,
+    contentType: decoded.contentType,
+    cacheKey: decoded.cacheKey,
+  };
+}
+
+function parseDataImageUrl(input: {
+  dataUrl: string;
+  maxBytes: number;
+}):
+  | { ok: true; blob: Blob; byteSize: number; contentType: string; cacheKey: string }
+  | DataImageFailure {
+  const decoded = decodeDataImageUrl(input);
+  if (!decoded.ok) return decoded;
+  return {
+    ok: true,
+    blob: new Blob([Uint8Array.from(decoded.bytes)], { type: decoded.contentType }),
+    byteSize: decoded.byteSize,
+    contentType: decoded.contentType,
+    cacheKey: decoded.cacheKey,
+  };
+}
+
+async function getCachedImagesByUrls(
+  conversationId: number,
+  urls: readonly string[],
+): Promise<Map<string, ImageCacheRow>> {
+  const lookupUrls: string[] = [];
+  const seen = new Set<string>();
+  for (const rawUrl of urls) {
+    const url = String(rawUrl || '').trim();
+    if (!url || seen.has(url)) continue;
+    seen.add(url);
+    lookupUrls.push(url);
+  }
+  if (!lookupUrls.length) return new Map();
+
   const db = await openDb();
   const { t, stores } = tx(db, ['image_cache'], 'readonly');
+  const done = txDone(t);
   const idx = stores.image_cache.index('by_conversationId_url');
-  const row = (await reqToPromise(idx.get([conversationId, safeUrl]) as any)) as ImageCacheRow | undefined;
-  await txDone(t);
-  return row || null;
+  const requests = lookupUrls.map((url) =>
+    reqToPromise(idx.get([conversationId, url]) as IDBRequest<ImageCacheRow | undefined>).then(
+      (row) => [url, row] as const,
+    ),
+  );
+  const [rows] = await Promise.all([Promise.all(requests), done]);
+
+  const cached = new Map<string, ImageCacheRow>();
+  for (const [url, row] of rows) {
+    if (row) cached.set(url, row);
+  }
+  return cached;
 }
 
 async function upsertCachedImageAsset(input: {
@@ -385,6 +435,41 @@ export async function inlineChatImagesInMessages(input: {
   const onlyKeys = input.onlyMessageKeys || null;
   const enableHttpImages = input.enableHttpImages !== false;
 
+  const dataDescriptorByUrl = new Map<string, DataImageDescriptor>();
+  const cacheLookupUrls: string[] = [];
+  const seenCacheLookupUrls = new Set<string>();
+  const addCacheLookupUrl = (url: string) => {
+    if (!url || seenCacheLookupUrls.has(url)) return;
+    seenCacheLookupUrls.add(url);
+    cacheLookupUrls.push(url);
+  };
+
+  for (const msg of messages) {
+    if (!msg || !msg.messageKey) continue;
+    if (onlyKeys && !onlyKeys.has(String(msg.messageKey))) continue;
+    const markdown = msg.contentMarkdown && String(msg.contentMarkdown).trim() ? String(msg.contentMarkdown) : '';
+    if (!markdown) continue;
+
+    for (const url of extractInlineCandidateUrlsFromMarkdown(markdown)) {
+      const isDataUrl = isDataImageUrl(url);
+      const isHttpImage = !isDataUrl && isHttpUrl(url);
+      if (!isDataUrl && !isHttpImage) continue;
+      if (isHttpImage && !enableHttpImages) continue;
+      if (isDataUrl) {
+        if (!dataDescriptorByUrl.has(url)) {
+          dataDescriptorByUrl.set(url, describeDataImageUrl({ dataUrl: url, maxBytes: NO_IMAGE_SIZE_LIMIT }));
+        }
+        const descriptor = dataDescriptorByUrl.get(url)!;
+        if (!descriptor.ok) continue;
+        addCacheLookupUrl(descriptor.cacheKey);
+        addCacheLookupUrl(url);
+      } else {
+        addCacheLookupUrl(url);
+      }
+    }
+  }
+
+  const cachedByUrl = await getCachedImagesByUrls(conversationId, cacheLookupUrls);
   const replacements = new Map<string, string>();
   const warningFlags = new Set<string>();
   let inlinedCount = 0;
@@ -409,23 +494,18 @@ export async function inlineChatImagesInMessages(input: {
       if (!isDataUrl && !isHttpImage) continue;
       if (isHttpImage && !enableHttpImages) continue;
 
-      let parsedDataUrl:
-        | { ok: true; blob: Blob; byteSize: number; contentType: string; cacheKey: string }
-        | { ok: false; reason: 'non_image' | 'empty' | 'too_large' | 'fetch' }
-        | null = null;
       let cacheLookupUrl = url;
       if (isDataUrl) {
-        parsedDataUrl = parseDataImageUrl({ dataUrl: url, maxBytes: NO_IMAGE_SIZE_LIMIT });
-        if (!parsedDataUrl.ok) {
+        const descriptor =
+          dataDescriptorByUrl.get(url) || describeDataImageUrl({ dataUrl: url, maxBytes: NO_IMAGE_SIZE_LIMIT });
+        if (!descriptor.ok) {
           warningFlags.add('inline_images_download_failed');
           continue;
         }
-        cacheLookupUrl = parsedDataUrl.cacheKey;
+        cacheLookupUrl = descriptor.cacheKey;
       }
 
-      const cached =
-        (await getCachedImage(conversationId, cacheLookupUrl)) ||
-        (isDataUrl ? await getCachedImage(conversationId, url) : null);
+      const cached = cachedByUrl.get(cacheLookupUrl) || (isDataUrl ? cachedByUrl.get(url) : undefined);
       if (cached) {
         const cachedAsset = await ensureCachedAssetRecord(cached);
         if (cachedAsset) {
@@ -439,8 +519,12 @@ export async function inlineChatImagesInMessages(input: {
 
       let nextAsset: CachedAsset | null = null;
       if (isDataUrl) {
-        const parsed = parsedDataUrl && parsedDataUrl.ok ? parsedDataUrl : null;
-        if (!parsed) continue;
+        // ponytail: 预扫描只保留 cacheKey；cache miss 在原处理位置二次解码，避免整批 Blob 常驻。只有 profiling 证明 CPU 成本更高时才缓存解码结果。
+        const parsed = parseDataImageUrl({ dataUrl: url, maxBytes: NO_IMAGE_SIZE_LIMIT });
+        if (!parsed.ok) {
+          warningFlags.add('inline_images_download_failed');
+          continue;
+        }
 
         nextAsset = await upsertCachedImageAsset({
           conversationId,

--- a/src/services/conversations/data/image-inline.ts
+++ b/src/services/conversations/data/image-inline.ts
@@ -155,9 +155,7 @@ function utf8ToBytes(text: string): Uint8Array {
 }
 
 type DataImageFailure = { ok: false; reason: 'non_image' | 'empty' | 'too_large' | 'fetch' };
-type DataImageDescriptor =
-  | { ok: true; byteSize: number; contentType: string; cacheKey: string }
-  | DataImageFailure;
+type DataImageDescriptor = { ok: true; byteSize: number; contentType: string; cacheKey: string } | DataImageFailure;
 type DecodedDataImage =
   | { ok: true; bytes: Uint8Array; byteSize: number; contentType: string; cacheKey: string }
   | DataImageFailure;
@@ -217,9 +215,7 @@ function describeDataImageUrl(input: { dataUrl: string; maxBytes: number }): Dat
 function parseDataImageUrl(input: {
   dataUrl: string;
   maxBytes: number;
-}):
-  | { ok: true; blob: Blob; byteSize: number; contentType: string; cacheKey: string }
-  | DataImageFailure {
+}): { ok: true; blob: Blob; byteSize: number; contentType: string; cacheKey: string } | DataImageFailure {
   const decoded = decodeDataImageUrl(input);
   if (!decoded.ok) return decoded;
   return {

--- a/src/services/conversations/data/image-inline.ts
+++ b/src/services/conversations/data/image-inline.ts
@@ -373,23 +373,12 @@ export type InlineChatImagesResult = {
   warningFlags: string[];
 };
 
-export type InlineChatImageMessageUpdate = {
-  messageKey: string;
-  message: any;
-  inlinedCount: number;
-  fromCacheCount: number;
-  downloadedCount: number;
-  inlinedBytes: number;
-  warningFlags: string[];
-};
-
 export async function inlineChatImagesInMessages(input: {
   conversationId: number;
   conversationUrl?: string;
   messages: any[];
   onlyMessageKeys?: Set<string> | null;
   enableHttpImages?: boolean;
-  onMessageUpdated?: (update: InlineChatImageMessageUpdate) => Promise<void> | void;
 }): Promise<InlineChatImagesResult> {
   const conversationId = Number(input.conversationId);
   const messages = Array.isArray(input.messages) ? input.messages : [];
@@ -488,20 +477,7 @@ export async function inlineChatImagesInMessages(input: {
 
     if (!replacements.size) continue;
     const nextMarkdown = replaceMarkdownImageUrls(markdown, replacements);
-    if (nextMarkdown !== markdown) {
-      msg.contentMarkdown = nextMarkdown;
-      if (typeof input.onMessageUpdated === 'function') {
-        await input.onMessageUpdated({
-          messageKey: String(msg.messageKey || '').trim(),
-          message: msg,
-          inlinedCount,
-          fromCacheCount,
-          downloadedCount,
-          inlinedBytes,
-          warningFlags: Array.from(warningFlags),
-        });
-      }
-    }
+    if (nextMarkdown !== markdown) msg.contentMarkdown = nextMarkdown;
   }
 
   return {

--- a/src/services/conversations/data/storage-idb.ts
+++ b/src/services/conversations/data/storage-idb.ts
@@ -834,11 +834,17 @@ export async function syncConversationMessages(
             ? upsertKeys.filter((key) => byKey.get(key)?.captureSequencePolicy === 'reconcile-existing-order')
             : [];
         const sequenceOverrides = new Map<string, number>();
+        let existingByKey: Map<unknown, any> | null = null;
         let nextTailSequence = 0;
         if (hasTailPolicy || reconcileKeys.length) {
           const seqIdx = stores.messages.index('by_conversationId_sequence');
           const range = IDBKeyRange.bound([conversationId, -Infinity] as any, [conversationId, Infinity] as any);
           const storedRows = (await reqToPromise(seqIdx.getAll(range) as any)) as any[];
+          existingByKey = new Map<unknown, any>();
+          for (const row of storedRows) {
+            if (!row || !Object.prototype.hasOwnProperty.call(row, 'messageKey')) continue;
+            existingByKey.set(row.messageKey, row);
+          }
           const finiteSequences = storedRows
             .map((row) => Number(row?.sequence))
             .filter((sequence) => Number.isFinite(sequence));
@@ -856,7 +862,9 @@ export async function syncConversationMessages(
                 const key = safeString(row?.messageKey);
                 const sequence = sequenceByKey.get(key);
                 if (sequence === undefined || Number(row?.sequence) === sequence) continue;
-                await reqToPromise(stores.messages.put({ ...row, sequence }));
+                const nextRow = { ...row, sequence };
+                await reqToPromise(stores.messages.put(nextRow));
+                existingByKey.set(row?.messageKey, nextRow);
                 markChanged('messages');
               }
               nextTailSequence = reconciled.keys.length;
@@ -869,7 +877,9 @@ export async function syncConversationMessages(
           const m = byKey.get(key);
           if (!m) continue;
 
-          const existing: any = await reqToPromise(idx.get([conversationId, key]) as any);
+          const existing: any = existingByKey
+            ? existingByKey.get(key)
+            : await reqToPromise(idx.get([conversationId, key]) as any);
           const reconcileSequence =
             mode === 'append' && m.captureSequencePolicy === 'reconcile-existing-order'
               ? sequenceOverrides.get(key)
@@ -923,6 +933,7 @@ export async function syncConversationMessages(
             record.id = id as any;
             markChanged('messages');
           }
+          existingByKey?.set(key, record);
           upserted += 1;
         }
 
@@ -939,6 +950,15 @@ export async function syncConversationMessages(
         return { upserted, deleted };
       }
 
+      const seqIdx = stores.messages.index('by_conversationId_sequence');
+      const range = IDBKeyRange.bound([conversationId, -Infinity] as any, [conversationId, Infinity] as any);
+      const storedRows = (await reqToPromise(seqIdx.getAll(range) as any)) as any[];
+      const existingByKey = new Map<unknown, any>();
+      for (const row of storedRows) {
+        if (!row || !Object.prototype.hasOwnProperty.call(row, 'messageKey')) continue;
+        existingByKey.set(row.messageKey, row);
+      }
+
       const presentKeys = new Set<string>();
       let upserted = 0;
 
@@ -946,7 +966,7 @@ export async function syncConversationMessages(
         if (!m || !m.messageKey) continue;
         presentKeys.add(String(m.messageKey));
 
-        const existing: any = await reqToPromise(idx.get([conversationId, m.messageKey]) as any);
+        const existing: any = existingByKey.get(m.messageKey);
         const incomingMarkdown = m.contentMarkdown && String(m.contentMarkdown).trim() ? String(m.contentMarkdown) : '';
         const incomingAuthorName = m.authorName && String(m.authorName).trim() ? String(m.authorName).trim() : '';
         const timestamp = resolveMessageTimestamp(existing, m.updatedAt, false);
@@ -971,12 +991,10 @@ export async function syncConversationMessages(
           record.id = id as any;
           markChanged('messages');
         }
+        existingByKey.set(m.messageKey, record);
         upserted += 1;
       }
 
-      const seqIdx = stores.messages.index('by_conversationId_sequence');
-      const range = IDBKeyRange.bound([conversationId, -Infinity] as any, [conversationId, Infinity] as any);
-      const storedRows = (await reqToPromise(seqIdx.getAll(range) as any)) as any[];
       let deleted = 0;
       for (const row of Array.isArray(storedRows) ? storedRows : []) {
         if (!row?.messageKey || presentKeys.has(String(row.messageKey))) continue;

--- a/src/services/conversations/data/storage-idb.ts
+++ b/src/services/conversations/data/storage-idb.ts
@@ -785,6 +785,67 @@ function mergeAnchoredMessageOrder(
   return { keys: merged, anchored: true, changed };
 }
 
+export type ConversationMessageMarkdownPatch = {
+  messageKey: string;
+  beforeMarkdown: string;
+  afterMarkdown: string;
+};
+
+export async function patchConversationMessageMarkdownBatch(
+  conversationId: number,
+  patches: ConversationMessageMarkdownPatch[],
+): Promise<{ updated: number; conflicts: number }> {
+  const safeConversationId = Number(conversationId);
+  if (!Number.isFinite(safeConversationId) || safeConversationId <= 0) throw new Error('invalid conversationId');
+
+  const uniqueByKey = new Map<string, ConversationMessageMarkdownPatch>();
+  for (const rawPatch of Array.isArray(patches) ? patches : []) {
+    const messageKey = String(rawPatch?.messageKey || '');
+    if (!messageKey.trim()) continue;
+    const patch: ConversationMessageMarkdownPatch = {
+      messageKey,
+      beforeMarkdown: String(rawPatch?.beforeMarkdown ?? ''),
+      afterMarkdown: String(rawPatch?.afterMarkdown ?? ''),
+    };
+    const previous = uniqueByKey.get(messageKey);
+    if (previous) {
+      if (previous.beforeMarkdown !== patch.beforeMarkdown || previous.afterMarkdown !== patch.afterMarkdown) {
+        throw new Error(`conflicting Markdown patches for messageKey: ${messageKey}`);
+      }
+      continue;
+    }
+    uniqueByKey.set(messageKey, patch);
+  }
+
+  const effectivePatches = Array.from(uniqueByKey.values()).filter(
+    (patch) => patch.beforeMarkdown !== patch.afterMarkdown,
+  );
+  if (!effectivePatches.length) return { updated: 0, conflicts: 0 };
+
+  const db = await openDb();
+  return runTrackedTransaction(
+    { db, stores: ['messages'], revisionScopes: ['messages'] },
+    async ({ stores, markChanged }) => {
+      const idx = stores.messages.index('by_conversationId_messageKey');
+      let updated = 0;
+      let conflicts = 0;
+
+      for (const patch of effectivePatches) {
+        const latest = (await reqToPromise(idx.get([safeConversationId, patch.messageKey]) as any)) as any;
+        if (!latest || String(latest.contentMarkdown || '') !== patch.beforeMarkdown) {
+          conflicts += 1;
+          continue;
+        }
+        await reqToPromise(stores.messages.put({ ...latest, contentMarkdown: patch.afterMarkdown }));
+        markChanged('messages');
+        updated += 1;
+      }
+
+      return { updated, conflicts };
+    },
+  );
+}
+
 export async function syncConversationMessages(
   conversationId: number,
   messages: any[],

--- a/src/services/sync/feishu/docx/feishu-docx-image-preprocess.ts
+++ b/src/services/sync/feishu/docx/feishu-docx-image-preprocess.ts
@@ -1,5 +1,9 @@
 import { sha256Hex } from '@services/sync/shared/content-hash';
-import { getImageCacheAssetById } from '@services/conversations/data/image-cache-read';
+import {
+  getImageCacheAssetsByIds,
+  type ImageCacheAsset,
+} from '@services/conversations/data/image-cache-read';
+import { parseSyncnosAssetId } from '@services/sync/shared/markdown-asset-refs';
 
 function safeString(v: unknown) {
   return String(v == null ? '' : v).trim();
@@ -17,13 +21,6 @@ function isHttpUrl(url: string): boolean {
 
 function isDataImageUrl(url: string): boolean {
   return /^data:image\/[a-z0-9.+-]+(?:;charset=[a-z0-9._-]+)?;base64,/i.test(safeString(url));
-}
-
-function parseSyncnosAssetId(url: string): number {
-  const m = /^syncnos-asset:\/\/(\d+)$/i.exec(safeString(url));
-  if (!m) return 0;
-  const id = Number(m[1]);
-  return Number.isFinite(id) && id > 0 ? id : 0;
 }
 
 function normalizeImageExt(ext: string): string {
@@ -101,6 +98,21 @@ export async function preprocessFeishuDocxMarkdownImages(markdown: string): Prom
   const src = String(markdown || '');
   if (!src) return { markdownForConvert: '', imageSourcesInOrder: [] };
 
+  const localAssetIds: number[] = [];
+  const seenLocalAssetIds = new Set<number>();
+  MARKDOWN_IMAGE_RE.lastIndex = 0;
+  let assetMatch: RegExpExecArray | null = null;
+  while ((assetMatch = MARKDOWN_IMAGE_RE.exec(src)) != null) {
+    const sourceUrl = stripAngleBrackets(assetMatch[2] || '');
+    const assetId = parseSyncnosAssetId(sourceUrl);
+    if (assetId == null || seenLocalAssetIds.has(assetId)) continue;
+    seenLocalAssetIds.add(assetId);
+    localAssetIds.push(assetId);
+  }
+
+  const localAssets: Map<number, ImageCacheAsset> = localAssetIds.length
+    ? await getImageCacheAssetsByIds({ ids: localAssetIds }).catch(() => new Map<number, ImageCacheAsset>())
+    : new Map<number, ImageCacheAsset>();
   const cache = new Map<string, Promise<FeishuMarkdownImageSource>>();
   const imageSourcesInOrder: FeishuMarkdownImageSource[] = [];
 
@@ -126,8 +138,8 @@ export async function preprocessFeishuDocxMarkdownImages(markdown: string): Prom
           }
 
           const assetId = parseSyncnosAssetId(sourceUrl);
-          if (assetId) {
-            const asset = await getImageCacheAssetById({ id: assetId }).catch(() => null);
+          if (assetId != null) {
+            const asset = localAssets.get(assetId) || null;
             const contentType = safeString(asset?.contentType);
             const ext = extFromContentType(contentType || 'image/png');
             const blob = asset?.blob instanceof Blob ? asset.blob : undefined;

--- a/src/services/sync/feishu/docx/feishu-docx-image-preprocess.ts
+++ b/src/services/sync/feishu/docx/feishu-docx-image-preprocess.ts
@@ -1,8 +1,5 @@
 import { sha256Hex } from '@services/sync/shared/content-hash';
-import {
-  getImageCacheAssetsByIds,
-  type ImageCacheAsset,
-} from '@services/conversations/data/image-cache-read';
+import { getImageCacheAssetsByIds, type ImageCacheAsset } from '@services/conversations/data/image-cache-read';
 import { parseSyncnosAssetId } from '@services/sync/shared/markdown-asset-refs';
 
 function safeString(v: unknown) {

--- a/src/services/sync/github/github-markdown-projection.ts
+++ b/src/services/sync/github/github-markdown-projection.ts
@@ -1,6 +1,6 @@
 import type { ArticleCommentDto } from '@services/comments/domain/comment-dto';
 import { buildConversationBasename } from '@services/conversations/domain/file-naming';
-import { getImageCacheAssetById, type ImageCacheAsset } from '@services/conversations/data/image-cache-read';
+import { getImageCacheAssetsByIds, type ImageCacheAsset } from '@services/conversations/data/image-cache-read';
 import { sha256Hex } from '@services/sync/github/github-content-hash';
 import { isGithubManagedPathOwnedByConversation } from '@services/sync/github/github-managed-path-ownership';
 import { GITHUB_OUTPUT_FOLDERS } from '@services/sync/github/settings-store';
@@ -46,7 +46,10 @@ export type GithubMarkdownProjection = {
   warnings: GithubProjectionWarning[];
 };
 
-export type GithubImageLoader = (input: { id: number; conversationId: number }) => Promise<ImageCacheAsset | null>;
+export type GithubImageBatchLoader = (input: {
+  ids: readonly number[];
+  conversationId: number;
+}) => Promise<Map<number, ImageCacheAsset>>;
 export type GithubBlobUploader = (input: { content: Uint8Array }) => Promise<{ sha: string }>;
 
 function folderForConversation(conversation: any): string {
@@ -159,7 +162,7 @@ export async function buildGithubMarkdownProjection(input: {
   comments?: ArticleCommentDto[];
   remoteKey?: string;
   continuity?: GithubProjectionContinuity;
-  imageLoader?: GithubImageLoader;
+  imageBatchLoader?: GithubImageBatchLoader;
   blobUploader?: GithubBlobUploader;
 }): Promise<GithubMarkdownProjection> {
   const conversation = input.conversation || {};
@@ -179,10 +182,11 @@ export async function buildGithubMarkdownProjection(input: {
     throw new Error('github_conversation_id_required');
   }
 
-  const imageLoader = input.imageLoader ?? getImageCacheAssetById;
+  const imageBatchLoader = input.imageBatchLoader ?? getImageCacheAssetsByIds;
   const blobUploader = input.blobUploader ?? null;
   if (assetIds.length && !blobUploader) throw new Error('github_blob_uploader_required');
 
+  const assetsById = assetIds.length ? await imageBatchLoader({ ids: assetIds, conversationId }) : new Map();
   const remoteKey = String(input.remoteKey || '');
   const namespace = attachmentNamespace(markdownPath);
   const replacementByAssetId = new Map<number, { target?: string; placeholder?: true }>();
@@ -190,7 +194,7 @@ export async function buildGithubMarkdownProjection(input: {
   const warnings: GithubProjectionWarning[] = [];
 
   for (const assetId of assetIds) {
-    const asset = await imageLoader({ id: assetId, conversationId });
+    const asset = assetsById.get(assetId) || null;
     if (!asset || !(asset.blob instanceof Blob)) {
       replacementByAssetId.set(assetId, { placeholder: true });
       warnings.push({ code: 'image_missing', assetId });

--- a/src/services/sync/github/github-orchestrator-services.ts
+++ b/src/services/sync/github/github-orchestrator-services.ts
@@ -1,6 +1,6 @@
 import { backgroundStorage } from '@services/conversations/background/storage';
 import { GITHUB_AUTO_SYNC_DEBOUNCE_MS } from '@services/sync/auto-sync/auto-sync-keys';
-import { getImageCacheAssetById } from '@services/conversations/data/image-cache-read';
+import { getImageCacheAssetsByIds } from '@services/conversations/data/image-cache-read';
 import {
   ackGithubCleanupRows,
   deferGithubCleanupRows,
@@ -37,7 +37,7 @@ export type GithubOrchestratorServices = {
   getSettings: () => Promise<GithubSettings>;
   preflight: (input: { repository: string; branch: string }) => Promise<GithubRepositoryPreflight>;
   storage: GithubOrchestratorStorage;
-  loadImage: typeof getImageCacheAssetById;
+  loadImages: typeof getImageCacheAssetsByIds;
   createBlob: (input: { repository: string; content: Uint8Array }) => Promise<{ sha: string }>;
   commit: (input: {
     repository: string;
@@ -58,7 +58,7 @@ export const defaultGithubOrchestratorServices: GithubOrchestratorServices = {
   getSettings: getGithubSettings,
   preflight: (input) => preflightGithubRepository(input),
   storage: backgroundStorage,
-  loadImage: getImageCacheAssetById,
+  loadImages: getImageCacheAssetsByIds,
   createBlob: createGithubBlob,
   commit: ({ repository, branch, operations, message }) =>
     commitGithubStagedOperations({ repository, branch, operations, message }),

--- a/src/services/sync/github/github-sync-orchestrator.ts
+++ b/src/services/sync/github/github-sync-orchestrator.ts
@@ -297,7 +297,7 @@ export function createGithubSyncOrchestrator(services: GithubOrchestratorService
           comments,
           remoteKey: preflight.remoteKey,
           continuity: row.mapping || undefined,
-          imageLoader: services.loadImage,
+          imageBatchLoader: services.loadImages,
           blobUploader: ({ content }) => services.createBlob({ repository: preflight.repository, content }),
         });
         const plan = planGithubConversationSync({

--- a/src/services/sync/notion/notion-image-upload-upgrader.ts
+++ b/src/services/sync/notion/notion-image-upload-upgrader.ts
@@ -1,8 +1,5 @@
 import * as notionFilesApi from '@services/sync/notion/notion-files-api.ts';
-import {
-  getImageCacheAssetsByIds,
-  type ImageCacheAsset,
-} from '@services/conversations/data/image-cache-read.ts';
+import { getImageCacheAssetsByIds, type ImageCacheAsset } from '@services/conversations/data/image-cache-read.ts';
 import { parseSyncnosAssetId } from '@services/sync/shared/markdown-asset-refs';
 
 const MAX_IMAGE_BYTES = 15 * 1024 * 1024;
@@ -186,12 +183,7 @@ async function uploadFromDataUrl(files: any, accessToken: string, dataUrl: unkno
   return ready && ready.id ? String(ready.id).trim() : fileId;
 }
 
-async function uploadFromSyncnosAsset(
-  files: any,
-  accessToken: string,
-  assetId: number,
-  asset: ImageCacheAsset | null,
-) {
+async function uploadFromSyncnosAsset(files: any, accessToken: string, assetId: number, asset: ImageCacheAsset | null) {
   if (!asset || !(asset.blob instanceof Blob)) throw new Error(`missing local asset blob: ${assetId}`);
 
   const bytes = new Uint8Array(await asset.blob.arrayBuffer());

--- a/src/services/sync/notion/notion-image-upload-upgrader.ts
+++ b/src/services/sync/notion/notion-image-upload-upgrader.ts
@@ -1,5 +1,9 @@
 import * as notionFilesApi from '@services/sync/notion/notion-files-api.ts';
-import { getImageCacheAssetById } from '@services/conversations/data/image-cache-read.ts';
+import {
+  getImageCacheAssetsByIds,
+  type ImageCacheAsset,
+} from '@services/conversations/data/image-cache-read.ts';
+import { parseSyncnosAssetId } from '@services/sync/shared/markdown-asset-refs';
 
 const MAX_IMAGE_BYTES = 15 * 1024 * 1024;
 
@@ -7,18 +11,6 @@ function isDataImageUrl(url: unknown): boolean {
   const text = String(url || '').trim();
   if (!text) return false;
   return /^data:image\/[a-z0-9.+-]+(?:;charset=[a-z0-9._-]+)?;base64,/i.test(text);
-}
-
-function parseSyncnosAssetId(url: unknown): number {
-  const text = String(url || '').trim();
-  const matched = /^syncnos-asset:\/\/(\d+)$/i.exec(text);
-  if (!matched) return 0;
-  const id = Number(matched[1]);
-  return Number.isFinite(id) && id > 0 ? id : 0;
-}
-
-function isSyncnosAssetUrl(url: unknown): boolean {
-  return parseSyncnosAssetId(url) > 0;
 }
 
 function guessExtensionFromContentType(contentType: unknown): string {
@@ -194,11 +186,12 @@ async function uploadFromDataUrl(files: any, accessToken: string, dataUrl: unkno
   return ready && ready.id ? String(ready.id).trim() : fileId;
 }
 
-async function uploadFromSyncnosAsset(files: any, accessToken: string, url: unknown) {
-  const assetId = parseSyncnosAssetId(url);
-  if (!assetId) throw new Error('invalid syncnos asset url');
-
-  const asset = await getImageCacheAssetById({ id: assetId });
+async function uploadFromSyncnosAsset(
+  files: any,
+  accessToken: string,
+  assetId: number,
+  asset: ImageCacheAsset | null,
+) {
   if (!asset || !(asset.blob instanceof Blob)) throw new Error(`missing local asset blob: ${assetId}`);
 
   const bytes = new Uint8Array(await asset.blob.arrayBuffer());
@@ -227,6 +220,19 @@ async function upgradeImageBlocksToFileUploads(accessToken: string, blocks: any)
   const list = Array.isArray(blocks) ? blocks : [];
   if (!list.length) return [];
   const files = notionFilesApi;
+  const localAssetIds: number[] = [];
+  const seenLocalAssetIds = new Set<number>();
+  for (const block of list) {
+    if (!block || block.type !== 'image' || !block.image || block.image.type !== 'external') continue;
+    const url = block.image?.external?.url ? String(block.image.external.url).trim() : '';
+    const assetId = parseSyncnosAssetId(url);
+    if (assetId == null || seenLocalAssetIds.has(assetId)) continue;
+    seenLocalAssetIds.add(assetId);
+    localAssetIds.push(assetId);
+  }
+  const localAssets: Map<number, ImageCacheAsset> = localAssetIds.length
+    ? await getImageCacheAssetsByIds({ ids: localAssetIds }).catch(() => new Map<number, ImageCacheAsset>())
+    : new Map<number, ImageCacheAsset>();
   const cache = new Map<string, string>();
   const out: any[] = [];
 
@@ -241,6 +247,7 @@ async function upgradeImageBlocksToFileUploads(accessToken: string, blocks: any)
       continue;
     }
 
+    const assetId = parseSyncnosAssetId(url);
     let uploadId = cache.get(url) || '';
     if (!uploadId) {
       if (isDataImageUrl(url)) {
@@ -256,9 +263,9 @@ async function upgradeImageBlocksToFileUploads(accessToken: string, blocks: any)
           }
           uploadId = '';
         }
-      } else if (isSyncnosAssetUrl(url)) {
+      } else if (assetId != null) {
         try {
-          uploadId = await uploadFromSyncnosAsset(files, accessToken, url);
+          uploadId = await uploadFromSyncnosAsset(files, accessToken, assetId, localAssets.get(assetId) || null);
           if (uploadId) cache.set(url, uploadId);
         } catch (e) {
           const msg = e && (e as any).message ? String((e as any).message) : String(e);
@@ -298,7 +305,7 @@ async function upgradeImageBlocksToFileUploads(accessToken: string, blocks: any)
     }
 
     if (!uploadId) {
-      if (isDataImageUrl(url) || isSyncnosAssetUrl(url)) {
+      if (isDataImageUrl(url) || assetId != null) {
         out.push(paragraphBlock('[Image omitted: local image upload failed]'));
       } else out.push(b);
       continue;

--- a/src/services/sync/notion/notion-markdown-blocks.ts
+++ b/src/services/sync/notion/notion-markdown-blocks.ts
@@ -1,4 +1,5 @@
 import { normalizeStandaloneImageCaptionLines } from '@services/sync/shared/markdown-image-normalizer';
+import { parseSyncnosAssetId } from '@services/sync/shared/markdown-asset-refs';
 
 const MAX_TEXT = 1900;
 const MAX_EQUATION_EXPRESSION = 1900;
@@ -363,11 +364,6 @@ function markdownToNotionBlocks(markdown: string) {
     return /^data:image\/[a-z0-9.+-]+(?:;charset=[a-z0-9._-]+)?;base64,/i.test(text);
   }
 
-  function isSyncnosAssetUrl(url: unknown): boolean {
-    const text = String(url || '').trim();
-    return /^syncnos-asset:\/\/\d+$/i.test(text);
-  }
-
   function stripAngleBrackets(url: unknown): string {
     const text = String(url || '').trim();
     if (text.startsWith('<') && text.endsWith('>')) return text.slice(1, -1).trim();
@@ -413,7 +409,7 @@ function markdownToNotionBlocks(markdown: string) {
     const m = trimmed.match(/^!\[([^\]]*)\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)\s*$/);
     if (!m) return null;
     const url = stripAngleBrackets(String(m[2] || '').trim());
-    if (!isHttpUrl(url) && !isDataImageUrl(url) && !isSyncnosAssetUrl(url)) return null;
+    if (!isHttpUrl(url) && !isDataImageUrl(url) && parseSyncnosAssetId(url) == null) return null;
     return { url, alt: String(m[1] || '') };
   }
 

--- a/src/services/sync/obsidian/obsidian-sync-orchestrator.ts
+++ b/src/services/sync/obsidian/obsidian-sync-orchestrator.ts
@@ -15,7 +15,7 @@ import {
   readSyncnosObject as readDefaultSyncnosObject,
 } from '@services/sync/shared/remote-markdown-metadata.ts';
 import { createSyncJobStore } from '@services/sync/sync-job-store';
-import { getImageCacheAssetById } from '@services/conversations/data/image-cache-read';
+import { getImageCacheAssetsByIds } from '@services/conversations/data/image-cache-read';
 import {
   collectOrderedSyncnosAssetIds,
   replaceSyncnosAssetImageTargets,
@@ -103,6 +103,7 @@ async function materializeMarkdownAssetsForObsidian({
 
   const targetIds = collectOrderedSyncnosAssetIds(targetMarkdown);
   if (!targetIds.length) return targetMarkdown;
+  const assetsById = await getImageCacheAssetsByIds({ ids: targetIds });
 
   const noteBase = buildNoteBasenameFromFilePath(filePath);
   const attachmentNameByAssetId = new Map<number, string>();
@@ -111,7 +112,7 @@ async function materializeMarkdownAssetsForObsidian({
     const index = indexByAssetId.get(assetId);
     if (!index) throw new Error(`missing asset index mapping: ${assetId}`);
 
-    const asset = await getImageCacheAssetById({ id: assetId });
+    const asset = assetsById.get(assetId);
     if (!asset || !(asset.blob instanceof Blob)) throw new Error(`missing local asset blob: ${assetId}`);
 
     const ext = inferImageExtFromAsset(asset);

--- a/src/viewmodels/conversations/useSyncnosAssetSrcMap.ts
+++ b/src/viewmodels/conversations/useSyncnosAssetSrcMap.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { getImageCacheAssetById } from '@services/conversations/data/image-cache-read';
+import { getImageCacheAssetsByIds, type ImageCacheAsset } from '@services/conversations/data/image-cache-read';
 import {
   requestDataRevisionRetry,
   subscribeDataRevisionChanges,
@@ -94,42 +94,57 @@ export function useSyncnosAssetSrcMap(input: {
       }
     };
 
-    for (const id of currentAssetIds) {
-      try {
-        const asset = await getImageCacheAssetById({ id, conversationId: currentConversationId });
-        if (!mountedRef.current || generation !== generationRef.current) {
-          discardCreatedUrls();
-          return;
-        }
+    let assets: Map<number, ImageCacheAsset>;
+    try {
+      assets = await getImageCacheAssetsByIds({ ids: currentAssetIds, conversationId: currentConversationId });
+    } catch (_error) {
+      if (!mountedRef.current || generation !== generationRef.current) {
+        discardCreatedUrls();
+        return;
+      }
+      readFailed = true;
+      assets = new Map();
+    }
+
+    if (!mountedRef.current || generation !== generationRef.current) {
+      discardCreatedUrls();
+      return;
+    }
+
+    if (!readFailed) {
+      for (const id of currentAssetIds) {
+        const asset = assets.get(id);
         if (!asset) {
           resolved.set(id, null);
           continue;
         }
 
-        let url = '';
-        let objectUrl = false;
         try {
-          if (typeof URL?.createObjectURL === 'function') {
-            url = URL.createObjectURL(asset.blob);
-            objectUrl = Boolean(url);
-            if (objectUrl) newlyCreatedObjectUrls.push(url);
+          let url = '';
+          let objectUrl = false;
+          try {
+            if (typeof URL?.createObjectURL === 'function') {
+              url = URL.createObjectURL(asset.blob);
+              objectUrl = Boolean(url);
+              if (objectUrl) newlyCreatedObjectUrls.push(url);
+            }
+          } catch (_error) {
+            url = '';
+            objectUrl = false;
           }
+          if (!url) url = await blobToDataUrl(asset.blob);
+          if (!mountedRef.current || generation !== generationRef.current) {
+            discardCreatedUrls();
+            return;
+          }
+          resolved.set(id, { url, objectUrl });
         } catch (_error) {
-          url = '';
-          objectUrl = false;
+          if (!mountedRef.current || generation !== generationRef.current) {
+            discardCreatedUrls();
+            return;
+          }
+          readFailed = true;
         }
-        if (!url) url = await blobToDataUrl(asset.blob);
-        if (!mountedRef.current || generation !== generationRef.current) {
-          discardCreatedUrls();
-          return;
-        }
-        resolved.set(id, { url, objectUrl });
-      } catch (_error) {
-        if (!mountedRef.current || generation !== generationRef.current) {
-          discardCreatedUrls();
-          return;
-        }
-        readFailed = true;
       }
     }
 

--- a/tests/integration/github-markdown-sync.test.ts
+++ b/tests/integration/github-markdown-sync.test.ts
@@ -6,7 +6,7 @@ import { GITHUB_MESSAGE_TYPES } from '@platform/messaging/message-contracts';
 import { closeDbForTests, openDb } from '@platform/idb/schema';
 import { addArticleComment } from '@services/comments/data/storage';
 import { backgroundStorage } from '@services/conversations/background/storage';
-import { getImageCacheAssetById } from '@services/conversations/data/image-cache-read';
+import { getImageCacheAssetsByIds } from '@services/conversations/data/image-cache-read';
 import { __resetConversationStorageStateForTests } from '@services/conversations/data/storage-idb';
 import { readDataRevision } from '@services/data-revisions/storage-idb';
 import {
@@ -479,7 +479,7 @@ const orchestrator = createGithubSyncOrchestrator({
   getSettings: getGithubSettings,
   preflight: (input) => preflightGithubRepository(input, api),
   storage: backgroundStorage,
-  loadImage: getImageCacheAssetById,
+  loadImages: getImageCacheAssetsByIds,
   createBlob: (input) => createGithubBlob(input, api),
   commit: (input) => commitGithubStagedOperations(input, api),
   listDueCleanupRows: listDueGithubCleanupRows,

--- a/tests/smoke/background-router-conversations.test.ts
+++ b/tests/smoke/background-router-conversations.test.ts
@@ -273,24 +273,19 @@ describe('background-router conversations', () => {
     );
   });
 
-  it('coalesces backfill progress into durable auto-sync change signals without a UI event bus', async () => {
+  it('emits exactly one backfillImages signal after durable backfill changes', async () => {
     const onConversationChanged = vi.fn(async () => {});
-    backfillJobMocks.backfillConversationImages.mockImplementation(async (input: any) => {
-      await input?.onProgress?.({ updatedMessages: 1 });
-      await input?.onProgress?.({ updatedMessages: 2 });
-      return {
-        scannedMessages: 2,
-        updatedMessages: 2,
-        inlinedCount: 2,
-        fromCacheCount: 1,
-        downloadedCount: 1,
-        inlinedBytes: 2048,
-        warningFlags: [],
-      };
+    backfillJobMocks.backfillConversationImages.mockResolvedValue({
+      scannedMessages: 2,
+      updatedMessages: 2,
+      inlinedCount: 2,
+      fromCacheCount: 1,
+      downloadedCount: 1,
+      inlinedBytes: 2048,
+      warningFlags: [],
     });
 
     const router = createRouter({ onConversationChanged });
-
     const res = await router.__handleMessageForTests({
       type: 'backfillConversationImages',
       conversationId: 888,
@@ -298,16 +293,53 @@ describe('background-router conversations', () => {
     });
 
     expect(res.ok).toBe(true);
-    expect(backfillJobMocks.backfillConversationImages).toHaveBeenCalledWith(
-      expect.objectContaining({
-        conversationId: 888,
-        conversationUrl: 'https://example.com/a',
-      }),
-    );
+    expect(backfillJobMocks.backfillConversationImages).toHaveBeenCalledWith({
+      conversationId: 888,
+      conversationUrl: 'https://example.com/a',
+    });
     await Promise.resolve();
-    expect(onConversationChanged).toHaveBeenCalledTimes(2);
-    expect(onConversationChanged).toHaveBeenNthCalledWith(1, 888, 'backfillImages');
-    expect(onConversationChanged).toHaveBeenNthCalledWith(2, 888, 'backfillImages');
+    expect(onConversationChanged).toHaveBeenCalledTimes(1);
+    expect(onConversationChanged).toHaveBeenCalledWith(888, 'backfillImages');
+  });
+
+  it('does not emit backfillImages for no-op or conflict-only durable results', async () => {
+    const onConversationChanged = vi.fn(async () => {});
+    backfillJobMocks.backfillConversationImages.mockResolvedValue({
+      scannedMessages: 2,
+      updatedMessages: 0,
+      inlinedCount: 2,
+      fromCacheCount: 1,
+      downloadedCount: 1,
+      inlinedBytes: 2048,
+      warningFlags: [],
+    });
+
+    const router = createRouter({ onConversationChanged });
+    const res = await router.__handleMessageForTests({
+      type: 'backfillConversationImages',
+      conversationId: 889,
+      conversationUrl: 'https://example.com/b',
+    });
+
+    expect(res.ok).toBe(true);
+    await Promise.resolve();
+    expect(onConversationChanged).not.toHaveBeenCalled();
+  });
+
+  it('does not emit backfillImages when the backfill job fails', async () => {
+    const onConversationChanged = vi.fn(async () => {});
+    backfillJobMocks.backfillConversationImages.mockRejectedValue(new Error('conditional patch failed'));
+
+    const router = createRouter({ onConversationChanged });
+    const res = await router.__handleMessageForTests({
+      type: 'backfillConversationImages',
+      conversationId: 890,
+      conversationUrl: 'https://example.com/c',
+    });
+
+    expect(res).toMatchObject({ ok: false, error: { message: 'conditional patch failed' } });
+    await Promise.resolve();
+    expect(onConversationChanged).not.toHaveBeenCalled();
   });
 
   it('marks the kept conversation dirty and wakes remote cleanup after a real merge', async () => {

--- a/tests/smoke/github-sync-orchestrator.test.ts
+++ b/tests/smoke/github-sync-orchestrator.test.ts
@@ -50,7 +50,7 @@ function fakeServices(input: {
   order?: string[];
   commitImpl?: GithubOrchestratorServices['commit'];
   patchFailures?: ReadonlySet<number>;
-  loadImage?: GithubOrchestratorServices['loadImage'];
+  loadImages?: GithubOrchestratorServices['loadImages'];
   createBlob?: GithubOrchestratorServices['createBlob'];
   cleanupRows?: GithubCleanupOutboxRecord[];
   cleanupHasMoreDue?: boolean;
@@ -119,7 +119,7 @@ function fakeServices(input: {
         return true;
       }),
     },
-    loadImage: input.loadImage ?? vi.fn(async () => null),
+    loadImages: input.loadImages ?? vi.fn(async () => new Map()),
     createBlob: input.createBlob ?? vi.fn(async () => ({ sha: 'c'.repeat(40) })),
     commit,
     listDueCleanupRows: vi.fn(async (remoteKey, now, limit) => {
@@ -310,6 +310,32 @@ describe('github sync orchestrator staging through production sync', () => {
       mode: 'failed',
       error: 'broken local read',
     });
+  });
+
+  it('fails staging when the GitHub image batch loader rejects', async () => {
+    const createBlob = vi.fn(async () => ({ sha: 'c'.repeat(40) }));
+    const { services, commit } = fakeServices({
+      rows: { 1: { conversation: chat(1) } },
+      messages: { 1: [message('![x](syncnos-asset://1)')] },
+      loadImages: vi.fn(async () => {
+        throw new Error('image batch failed');
+      }),
+      createBlob,
+    });
+
+    const result = await createGithubSyncOrchestrator(services).sync({
+      conversationIds: [1],
+      instanceId: 'image-batch-failure',
+    });
+
+    expect(result.items[0]).toMatchObject({
+      conversationId: 1,
+      status: 'failed',
+      error: 'image batch failed',
+    });
+    expect(services.loadImages).toHaveBeenCalledWith({ ids: [1], conversationId: 1 });
+    expect(createBlob).not.toHaveBeenCalled();
+    expect(commit).not.toHaveBeenCalled();
   });
 
   it('dedupes identical content staged to the same path', async () => {
@@ -1634,14 +1660,20 @@ describe('github sync orchestrator atomic cross-layer contracts', () => {
     const { services } = fakeServices({
       rows: { 1: { conversation: chat(1) } },
       messages: { 1: [message('before ![img](syncnos-asset://1) after')] },
-      loadImage: async () => ({
-        id: 1,
-        conversationId: 1,
-        url: 'https://cdn.example.com/image.png',
-        blob: new Blob([new Uint8Array([1])], { type: 'image/png' }),
-        byteSize: 1,
-        contentType: 'image/png',
-      }),
+      loadImages: async () =>
+        new Map([
+          [
+            1,
+            {
+              id: 1,
+              conversationId: 1,
+              url: 'https://cdn.example.com/image.png',
+              blob: new Blob([new Uint8Array([1])], { type: 'image/png' }),
+              byteSize: 1,
+              contentType: 'image/png',
+            },
+          ],
+        ]),
       createBlob: async () => {
         throw new GithubApiError('github_outcome_unknown', 0, 'github_outcome_unknown');
       },

--- a/tests/smoke/obsidian-sync-orchestrator.test.ts
+++ b/tests/smoke/obsidian-sync-orchestrator.test.ts
@@ -8,7 +8,7 @@ const backgroundStorageMocks = vi.hoisted(() => ({
   attachOrphanArticleCommentsToConversation: vi.fn(),
   recordObsidianRemoteWrite: vi.fn(),
 }));
-const imageCacheMocks = vi.hoisted(() => ({ getImageCacheAssetById: vi.fn() }));
+const imageCacheMocks = vi.hoisted(() => ({ getImageCacheAssetsByIds: vi.fn() }));
 
 vi.mock('@services/conversations/background/storage', () => ({
   backgroundStorage: {
@@ -267,18 +267,37 @@ describe('obsidian-sync-orchestrator', () => {
       {
         messageKey: 'm1',
         sequence: 1,
-        contentMarkdown: 'before\n\n![diagram](<syncnos-asset://7> "caption")\n\nafter',
+        contentMarkdown:
+          'before\n\n![diagram](<syncnos-asset://7> "caption")\n\n![again](syncnos-asset://7)\n\n![photo](syncnos-asset://8)\n\nafter',
         updatedAt: 1,
       },
     ]);
-    imageCacheMocks.getImageCacheAssetById.mockResolvedValue({
-      id: 7,
-      conversationId: 1,
-      url: 'https://example.com/diagram.png',
-      blob: new Blob([new Uint8Array([1, 2, 3])], { type: 'image/png' }),
-      byteSize: 3,
-      contentType: 'image/png',
-    });
+    imageCacheMocks.getImageCacheAssetsByIds.mockResolvedValue(
+      new Map([
+        [
+          7,
+          {
+            id: 7,
+            conversationId: 1,
+            url: 'https://example.com/diagram.png',
+            blob: new Blob([new Uint8Array([1, 2, 3])], { type: 'image/png' }),
+            byteSize: 3,
+            contentType: 'image/png',
+          },
+        ],
+        [
+          8,
+          {
+            id: 8,
+            conversationId: 1,
+            url: 'https://example.com/photo.webp',
+            blob: new Blob([new Uint8Array([4, 5])], { type: 'image/webp' }),
+            byteSize: 2,
+            contentType: 'image/webp',
+          },
+        ],
+      ]),
+    );
 
     const seen: Array<{ method: string; url: string; body: unknown }> = [];
     // @ts-expect-error test global
@@ -303,15 +322,72 @@ describe('obsidian-sync-orchestrator', () => {
     await settingsStore.saveObsidianSettings({ apiBaseUrl: 'http://127.0.0.1:27123', apiKey: 'k' });
     const syncRes = await orch.syncConversations({ conversationIds: [1], instanceId: 'x' });
     expect(syncRes.results[0].ok).toBe(true);
-    expect(imageCacheMocks.getImageCacheAssetById).toHaveBeenCalledWith({ id: 7 });
+    expect(imageCacheMocks.getImageCacheAssetsByIds).toHaveBeenCalledTimes(1);
+    expect(imageCacheMocks.getImageCacheAssetsByIds).toHaveBeenCalledWith({ ids: [7, 8] });
 
-    const encodedAttachmentName = encodeURIComponent(`${noteBasename}-1.png`);
+    const encodedAttachmentNames = [
+      encodeURIComponent(`${noteBasename}-1.png`),
+      encodeURIComponent(`${noteBasename}-2.webp`),
+    ];
+    const binaryPuts = seen.filter(
+      (call) => call.method === 'PUT' && encodedAttachmentNames.some((name) => call.url.endsWith(name)),
+    );
+    expect(binaryPuts.map((call) => call.url.split('/').at(-1))).toEqual(encodedAttachmentNames);
     const encodedNoteName = encodeURIComponent(`${noteBasename}.md`);
-    const binaryPut = seen.find((call) => call.method === 'PUT' && call.url.endsWith(encodedAttachmentName));
-    expect(binaryPut?.url).toContain(`/vault/SyncNos-AIChats/${encodedAttachmentName}`);
     const markdownPut = seen.find((call) => call.method === 'PUT' && call.url.endsWith(encodedNoteName));
     expect(String(markdownPut?.body || '')).toContain(`![diagram](<${noteBasename}-1.png> "caption")`);
+    expect(String(markdownPut?.body || '')).toContain(`![again](${noteBasename}-1.png)`);
+    expect(String(markdownPut?.body || '')).toContain(`![photo](${noteBasename}-2.webp)`);
     expect(String(markdownPut?.body || '')).not.toContain('syncnos-asset://');
+  });
+
+  it.each([
+    ['missing asset', 'missing'],
+    ['bulk read rejection', 'reject'],
+  ] as const)('fails sync when an Obsidian local asset is unavailable: %s', async (_label, mode) => {
+    setupChromeStorage();
+    const settingsStore = await loadModule('@services/sync/obsidian/settings-store.ts');
+    const orch = await loadModule('@services/sync/obsidian/obsidian-sync-orchestrator.ts');
+
+    backgroundStorageMocks.getConversationById.mockResolvedValue({
+      id: 1,
+      sourceType: 'chat',
+      source: 'chatgpt',
+      conversationKey: `asset-${mode}`,
+      title: 'Asset failure',
+    });
+    backgroundStorageMocks.getMessagesByConversationId.mockResolvedValue([
+      { messageKey: 'm1', sequence: 1, contentMarkdown: '![asset](syncnos-asset://7)', updatedAt: 1 },
+    ]);
+    if (mode === 'reject') imageCacheMocks.getImageCacheAssetsByIds.mockRejectedValue(new Error('idb unavailable'));
+    else imageCacheMocks.getImageCacheAssetsByIds.mockResolvedValue(new Map());
+
+    let putCount = 0;
+    // @ts-expect-error test global
+    globalThis.fetch = async (_url: any, init: any) => {
+      const method = String(init?.method || 'GET').toUpperCase();
+      if (method === 'GET') {
+        return new Response(JSON.stringify({ errorCode: 40400, message: 'not found' }), {
+          status: 404,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (method === 'PUT') {
+        putCount += 1;
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      throw new Error(`unexpected:${method}`);
+    };
+
+    await settingsStore.saveObsidianSettings({ apiBaseUrl: 'http://127.0.0.1:27123', apiKey: 'k' });
+    const syncRes = await orch.syncConversations({ conversationIds: [1], instanceId: 'x' });
+
+    expect(imageCacheMocks.getImageCacheAssetsByIds).toHaveBeenCalledWith({ ids: [7] });
+    expect(syncRes.results[0]).toMatchObject({ ok: false, mode: 'failed' });
+    expect(putCount).toBe(0);
   });
 
   it('does not record generation when only attachments succeed and the main note PUT fails', async () => {
@@ -334,14 +410,21 @@ describe('obsidian-sync-orchestrator', () => {
         updatedAt: 1,
       },
     ]);
-    imageCacheMocks.getImageCacheAssetById.mockResolvedValue({
-      id: 7,
-      conversationId: 1,
-      url: 'https://example.com/a.png',
-      blob: new Blob([new Uint8Array([1, 2, 3])], { type: 'image/png' }),
-      byteSize: 3,
-      contentType: 'image/png',
-    });
+    imageCacheMocks.getImageCacheAssetsByIds.mockResolvedValue(
+      new Map([
+        [
+          7,
+          {
+            id: 7,
+            conversationId: 1,
+            url: 'https://example.com/a.png',
+            blob: new Blob([new Uint8Array([1, 2, 3])], { type: 'image/png' }),
+            byteSize: 3,
+            contentType: 'image/png',
+          },
+        ],
+      ]),
+    );
 
     let binaryPutCount = 0;
     let notePutCount = 0;
@@ -952,7 +1035,7 @@ afterEach(() => {
   backgroundStorageMocks.getArticleCommentsByConversationId.mockReset();
   backgroundStorageMocks.attachOrphanArticleCommentsToConversation.mockReset();
   backgroundStorageMocks.recordObsidianRemoteWrite.mockReset();
-  imageCacheMocks.getImageCacheAssetById.mockReset();
+  imageCacheMocks.getImageCacheAssetsByIds.mockReset();
   // @ts-expect-error test cleanup
   delete globalThis.fetch;
   // @ts-expect-error test cleanup

--- a/tests/storage/conversations-idb.test.ts
+++ b/tests/storage/conversations-idb.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { IDBIndex, IDBKeyRange, indexedDB } from 'fake-indexeddb';
+import { IDBDatabase, IDBIndex, IDBKeyRange, IDBObjectStore, indexedDB } from 'fake-indexeddb';
 import { normalizeConversationListRecord } from '@platform/idb/conversation-list-record';
 import { closeDbForTests, openDb } from '../../src/platform/idb/schema';
 import { readDataRevision } from '@services/data-revisions/storage-idb';
@@ -21,6 +21,7 @@ import {
   getMessagesTailByConversationId,
   getSyncMappingByConversation,
   mergeConversationsByIds,
+  patchConversationMessageMarkdownBatch,
   patchSyncMapping,
   setConversationNotionPageId,
   setSyncCursor,
@@ -647,6 +648,162 @@ describe('conversations storage-idb', () => {
       ['m3', 2],
       ['m4', 3],
     ]);
+  });
+
+  it('patches multiple message Markdown rows in one tracked transaction while preserving latest non-Markdown fields', async () => {
+    const convo = await upsertConversation({
+      sourceType: 'chat',
+      source: 'debug',
+      conversationKey: 'markdown-patch-batch',
+      title: 'Patch batch',
+      lastCapturedAt: 1,
+    });
+    const id = Number(convo.id);
+    await syncConversationMessages(id, [
+      {
+        messageKey: 'm1',
+        role: 'user',
+        authorName: 'Alice',
+        contentText: 'text one',
+        contentMarkdown: 'before one',
+        sequence: 7,
+        updatedAt: 101,
+      },
+      {
+        messageKey: 'm2',
+        role: 'assistant',
+        authorName: 'Bot',
+        contentText: 'text two',
+        contentMarkdown: 'before two',
+        sequence: 8,
+        updatedAt: 102,
+      },
+    ]);
+    const beforeRows = await getMessagesByConversationId(id);
+    const beforeRevision = await readDataRevision('messages');
+
+    const transactionSpy = vi.spyOn(IDBDatabase.prototype, 'transaction');
+    const result = await patchConversationMessageMarkdownBatch(id, [
+      { messageKey: 'm1', beforeMarkdown: 'before one', afterMarkdown: 'after one' },
+      { messageKey: 'm2', beforeMarkdown: 'before two', afterMarkdown: 'after two' },
+    ]);
+    const messageTransactions = transactionSpy.mock.calls.filter(([storeNames]) => {
+      const names = Array.isArray(storeNames) ? storeNames : [storeNames];
+      return names.includes('messages');
+    });
+    transactionSpy.mockRestore();
+
+    expect(result).toEqual({ updated: 2, conflicts: 0 });
+    expect(messageTransactions).toHaveLength(1);
+    expect(await readDataRevision('messages')).toBe(beforeRevision + 1);
+
+    const afterRows = await getMessagesByConversationId(id);
+    expect(afterRows.map((row) => row.contentMarkdown)).toEqual(['after one', 'after two']);
+    expect(
+      afterRows.map(({ id: rowId, messageKey, role, authorName, contentText, sequence, updatedAt }) => ({
+        id: rowId,
+        messageKey,
+        role,
+        authorName,
+        contentText,
+        sequence,
+        updatedAt,
+      })),
+    ).toEqual(
+      beforeRows.map(({ id: rowId, messageKey, role, authorName, contentText, sequence, updatedAt }) => ({
+        id: rowId,
+        messageKey,
+        role,
+        authorName,
+        contentText,
+        sequence,
+        updatedAt,
+      })),
+    );
+  });
+
+  it('skips stale or missing Markdown patches and bumps revision only for durable matches', async () => {
+    const convo = await upsertConversation({
+      sourceType: 'chat',
+      source: 'debug',
+      conversationKey: 'markdown-patch-conflict',
+      title: 'Patch conflict',
+      lastCapturedAt: 1,
+    });
+    const id = Number(convo.id);
+    await syncConversationMessages(id, [
+      { messageKey: 'm1', role: 'user', contentText: 'one', contentMarkdown: 'latest one', sequence: 0 },
+      { messageKey: 'm2', role: 'assistant', contentText: 'two', contentMarkdown: 'before two', sequence: 1 },
+    ]);
+    const beforeRevision = await readDataRevision('messages');
+
+    const result = await patchConversationMessageMarkdownBatch(id, [
+      { messageKey: 'm1', beforeMarkdown: 'stale one', afterMarkdown: 'must not win' },
+      { messageKey: 'm2', beforeMarkdown: 'before two', afterMarkdown: 'after two' },
+      { messageKey: 'missing', beforeMarkdown: '', afterMarkdown: 'new' },
+    ]);
+
+    expect(result).toEqual({ updated: 1, conflicts: 2 });
+    expect(await readDataRevision('messages')).toBe(beforeRevision + 1);
+    expect((await getMessagesByConversationId(id)).map((row) => row.contentMarkdown)).toEqual([
+      'latest one',
+      'after two',
+    ]);
+  });
+
+  it('keeps no-op/conflict-only patches revision-free and rejects conflicting duplicate definitions before opening IDB', async () => {
+    const convo = await upsertConversation({
+      sourceType: 'chat',
+      source: 'debug',
+      conversationKey: 'markdown-patch-noop',
+      title: 'Patch no-op',
+      lastCapturedAt: 1,
+    });
+    const id = Number(convo.id);
+    await syncConversationMessages(id, [
+      { messageKey: 'm1', role: 'user', contentText: 'one', contentMarkdown: 'stable', sequence: 0 },
+    ]);
+    const beforeRevision = await readDataRevision('messages');
+
+    expect(
+      await patchConversationMessageMarkdownBatch(id, [
+        { messageKey: 'm1', beforeMarkdown: 'stable', afterMarkdown: 'stable' },
+        { messageKey: 'm1', beforeMarkdown: 'stable', afterMarkdown: 'stable' },
+      ]),
+    ).toEqual({ updated: 0, conflicts: 0 });
+    expect(
+      await patchConversationMessageMarkdownBatch(id, [
+        { messageKey: 'm1', beforeMarkdown: 'stale', afterMarkdown: 'other' },
+      ]),
+    ).toEqual({ updated: 0, conflicts: 1 });
+    expect(await readDataRevision('messages')).toBe(beforeRevision);
+
+    const putSpy = vi.spyOn(IDBObjectStore.prototype, 'put');
+    expect(
+      await patchConversationMessageMarkdownBatch(id, [
+        { messageKey: 'm1', beforeMarkdown: 'stable', afterMarkdown: 'patched' },
+        { messageKey: 'm1', beforeMarkdown: 'stable', afterMarkdown: 'patched' },
+      ]),
+    ).toEqual({ updated: 1, conflicts: 0 });
+    const messagePuts = putSpy.mock.contexts.filter(
+      (context) => String((context as IDBObjectStore)?.name || '') === 'messages',
+    );
+    expect(messagePuts).toHaveLength(1);
+    putSpy.mockRestore();
+    expect(await readDataRevision('messages')).toBe(beforeRevision + 1);
+
+    const revisionAfterDuplicate = await readDataRevision('messages');
+    const transactionSpy = vi.spyOn(IDBDatabase.prototype, 'transaction');
+    await expect(
+      patchConversationMessageMarkdownBatch(id, [
+        { messageKey: 'm1', beforeMarkdown: 'stable', afterMarkdown: 'first' },
+        { messageKey: 'm1', beforeMarkdown: 'stable', afterMarkdown: 'second' },
+      ]),
+    ).rejects.toThrow('conflicting Markdown patches');
+    expect(transactionSpy).not.toHaveBeenCalled();
+    transactionSpy.mockRestore();
+    expect(await readDataRevision('messages')).toBe(revisionAfterDuplicate);
+    expect((await getMessagesByConversationId(id))[0]?.contentMarkdown).toBe('patched');
   });
 
   it('syncs messages incrementally without snapshot cleanup', async () => {

--- a/tests/storage/conversations-idb.test.ts
+++ b/tests/storage/conversations-idb.test.ts
@@ -425,11 +425,13 @@ describe('conversations storage-idb', () => {
       getSpy.mockRestore();
     }
 
-    expect((await getMessagesByConversationId(id)).map((message) => [message.messageKey, message.contentText])).toEqual([
-      ['m1', 'one updated'],
-      ['m2', 'two'],
-      ['m4', 'four'],
-    ]);
+    expect((await getMessagesByConversationId(id)).map((message) => [message.messageKey, message.contentText])).toEqual(
+      [
+        ['m1', 'one updated'],
+        ['m2', 'two'],
+        ['m4', 'four'],
+      ],
+    );
   });
 
   it('keeps duplicate snapshot message keys on one row with the last incoming value', async () => {

--- a/tests/storage/conversations-idb.test.ts
+++ b/tests/storage/conversations-idb.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { IDBKeyRange, indexedDB } from 'fake-indexeddb';
+import { IDBIndex, IDBKeyRange, indexedDB } from 'fake-indexeddb';
 import { normalizeConversationListRecord } from '@platform/idb/conversation-list-record';
 import { closeDbForTests, openDb } from '../../src/platform/idb/schema';
 import { readDataRevision } from '@services/data-revisions/storage-idb';
@@ -384,6 +384,269 @@ describe('conversations storage-idb', () => {
     const stored = await getMessagesByConversationId(Number(convo.id));
     expect(Number(stored[0]?.updatedAt)).toBeGreaterThanOrEqual(before);
     expect(Number(stored[0]?.updatedAt)).toBeLessThanOrEqual(Date.now());
+  });
+
+  it('materializes the snapshot working set once without per-key existing lookups', async () => {
+    const convo = await upsertConversation({
+      sourceType: 'chat',
+      source: 'debug',
+      conversationKey: 'snapshot-working-set',
+      title: 'Working set',
+      lastCapturedAt: 1,
+    });
+    const id = Number(convo.id);
+    await syncConversationMessages(id, [
+      { messageKey: 'm1', role: 'user', contentText: 'one', sequence: 0, updatedAt: 1 },
+      { messageKey: 'm2', role: 'assistant', contentText: 'two', sequence: 1, updatedAt: 2 },
+      { messageKey: 'm3', role: 'user', contentText: 'remove', sequence: 2, updatedAt: 3 },
+    ]);
+
+    const getAllSpy = vi.spyOn(IDBIndex.prototype, 'getAll');
+    const getSpy = vi.spyOn(IDBIndex.prototype, 'get');
+    try {
+      const result = await syncConversationMessages(id, [
+        { messageKey: 'm1', role: 'user', contentText: 'one updated', sequence: 0, updatedAt: 4 },
+        { messageKey: 'm2', role: 'assistant', contentText: 'two', sequence: 1, updatedAt: 2 },
+        { messageKey: 'm4', role: 'assistant', contentText: 'four', sequence: 2, updatedAt: 5 },
+      ]);
+      expect(result).toEqual({ upserted: 3, deleted: 1 });
+
+      const sequenceReads = getAllSpy.mock.contexts.filter(
+        (context) => String((context as IDBIndex)?.name || '') === 'by_conversationId_sequence',
+      );
+      const perKeyReads = getSpy.mock.contexts.filter(
+        (context) => String((context as IDBIndex)?.name || '') === 'by_conversationId_messageKey',
+      );
+      expect(sequenceReads).toHaveLength(1);
+      expect(perKeyReads).toHaveLength(0);
+    } finally {
+      getAllSpy.mockRestore();
+      getSpy.mockRestore();
+    }
+
+    expect((await getMessagesByConversationId(id)).map((message) => [message.messageKey, message.contentText])).toEqual([
+      ['m1', 'one updated'],
+      ['m2', 'two'],
+      ['m4', 'four'],
+    ]);
+  });
+
+  it('keeps duplicate snapshot message keys on one row with the last incoming value', async () => {
+    const convo = await upsertConversation({
+      sourceType: 'chat',
+      source: 'debug',
+      conversationKey: 'snapshot-duplicate-key',
+      title: 'Duplicate',
+      lastCapturedAt: 1,
+    });
+    const id = Number(convo.id);
+
+    const result = await syncConversationMessages(id, [
+      { messageKey: 'm1', role: 'user', contentText: 'first', sequence: 0, updatedAt: 1 },
+      { messageKey: 'm1', role: 'assistant', contentText: 'second', sequence: 1, updatedAt: 2 },
+    ]);
+
+    expect(result).toEqual({ upserted: 2, deleted: 0 });
+    expect(await getMessagesByConversationId(id)).toMatchObject([
+      { messageKey: 'm1', role: 'assistant', contentText: 'second', sequence: 1, updatedAt: 2 },
+    ]);
+  });
+
+  it('keeps ordinary append deltas on per-key reads without materializing the conversation', async () => {
+    const convo = await upsertConversation({
+      sourceType: 'chat',
+      source: 'debug',
+      conversationKey: 'append-delta-read-shape',
+      title: 'Delta',
+      lastCapturedAt: 1,
+    });
+    const id = Number(convo.id);
+    await syncConversationMessages(id, [{ messageKey: 'm1', role: 'user', contentText: 'old', sequence: 0 }]);
+
+    const getAllSpy = vi.spyOn(IDBIndex.prototype, 'getAll');
+    const getSpy = vi.spyOn(IDBIndex.prototype, 'get');
+    try {
+      await syncConversationMessages(id, [{ messageKey: 'm1', role: 'user', contentText: 'new', sequence: 0 }], {
+        mode: 'append',
+        diff: { added: [], updated: ['m1'], removed: [] },
+      });
+
+      const sequenceReads = getAllSpy.mock.contexts.filter(
+        (context) => String((context as IDBIndex)?.name || '') === 'by_conversationId_sequence',
+      );
+      const perKeyReads = getSpy.mock.contexts.filter(
+        (context) => String((context as IDBIndex)?.name || '') === 'by_conversationId_messageKey',
+      );
+      expect(sequenceReads).toHaveLength(0);
+      expect(perKeyReads).toHaveLength(1);
+    } finally {
+      getAllSpy.mockRestore();
+      getSpy.mockRestore();
+    }
+  });
+
+  it('reuses the preserve-tail working set without redundant per-key reads', async () => {
+    const convo = await upsertConversation({
+      sourceType: 'chat',
+      source: 'debug',
+      conversationKey: 'append-tail-read-shape',
+      title: 'Tail',
+      lastCapturedAt: 1,
+    });
+    const id = Number(convo.id);
+    await syncConversationMessages(id, [
+      { messageKey: 'm1', role: 'user', contentText: 'one', sequence: 10 },
+      { messageKey: 'm2', role: 'assistant', contentText: 'two', sequence: 20 },
+    ]);
+
+    const getAllSpy = vi.spyOn(IDBIndex.prototype, 'getAll');
+    const getSpy = vi.spyOn(IDBIndex.prototype, 'get');
+    try {
+      await syncConversationMessages(
+        id,
+        [
+          {
+            messageKey: 'm2',
+            role: 'assistant',
+            contentText: 'two updated',
+            sequence: 0,
+            captureSequencePolicy: 'preserve-existing-tail',
+          },
+          {
+            messageKey: 'm3',
+            role: 'user',
+            contentText: 'three',
+            sequence: 0,
+            captureSequencePolicy: 'preserve-existing-tail',
+          },
+        ],
+        { mode: 'append', diff: { added: ['m3'], updated: ['m2'], removed: [] } },
+      );
+
+      const sequenceReads = getAllSpy.mock.contexts.filter(
+        (context) => String((context as IDBIndex)?.name || '') === 'by_conversationId_sequence',
+      );
+      const perKeyReads = getSpy.mock.contexts.filter(
+        (context) => String((context as IDBIndex)?.name || '') === 'by_conversationId_messageKey',
+      );
+      expect(sequenceReads).toHaveLength(1);
+      expect(perKeyReads).toHaveLength(0);
+    } finally {
+      getAllSpy.mockRestore();
+      getSpy.mockRestore();
+    }
+
+    expect((await getMessagesByConversationId(id)).map(({ messageKey, sequence }) => [messageKey, sequence])).toEqual([
+      ['m1', 10],
+      ['m2', 20],
+      ['m3', 21],
+    ]);
+  });
+
+  it('keeps exact stored message-key matching when reusing an append working set', async () => {
+    const convo = await upsertConversation({
+      sourceType: 'chat',
+      source: 'debug',
+      conversationKey: 'append-exact-key',
+      title: 'Exact key',
+      lastCapturedAt: 1,
+    });
+    const id = Number(convo.id);
+    await syncConversationMessages(id, [
+      { messageKey: ' m1 ', role: 'user', contentText: 'legacy spaced key', sequence: 0 },
+    ]);
+
+    await syncConversationMessages(
+      id,
+      [
+        {
+          messageKey: 'm1',
+          role: 'assistant',
+          contentText: 'normalized incoming key',
+          sequence: 0,
+          captureSequencePolicy: 'preserve-existing-tail',
+        },
+      ],
+      { mode: 'append', diff: { added: ['m1'], updated: [], removed: [] } },
+    );
+
+    expect((await getMessagesByConversationId(id)).map(({ messageKey, sequence }) => [messageKey, sequence])).toEqual([
+      [' m1 ', 0],
+      ['m1', 1],
+    ]);
+  });
+
+  it('reuses the append reconciliation working set without redundant per-key reads', async () => {
+    const convo = await upsertConversation({
+      sourceType: 'chat',
+      source: 'chatgpt',
+      conversationKey: 'append-reconcile-read-shape',
+      title: 'Reconcile',
+      lastCapturedAt: 1,
+    });
+    const id = Number(convo.id);
+    await syncConversationMessages(id, [
+      { messageKey: 'm3', role: 'user', contentText: 'three', sequence: 0 },
+      { messageKey: 'm4', role: 'assistant', contentText: 'four', sequence: 1 },
+    ]);
+
+    const getAllSpy = vi.spyOn(IDBIndex.prototype, 'getAll');
+    const getSpy = vi.spyOn(IDBIndex.prototype, 'get');
+    try {
+      await syncConversationMessages(
+        id,
+        [
+          {
+            messageKey: 'm1',
+            role: 'user',
+            contentText: 'one',
+            sequence: 0,
+            captureSequencePolicy: 'reconcile-existing-order',
+          },
+          {
+            messageKey: 'm2',
+            role: 'assistant',
+            contentText: 'two',
+            sequence: 1,
+            captureSequencePolicy: 'reconcile-existing-order',
+          },
+          {
+            messageKey: 'm3',
+            role: 'user',
+            contentText: 'three',
+            sequence: 2,
+            captureSequencePolicy: 'reconcile-existing-order',
+          },
+          {
+            messageKey: 'm4',
+            role: 'assistant',
+            contentText: 'four',
+            sequence: 3,
+            captureSequencePolicy: 'reconcile-existing-order',
+          },
+        ],
+        { mode: 'append', diff: { added: ['m1', 'm2'], updated: ['m3', 'm4'], removed: [] } },
+      );
+
+      const sequenceReads = getAllSpy.mock.contexts.filter(
+        (context) => String((context as IDBIndex)?.name || '') === 'by_conversationId_sequence',
+      );
+      const perKeyReads = getSpy.mock.contexts.filter(
+        (context) => String((context as IDBIndex)?.name || '') === 'by_conversationId_messageKey',
+      );
+      expect(sequenceReads).toHaveLength(1);
+      expect(perKeyReads).toHaveLength(0);
+    } finally {
+      getAllSpy.mockRestore();
+      getSpy.mockRestore();
+    }
+
+    expect((await getMessagesByConversationId(id)).map(({ messageKey, sequence }) => [messageKey, sequence])).toEqual([
+      ['m1', 0],
+      ['m2', 1],
+      ['m3', 2],
+      ['m4', 3],
+    ]);
   });
 
   it('syncs messages incrementally without snapshot cleanup', async () => {

--- a/tests/storage/image-cache-read.test.ts
+++ b/tests/storage/image-cache-read.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { IDBDatabase, IDBKeyRange, IDBObjectStore, indexedDB } from 'fake-indexeddb';
+
+import { closeDbForTests, openDb } from '@platform/idb/schema';
+import {
+  getImageCacheAssetById,
+  getImageCacheAssetsByIds,
+} from '@services/conversations/data/image-cache-read';
+
+function reqToPromise<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error || new Error('indexedDB request failed'));
+  });
+}
+
+function txDone(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error || new Error('transaction failed'));
+    transaction.onabort = () => reject(transaction.error || new Error('transaction aborted'));
+  });
+}
+
+async function deleteDb(name: string): Promise<void> {
+  const request = indexedDB.deleteDatabase(name);
+  await reqToPromise(request as unknown as IDBRequest<unknown>);
+}
+
+async function seedImageCacheRow(row: Record<string, unknown>): Promise<void> {
+  const db = await openDb();
+  const transaction = db.transaction(['image_cache'], 'readwrite');
+  const done = txDone(transaction);
+  await reqToPromise(transaction.objectStore('image_cache').put(row as any));
+  await done;
+}
+
+function imageCacheTransactions(calls: unknown[][]): unknown[][] {
+  return calls.filter(([storeNames]) => {
+    const names = Array.isArray(storeNames) ? storeNames : [storeNames];
+    return names.includes('image_cache');
+  });
+}
+
+describe('image cache bulk reader', () => {
+  beforeEach(async () => {
+    closeDbForTests();
+    // @ts-expect-error fake IndexedDB test global
+    globalThis.indexedDB = indexedDB;
+    // @ts-expect-error fake IndexedDB test global
+    globalThis.IDBKeyRange = IDBKeyRange;
+    await deleteDb('webclipper');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    closeDbForTests();
+  });
+
+  it('reads deduped ids in one readonly transaction and preserves normalization semantics', async () => {
+    await seedImageCacheRow({
+      id: 1,
+      conversationId: 42,
+      url: 'https://example.com/blob.png',
+      blob: new Blob([Uint8Array.of(1, 2)], { type: 'image/png' }),
+      byteSize: 2,
+      contentType: 'IMAGE/PNG',
+    });
+    await seedImageCacheRow({
+      id: 1.5,
+      conversationId: 42,
+      url: 'https://example.com/fractional.png',
+      blob: new Blob([Uint8Array.of(9)], { type: 'image/png' }),
+      byteSize: 1,
+      contentType: 'image/png',
+    });
+    await seedImageCacheRow({
+      id: 2,
+      conversationId: 42,
+      url: 'https://example.com/array-buffer.png',
+      blob: Uint8Array.of(3, 4, 5).buffer,
+      byteSize: 3,
+      contentType: 'image/png; charset=utf-8',
+    });
+    await seedImageCacheRow({
+      id: 3,
+      conversationId: 42,
+      url: 'https://example.com/view.png',
+      blob: Uint8Array.of(6, 7),
+      byteSize: 2,
+      contentType: 'image/webp',
+    });
+    await seedImageCacheRow({
+      id: 4,
+      conversationId: 42,
+      url: 'legacy:data-url',
+      dataUrl: 'data:image/png;base64,AQID',
+      byteSize: 3,
+      contentType: 'image/png',
+    });
+    await seedImageCacheRow({
+      id: 5,
+      conversationId: 0,
+      url: 'https://example.com/invalid-owner.png',
+      blob: new Blob([Uint8Array.of(1)], { type: 'image/png' }),
+      byteSize: 1,
+      contentType: 'image/png',
+    });
+    await seedImageCacheRow({
+      id: 6,
+      conversationId: 99,
+      url: 'https://example.com/other-conversation.png',
+      blob: new Blob([Uint8Array.of(1)], { type: 'image/png' }),
+      byteSize: 1,
+      contentType: 'image/png',
+    });
+    await seedImageCacheRow({
+      id: 7,
+      conversationId: 42,
+      url: 'https://example.com/empty.png',
+      blob: new Blob([], { type: 'image/png' }),
+      byteSize: 0,
+      contentType: 'image/png',
+    });
+
+    const transactionSpy = vi.spyOn(IDBDatabase.prototype, 'transaction');
+    const getSpy = vi.spyOn(IDBObjectStore.prototype, 'get');
+    const assets = await getImageCacheAssetsByIds({
+      ids: [1, 1, 1.5, 2, 3, 4, 5, 6, 7, 0, -1, Number.NaN, Number.POSITIVE_INFINITY],
+      conversationId: 42,
+    });
+
+    const imageGets = getSpy.mock.contexts.filter((context) => String((context as IDBObjectStore)?.name || '') === 'image_cache');
+    expect(imageCacheTransactions(transactionSpy.mock.calls)).toHaveLength(1);
+    expect(imageGets).toHaveLength(8);
+    expect([...assets.keys()]).toEqual([1, 1.5, 2, 3, 4]);
+
+    expect(assets.get(1)).toMatchObject({
+      id: 1,
+      conversationId: 42,
+      url: 'https://example.com/blob.png',
+      byteSize: 2,
+      contentType: 'image/png',
+    });
+    expect(assets.get(1)?.blob).toBeInstanceOf(Blob);
+    expect(assets.get(1.5)?.byteSize).toBe(1);
+    expect(assets.get(2)?.blob.size).toBe(3);
+    expect(assets.get(2)?.contentType).toBe('image/png; charset=utf-8');
+    expect(assets.get(3)?.blob.size).toBe(2);
+    expect(assets.get(4)?.blob.size).toBe(3);
+    expect(assets.has(5)).toBe(false);
+    expect(assets.has(6)).toBe(false);
+    expect(assets.has(7)).toBe(false);
+  });
+
+  it('uses blob size and blob content type when legacy metadata is absent', async () => {
+    await seedImageCacheRow({
+      id: 8,
+      conversationId: 42,
+      url: 'https://example.com/fallback.webp',
+      blob: new Blob([Uint8Array.of(1, 2, 3, 4)], { type: 'image/webp' }),
+    });
+
+    const assets = await getImageCacheAssetsByIds({ ids: [8], conversationId: 42 });
+    expect(assets.get(8)).toMatchObject({ byteSize: 4, contentType: 'image/webp' });
+  });
+
+  it('does not open IndexedDB when there are no valid positive finite ids', async () => {
+    await openDb();
+    const transactionSpy = vi.spyOn(IDBDatabase.prototype, 'transaction');
+
+    const assets = await getImageCacheAssetsByIds({
+      ids: [0, -1, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY],
+      conversationId: 42,
+    });
+
+    expect(assets.size).toBe(0);
+    expect(transactionSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects the whole bulk read when its readonly transaction aborts', async () => {
+    await seedImageCacheRow({
+      id: 9,
+      conversationId: 42,
+      url: 'https://example.com/abort.png',
+      blob: new Blob([Uint8Array.of(1)], { type: 'image/png' }),
+      byteSize: 1,
+      contentType: 'image/png',
+    });
+
+    const originalTransaction = IDBDatabase.prototype.transaction;
+    vi.spyOn(IDBDatabase.prototype, 'transaction').mockImplementation(function (...args: any[]) {
+      const transaction = (originalTransaction as any).apply(this, args) as IDBTransaction;
+      const names = Array.isArray(args[0]) ? args[0] : [args[0]];
+      if (args[1] === 'readonly' && names.includes('image_cache')) queueMicrotask(() => transaction.abort());
+      return transaction;
+    });
+
+    await expect(getImageCacheAssetsByIds({ ids: [9], conversationId: 42 })).rejects.toBeTruthy();
+  });
+
+  it('keeps the single reader as a thin compatibility surface over bulk ownership and missing semantics', async () => {
+    await seedImageCacheRow({
+      id: 10,
+      conversationId: 42,
+      url: 'https://example.com/single.png',
+      blob: new Blob([Uint8Array.of(1, 2, 3)], { type: 'image/png' }),
+      byteSize: 3,
+      contentType: 'image/png',
+    });
+
+    await expect(getImageCacheAssetById({ id: 10, conversationId: 42 })).resolves.toMatchObject({
+      id: 10,
+      conversationId: 42,
+      byteSize: 3,
+    });
+    await expect(getImageCacheAssetById({ id: 10, conversationId: 99 })).resolves.toBeNull();
+    await expect(getImageCacheAssetById({ id: 404, conversationId: 42 })).resolves.toBeNull();
+    await expect(getImageCacheAssetById({ id: 0, conversationId: 42 })).resolves.toBeNull();
+  });
+});

--- a/tests/storage/image-cache-read.test.ts
+++ b/tests/storage/image-cache-read.test.ts
@@ -2,10 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { IDBDatabase, IDBKeyRange, IDBObjectStore, indexedDB } from 'fake-indexeddb';
 
 import { closeDbForTests, openDb } from '@platform/idb/schema';
-import {
-  getImageCacheAssetById,
-  getImageCacheAssetsByIds,
-} from '@services/conversations/data/image-cache-read';
+import { getImageCacheAssetById, getImageCacheAssetsByIds } from '@services/conversations/data/image-cache-read';
 
 function reqToPromise<T>(request: IDBRequest<T>): Promise<T> {
   return new Promise((resolve, reject) => {
@@ -130,7 +127,9 @@ describe('image cache bulk reader', () => {
       conversationId: 42,
     });
 
-    const imageGets = getSpy.mock.contexts.filter((context) => String((context as IDBObjectStore)?.name || '') === 'image_cache');
+    const imageGets = getSpy.mock.contexts.filter(
+      (context) => String((context as IDBObjectStore)?.name || '') === 'image_cache',
+    );
     expect(imageCacheTransactions(transactionSpy.mock.calls)).toHaveLength(1);
     expect(imageGets).toHaveLength(8);
     expect([...assets.keys()]).toEqual([1, 1.5, 2, 3, 4]);

--- a/tests/unit/feishu-docx-image-preprocess.test.ts
+++ b/tests/unit/feishu-docx-image-preprocess.test.ts
@@ -70,9 +70,7 @@ describe('feishu docx image preprocess', () => {
 
   it('degrades a bulk local-asset read rejection to the existing placeholder semantics', async () => {
     imageCacheMocks.getImageCacheAssetsByIds.mockRejectedValue(new Error('idb unavailable'));
-    const result = await preprocessFeishuDocxMarkdownImages(
-      '![one](syncnos-asset://7)\n\n![two](syncnos-asset://8)',
-    );
+    const result = await preprocessFeishuDocxMarkdownImages('![one](syncnos-asset://7)\n\n![two](syncnos-asset://8)');
 
     expect(imageCacheMocks.getImageCacheAssetsByIds).toHaveBeenCalledTimes(1);
     expect(imageCacheMocks.getImageCacheAssetsByIds).toHaveBeenCalledWith({ ids: [7, 8] });

--- a/tests/unit/feishu-docx-image-preprocess.test.ts
+++ b/tests/unit/feishu-docx-image-preprocess.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const imageCacheMocks = vi.hoisted(() => ({
+  getImageCacheAssetsByIds: vi.fn(),
+}));
+
+vi.mock('@services/conversations/data/image-cache-read', () => ({
+  getImageCacheAssetsByIds: (...args: any[]) => imageCacheMocks.getImageCacheAssetsByIds(...args),
+}));
+
+import { preprocessFeishuDocxMarkdownImages } from '@services/sync/feishu/docx/feishu-docx-image-preprocess';
+
+function makeAsset(id: number) {
+  return {
+    id,
+    conversationId: 1,
+    url: `https://cdn.example.com/${id}.png`,
+    blob: new Blob([Uint8Array.of(id)], { type: 'image/png' }),
+    byteSize: 1,
+    contentType: 'image/png',
+  };
+}
+
+describe('feishu docx image preprocess', () => {
+  beforeEach(() => {
+    imageCacheMocks.getImageCacheAssetsByIds.mockReset();
+  });
+
+  it('bulk-loads unique SyncNos assets once while preserving repeated source order', async () => {
+    imageCacheMocks.getImageCacheAssetsByIds.mockResolvedValue(new Map([[7, makeAsset(7)]]));
+    const dataUrl = `data:image/png;base64,${Buffer.from(Uint8Array.of(1, 2, 3)).toString('base64')}`;
+    const markdown = [
+      '![remote](https://example.com/remote.png)',
+      '![local](syncnos-asset://7)',
+      '![local-again](<syncnos-asset://7>)',
+      '![missing](syncnos-asset://8)',
+      `![data](${dataUrl})`,
+    ].join('\n\n');
+
+    const result = await preprocessFeishuDocxMarkdownImages(markdown);
+
+    expect(imageCacheMocks.getImageCacheAssetsByIds).toHaveBeenCalledTimes(1);
+    expect(imageCacheMocks.getImageCacheAssetsByIds).toHaveBeenCalledWith({ ids: [7, 8] });
+    expect(result.imageSourcesInOrder.map((source) => source.kind)).toEqual([
+      'http',
+      'syncnos_asset',
+      'syncnos_asset',
+      'syncnos_asset',
+      'data',
+    ]);
+    expect(result.imageSourcesInOrder.map((source) => source.sourceUrl)).toEqual([
+      'https://example.com/remote.png',
+      'syncnos-asset://7',
+      'syncnos-asset://7',
+      'syncnos-asset://8',
+      dataUrl,
+    ]);
+    expect(result.imageSourcesInOrder[1]).toMatchObject({
+      urlForConvert: 'https://cdn.example.com/7.png',
+      contentType: 'image/png',
+    });
+    expect(result.imageSourcesInOrder[1]?.blob).toBeInstanceOf(Blob);
+    expect(result.imageSourcesInOrder[2]?.blob).toBe(result.imageSourcesInOrder[1]?.blob);
+    expect(result.imageSourcesInOrder[3]?.urlForConvert).toMatch(/^https:\/\/syncnos\.invalid\/asset\/[a-f0-9]+\.png$/);
+    expect(result.imageSourcesInOrder[3]?.blob).toBeUndefined();
+    expect(result.imageSourcesInOrder[4]?.urlForConvert).toMatch(/^https:\/\/syncnos\.invalid\/data\/[a-f0-9]+\.png$/);
+    expect(result.imageSourcesInOrder[4]?.blob).toBeInstanceOf(Blob);
+    expect(result.markdownForConvert).not.toContain('syncnos-asset://');
+  });
+
+  it('degrades a bulk local-asset read rejection to the existing placeholder semantics', async () => {
+    imageCacheMocks.getImageCacheAssetsByIds.mockRejectedValue(new Error('idb unavailable'));
+    const result = await preprocessFeishuDocxMarkdownImages(
+      '![one](syncnos-asset://7)\n\n![two](syncnos-asset://8)',
+    );
+
+    expect(imageCacheMocks.getImageCacheAssetsByIds).toHaveBeenCalledTimes(1);
+    expect(imageCacheMocks.getImageCacheAssetsByIds).toHaveBeenCalledWith({ ids: [7, 8] });
+    expect(result.imageSourcesInOrder).toHaveLength(2);
+    for (const source of result.imageSourcesInOrder) {
+      expect(source.kind).toBe('syncnos_asset');
+      expect(source.urlForConvert).toMatch(/^https:\/\/syncnos\.invalid\/asset\/[a-f0-9]+\.png$/);
+      expect(source.blob).toBeUndefined();
+    }
+    expect(result.markdownForConvert).not.toContain('syncnos-asset://');
+  });
+
+  it('keeps HTTP/data-image preprocessing unchanged and skips the local bulk reader when no local ids exist', async () => {
+    const dataUrl = `data:image/png;base64,${Buffer.from(Uint8Array.of(4, 5, 6)).toString('base64')}`;
+    const result = await preprocessFeishuDocxMarkdownImages(
+      `![remote](https://example.com/a.png)\n\n![data](${dataUrl})`,
+    );
+
+    expect(imageCacheMocks.getImageCacheAssetsByIds).not.toHaveBeenCalled();
+    expect(result.imageSourcesInOrder[0]).toEqual({
+      kind: 'http',
+      sourceUrl: 'https://example.com/a.png',
+      urlForConvert: 'https://example.com/a.png',
+    });
+    expect(result.imageSourcesInOrder[1]).toMatchObject({
+      kind: 'data',
+      sourceUrl: dataUrl,
+      contentType: 'image/png',
+    });
+    expect(result.imageSourcesInOrder[1]?.blob).toBeInstanceOf(Blob);
+    expect(result.markdownForConvert).toContain('https://example.com/a.png');
+    expect(result.markdownForConvert).not.toContain(dataUrl);
+  });
+});

--- a/tests/unit/github-markdown-projection.test.ts
+++ b/tests/unit/github-markdown-projection.test.ts
@@ -427,9 +427,7 @@ describe('github markdown projection', () => {
     const projection = await buildGithubMarkdownProjection({
       conversation: conversation(),
       messages: [{ messageKey: 'm1', sequence: 1, contentMarkdown: '![x](syncnos-asset://1)' }],
-      imageBatchLoader: batchLoaderFromAssets(
-        new Map([[1, imageAsset(1, [1], 'https://cdn.example.com/safe.png')]]),
-      ),
+      imageBatchLoader: batchLoaderFromAssets(new Map([[1, imageAsset(1, [1], 'https://cdn.example.com/safe.png')]])),
       blobUploader: async () => {
         throw Object.assign(new Error('ambiguous mutation outcome'), { code: 'github_outcome_unknown' });
       },

--- a/tests/unit/github-markdown-projection.test.ts
+++ b/tests/unit/github-markdown-projection.test.ts
@@ -29,6 +29,17 @@ function imageAsset(id: number, bytes: number[], url = 'https://cdn.example.com/
   };
 }
 
+function batchLoaderFromAssets(assets: ReadonlyMap<number, ReturnType<typeof imageAsset>>) {
+  return async ({ ids }: { ids: readonly number[]; conversationId: number }) => {
+    const selected = new Map<number, ReturnType<typeof imageAsset>>();
+    for (const id of ids) {
+      const asset = assets.get(id);
+      if (asset) selected.set(id, asset);
+    }
+    return selected;
+  };
+}
+
 afterEach(() => {
   process.env.TZ = originalTz;
 });
@@ -116,14 +127,19 @@ describe('github markdown projection', () => {
       buildGithubMarkdownProjection({
         conversation: conversation(),
         messages: [{ messageKey: 'm1', sequence: 1, contentMarkdown: '![x](syncnos-asset://1)' }],
-        imageLoader: async () => imageAsset(1, [1]),
+        imageBatchLoader: batchLoaderFromAssets(new Map([[1, imageAsset(1, [1])]])),
       }),
     ).rejects.toThrow('github_blob_uploader_required');
   });
 
   it('materializes content-addressed attachments and reuses same bytes within one projection', async () => {
-    const loader = vi.fn(async ({ id }: { id: number; conversationId: number }) =>
-      id === 1 ? imageAsset(1, [1, 2, 3]) : imageAsset(2, [1, 2, 3]),
+    const loader = vi.fn(
+      batchLoaderFromAssets(
+        new Map([
+          [1, imageAsset(1, [1, 2, 3])],
+          [2, imageAsset(2, [1, 2, 3])],
+        ]),
+      ),
     );
     const uploader = vi.fn(async () => ({ sha: 'a'.repeat(40) }));
     const current = conversation();
@@ -133,11 +149,12 @@ describe('github markdown projection', () => {
         {
           messageKey: 'm1',
           sequence: 1,
-          contentMarkdown: '![one](syncnos-asset://1)\n\n![two](<syncnos-asset://2> "caption")',
+          contentMarkdown:
+            '![one](syncnos-asset://1)\n\n![two](<syncnos-asset://2> "caption")\n\n![repeat](syncnos-asset://1)',
         },
       ],
       remoteKey: 'github.com/owner/repo@main',
-      imageLoader: loader,
+      imageBatchLoader: loader,
       blobUploader: uploader,
     });
 
@@ -151,9 +168,48 @@ describe('github markdown projection', () => {
         sha: 'a'.repeat(40),
       },
     ]);
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(loader).toHaveBeenCalledWith({ ids: [1, 2], conversationId: 7 });
     expect(uploader).toHaveBeenCalledTimes(1);
     expect(projection.markdownText).toContain(`![one](${relative})`);
     expect(projection.markdownText).toContain(`![two](<${relative}> "caption")`);
+    expect(projection.markdownText).toContain(`![repeat](${relative})`);
+    expect(projection.markdownText).not.toContain('syncnos-asset://');
+  });
+
+  it('keeps remote blob uploads sequential in first-reference order after one batch read', async () => {
+    const loader = vi.fn(
+      batchLoaderFromAssets(
+        new Map([
+          [1, imageAsset(1, [1])],
+          [2, imageAsset(2, [2])],
+        ]),
+      ),
+    );
+    const uploadOrder: number[] = [];
+    const uploader = vi.fn(async ({ content }: { content: Uint8Array }) => {
+      uploadOrder.push(content[0]!);
+      return { sha: content[0]!.toString(16).repeat(40) };
+    });
+
+    const projection = await buildGithubMarkdownProjection({
+      conversation: conversation(),
+      messages: [
+        {
+          messageKey: 'm1',
+          sequence: 1,
+          contentMarkdown: '![two](syncnos-asset://2)\n![one](syncnos-asset://1)\n![two-again](syncnos-asset://2)',
+        },
+      ],
+      imageBatchLoader: loader,
+      blobUploader: uploader,
+    });
+
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(loader).toHaveBeenCalledWith({ ids: [2, 1], conversationId: 7 });
+    expect(uploadOrder).toEqual([2, 1]);
+    expect(uploader).toHaveBeenCalledTimes(2);
+    expect(projection.warnings).toEqual([]);
     expect(projection.markdownText).not.toContain('syncnos-asset://');
   });
 
@@ -170,14 +226,14 @@ describe('github markdown projection', () => {
       },
     };
     const uploader = vi.fn(async () => ({ sha: 'c'.repeat(40) }));
-    const loader = vi.fn(async () => imageAsset(1, bytes));
+    const loader = vi.fn(batchLoaderFromAssets(new Map([[1, imageAsset(1, bytes)]])));
 
     const unchanged = await buildGithubMarkdownProjection({
       conversation: oldConversation,
       messages: [{ messageKey: 'm1', sequence: 1, contentMarkdown: '![x](syncnos-asset://1)' }],
       remoteKey: 'github.com/owner/repo@main',
       continuity,
-      imageLoader: loader,
+      imageBatchLoader: loader,
       blobUploader: uploader,
     });
     const renamed = await buildGithubMarkdownProjection({
@@ -185,7 +241,7 @@ describe('github markdown projection', () => {
       messages: [{ messageKey: 'm1', sequence: 1, contentMarkdown: '![x](syncnos-asset://1)' }],
       remoteKey: 'github.com/owner/repo@main',
       continuity,
-      imageLoader: loader,
+      imageBatchLoader: loader,
       blobUploader: uploader,
     });
 
@@ -216,7 +272,7 @@ describe('github markdown projection', () => {
           },
         },
       },
-      imageLoader: async () => imageAsset(1, bytes),
+      imageBatchLoader: batchLoaderFromAssets(new Map([[1, imageAsset(1, bytes)]])),
       blobUploader: uploader,
     });
 
@@ -243,7 +299,7 @@ describe('github markdown projection', () => {
           },
         },
       },
-      imageLoader: async () => imageAsset(1, bytes),
+      imageBatchLoader: batchLoaderFromAssets(new Map([[1, imageAsset(1, bytes)]])),
       blobUploader: uploader,
     });
 
@@ -269,7 +325,7 @@ describe('github markdown projection', () => {
           [path]: { kind: 'asset', contentHash, sha: 'b'.repeat(40) },
         },
       },
-      imageLoader: async () => imageAsset(1, bytes),
+      imageBatchLoader: batchLoaderFromAssets(new Map([[1, imageAsset(1, bytes)]])),
       blobUploader: uploader,
     });
 
@@ -283,7 +339,7 @@ describe('github markdown projection', () => {
       [2, imageAsset(2, [2])],
       [3, imageAsset(3, [3])],
     ]);
-    const loader = async ({ id }: { id: number; conversationId: number }) => assets.get(id) || null;
+    const loader = batchLoaderFromAssets(assets);
     const uploader = async ({ content }: { content: Uint8Array }) => ({
       sha: content[0]!.toString(16).repeat(40).slice(0, 40),
     });
@@ -293,7 +349,7 @@ describe('github markdown projection', () => {
       messages: [
         { messageKey: 'm1', sequence: 1, contentMarkdown: '![a](syncnos-asset://1)\n![b](syncnos-asset://2)' },
       ],
-      imageLoader: loader,
+      imageBatchLoader: loader,
       blobUploader: uploader,
     });
     const reordered = await buildGithubMarkdownProjection({
@@ -305,7 +361,7 @@ describe('github markdown projection', () => {
           contentMarkdown: '![new](syncnos-asset://3)\n![b](syncnos-asset://2)\n![a](syncnos-asset://1)',
         },
       ],
-      imageLoader: loader,
+      imageBatchLoader: loader,
       blobUploader: uploader,
     });
 
@@ -318,18 +374,19 @@ describe('github markdown projection', () => {
   });
 
   it('treats missing and cross-conversation assets as placeholders without uploading', async () => {
-    const loader = vi.fn(async ({ conversationId }: { id: number; conversationId: number }) =>
-      conversationId === 999 ? imageAsset(4, [4]) : null,
-    );
+    const loader = vi.fn(async ({ ids, conversationId }: { ids: readonly number[]; conversationId: number }) => {
+      if (conversationId !== 999) return new Map();
+      return new Map(ids.map((id) => [id, imageAsset(id, [id])]));
+    });
     const uploader = vi.fn(async () => ({ sha: 'a'.repeat(40) }));
     const projection = await buildGithubMarkdownProjection({
       conversation: conversation({ id: 7 }),
       messages: [{ messageKey: 'm1', sequence: 1, contentMarkdown: 'before ![secret](syncnos-asset://4) after' }],
-      imageLoader: loader,
+      imageBatchLoader: loader,
       blobUploader: uploader,
     });
 
-    expect(loader).toHaveBeenCalledWith({ id: 4, conversationId: 7 });
+    expect(loader).toHaveBeenCalledWith({ ids: [4], conversationId: 7 });
     expect(uploader).not.toHaveBeenCalled();
     expect(projection.markdownText).toContain('before [Image unavailable] after');
     expect(projection.markdownText).not.toContain('syncnos-asset://');
@@ -342,7 +399,7 @@ describe('github markdown projection', () => {
       [2, imageAsset(2, [2], 'https://cdn.example.com/signed.png?token=SECRET#frag')],
       [3, imageAsset(3, [3], 'https://user:pass@cdn.example.com/credential.png')],
     ]);
-    const loader = async ({ id }: { id: number; conversationId: number }) => assets.get(id) || null;
+    const loader = batchLoaderFromAssets(assets);
     const uploader = vi.fn(async () => {
       throw new Error('upload failed with remote details');
     });
@@ -355,7 +412,7 @@ describe('github markdown projection', () => {
           contentMarkdown: '![safe](syncnos-asset://1)\n![signed](syncnos-asset://2)\n![credential](syncnos-asset://3)',
         },
       ],
-      imageLoader: loader,
+      imageBatchLoader: loader,
       blobUploader: uploader,
     });
 
@@ -370,7 +427,9 @@ describe('github markdown projection', () => {
     const projection = await buildGithubMarkdownProjection({
       conversation: conversation(),
       messages: [{ messageKey: 'm1', sequence: 1, contentMarkdown: '![x](syncnos-asset://1)' }],
-      imageLoader: async () => imageAsset(1, [1], 'https://cdn.example.com/safe.png'),
+      imageBatchLoader: batchLoaderFromAssets(
+        new Map([[1, imageAsset(1, [1], 'https://cdn.example.com/safe.png')]]),
+      ),
       blobUploader: async () => {
         throw Object.assign(new Error('ambiguous mutation outcome'), { code: 'github_outcome_unknown' });
       },

--- a/tests/unit/image-backfill-job.test.ts
+++ b/tests/unit/image-backfill-job.test.ts
@@ -83,9 +83,7 @@ describe('image-backfill-job', () => {
   });
 
   it('does not count conflict-only candidates as updated messages', async () => {
-    storageMocks.getMessagesByConversationId.mockResolvedValue([
-      { messageKey: 'm1', contentMarkdown: 'before' },
-    ]);
+    storageMocks.getMessagesByConversationId.mockResolvedValue([{ messageKey: 'm1', contentMarkdown: 'before' }]);
     imageInlineMocks.inlineChatImagesInMessages.mockResolvedValue(
       inlineResult([{ messageKey: 'm1', contentMarkdown: 'after' }]),
     );

--- a/tests/unit/image-backfill-job.test.ts
+++ b/tests/unit/image-backfill-job.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const storageMocks = vi.hoisted(() => ({
+  getMessagesByConversationId: vi.fn(),
+  patchConversationMessageMarkdownBatch: vi.fn(),
+}));
+const imageInlineMocks = vi.hoisted(() => ({
+  inlineChatImagesInMessages: vi.fn(),
+}));
+
+vi.mock('@services/conversations/data/storage-idb', () => storageMocks);
+vi.mock('@services/conversations/data/image-inline', () => imageInlineMocks);
+
+import { backfillConversationImages } from '@services/conversations/background/image-backfill-job';
+
+function inlineResult(messages: any[]) {
+  return {
+    messages,
+    inlinedCount: 2,
+    fromCacheCount: 1,
+    downloadedCount: 1,
+    inlinedBytes: 12,
+    warningFlags: [],
+  };
+}
+
+describe('image-backfill-job', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storageMocks.patchConversationMessageMarkdownBatch.mockResolvedValue({ updated: 0, conflicts: 0 });
+  });
+
+  it('builds one conditional Markdown batch and reports only durably patched rows', async () => {
+    storageMocks.getMessagesByConversationId.mockResolvedValue([
+      { messageKey: 'm1', contentText: 'latest text one', contentMarkdown: 'before one', updatedAt: 10 },
+      { messageKey: 'm2', contentText: 'latest text two', contentMarkdown: 'before two', updatedAt: 20 },
+    ]);
+    imageInlineMocks.inlineChatImagesInMessages.mockImplementation(async (input: any) =>
+      inlineResult([
+        { ...input.messages[0], contentMarkdown: 'after one' },
+        { ...input.messages[1], contentMarkdown: '' },
+      ]),
+    );
+    storageMocks.patchConversationMessageMarkdownBatch.mockResolvedValue({ updated: 1, conflicts: 1 });
+
+    const result = await backfillConversationImages({
+      conversationId: 42,
+      conversationUrl: 'https://example.com/conversation',
+    });
+
+    expect(imageInlineMocks.inlineChatImagesInMessages).toHaveBeenCalledWith({
+      conversationId: 42,
+      conversationUrl: 'https://example.com/conversation',
+      messages: expect.any(Array),
+    });
+    expect(storageMocks.patchConversationMessageMarkdownBatch).toHaveBeenCalledTimes(1);
+    expect(storageMocks.patchConversationMessageMarkdownBatch).toHaveBeenCalledWith(42, [
+      { messageKey: 'm1', beforeMarkdown: 'before one', afterMarkdown: 'after one' },
+      { messageKey: 'm2', beforeMarkdown: 'before two', afterMarkdown: '' },
+    ]);
+    expect(result).toMatchObject({
+      scannedMessages: 2,
+      updatedMessages: 1,
+      inlinedCount: 2,
+      fromCacheCount: 1,
+      downloadedCount: 1,
+      inlinedBytes: 12,
+    });
+  });
+
+  it('does not call the patch mutation when inlining leaves Markdown unchanged', async () => {
+    const messages = [
+      { messageKey: 'm1', contentMarkdown: 'same' },
+      { messageKey: 'm2', contentMarkdown: '' },
+    ];
+    storageMocks.getMessagesByConversationId.mockResolvedValue(messages);
+    imageInlineMocks.inlineChatImagesInMessages.mockResolvedValue(inlineResult(messages));
+
+    const result = await backfillConversationImages({ conversationId: 42 });
+
+    expect(storageMocks.patchConversationMessageMarkdownBatch).not.toHaveBeenCalled();
+    expect(result.updatedMessages).toBe(0);
+  });
+
+  it('does not count conflict-only candidates as updated messages', async () => {
+    storageMocks.getMessagesByConversationId.mockResolvedValue([
+      { messageKey: 'm1', contentMarkdown: 'before' },
+    ]);
+    imageInlineMocks.inlineChatImagesInMessages.mockResolvedValue(
+      inlineResult([{ messageKey: 'm1', contentMarkdown: 'after' }]),
+    );
+    storageMocks.patchConversationMessageMarkdownBatch.mockResolvedValue({ updated: 0, conflicts: 1 });
+
+    const result = await backfillConversationImages({ conversationId: 42 });
+
+    expect(storageMocks.patchConversationMessageMarkdownBatch).toHaveBeenCalledTimes(1);
+    expect(result.updatedMessages).toBe(0);
+  });
+});

--- a/tests/unit/image-inline.test.ts
+++ b/tests/unit/image-inline.test.ts
@@ -160,7 +160,10 @@ describe('image-inline', () => {
     });
     const readonlyGets = getSpy.mock.contexts
       .map((context, index) => ({ context: context as IDBIndex, call: getSpy.mock.calls[index] }))
-      .filter(({ context }) => context.name === 'by_conversationId_url' && context.objectStore.transaction.mode === 'readonly');
+      .filter(
+        ({ context }) =>
+          context.name === 'by_conversationId_url' && context.objectStore.transaction.mode === 'readonly',
+      );
 
     expect(readonlyImageTransactions).toHaveLength(1);
     expect(readonlyGets.map(({ call }) => call?.[0])).toEqual([
@@ -170,9 +173,7 @@ describe('image-inline', () => {
     expect(result.fromCacheCount).toBe(2);
     expect(fetchMock).not.toHaveBeenCalled();
     expect(messages[0].contentMarkdown).toBe(`![](syncnos-asset://${firstId})`);
-    expect(messages[1].contentMarkdown).toBe(
-      `![](syncnos-asset://${firstId})\n\n![](syncnos-asset://${secondId})`,
-    );
+    expect(messages[1].contentMarkdown).toBe(`![](syncnos-asset://${firstId})\n\n![](syncnos-asset://${secondId})`);
   });
 
   it('prefetches only messages selected by onlyMessageKeys', async () => {
@@ -202,7 +203,10 @@ describe('image-inline', () => {
 
     const readonlyGets = getSpy.mock.contexts
       .map((context, index) => ({ context: context as IDBIndex, call: getSpy.mock.calls[index] }))
-      .filter(({ context }) => context.name === 'by_conversationId_url' && context.objectStore.transaction.mode === 'readonly');
+      .filter(
+        ({ context }) =>
+          context.name === 'by_conversationId_url' && context.objectStore.transaction.mode === 'readonly',
+      );
     expect(readonlyGets.map(({ call }) => call?.[0])).toEqual([[conversationId, selectedUrl]]);
     expect(messages[0].contentMarkdown).toBe(`![](${skippedUrl})`);
     expect(messages[1].contentMarkdown).toBe(`![](syncnos-asset://${selectedId})`);
@@ -248,9 +252,7 @@ describe('image-inline', () => {
 
     try {
       const dataImageUrl = `data:image/png;base64,${Buffer.from(Uint8Array.from([7, 8, 9])).toString('base64')}`;
-      const messages = [
-        { messageKey: 'm1', contentMarkdown: `![](${dataImageUrl})`, role: 'assistant', sequence: 1 },
-      ];
+      const messages = [{ messageKey: 'm1', contentMarkdown: `![](${dataImageUrl})`, role: 'assistant', sequence: 1 }];
       const result = await inlineChatImagesInMessages({ conversationId: 53, messages, enableHttpImages: false });
 
       expect(result.downloadedCount).toBe(1);

--- a/tests/unit/image-inline.test.ts
+++ b/tests/unit/image-inline.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { IDBKeyRange, indexedDB } from 'fake-indexeddb';
+import { IDBDatabase, IDBIndex, IDBKeyRange, indexedDB } from 'fake-indexeddb';
 import { inlineChatImagesInMessages } from '@services/conversations/data/image-inline';
 import {
   hasReusableImageCachePayload,
@@ -27,6 +27,14 @@ function txDone(t: IDBTransaction): Promise<true> {
 async function deleteDb(name: string) {
   const req = indexedDB.deleteDatabase(name);
   await reqToPromise(req as unknown as IDBRequest<unknown>);
+}
+
+async function seedImageCacheRow(row: Record<string, unknown>): Promise<number> {
+  const db = await openDb();
+  const transaction = db.transaction(['image_cache'], 'readwrite');
+  const id = Number(await reqToPromise(transaction.objectStore('image_cache').add(row as any)));
+  await txDone(transaction);
+  return id;
 }
 
 beforeEach(async () => {
@@ -105,6 +113,204 @@ describe('image-inline', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(String(messages2[0].contentMarkdown)).toMatch(/^!\[\]\(syncnos-asset:\/\/\d+\)$/);
     expect(String(messages2[1].contentMarkdown)).toMatch(/^!\[\]\(syncnos-asset:\/\/\d+\)$/);
+  });
+
+  it('prefetches multiple cached HTTP URLs in one readonly transaction and dedupes repeated references', async () => {
+    const conversationId = 50;
+    const firstUrl = 'https://example.com/first.png';
+    const secondUrl = 'https://example.com/second.png';
+    const firstId = await seedImageCacheRow({
+      conversationId,
+      url: firstUrl,
+      blob: new Blob([Uint8Array.of(1)], { type: 'image/png' }),
+      byteSize: 1,
+      contentType: 'image/png',
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    const secondId = await seedImageCacheRow({
+      conversationId,
+      url: secondUrl,
+      blob: new Blob([Uint8Array.of(2)], { type: 'image/png' }),
+      byteSize: 1,
+      contentType: 'image/png',
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    const transactionSpy = vi.spyOn(IDBDatabase.prototype, 'transaction');
+    const getSpy = vi.spyOn(IDBIndex.prototype, 'get');
+    const fetchMock = vi.fn();
+    // @ts-expect-error test global
+    globalThis.fetch = fetchMock;
+
+    const messages = [
+      { messageKey: 'm1', contentMarkdown: `![](${firstUrl})`, role: 'assistant', sequence: 1 },
+      {
+        messageKey: 'm2',
+        contentMarkdown: `![](${firstUrl})\n\n![](${secondUrl})`,
+        role: 'assistant',
+        sequence: 2,
+      },
+    ];
+    const result = await inlineChatImagesInMessages({ conversationId, messages });
+
+    const readonlyImageTransactions = transactionSpy.mock.calls.filter(([storeNames, mode]) => {
+      const names = Array.isArray(storeNames) ? storeNames : [storeNames];
+      return names.includes('image_cache') && mode === 'readonly';
+    });
+    const readonlyGets = getSpy.mock.contexts
+      .map((context, index) => ({ context: context as IDBIndex, call: getSpy.mock.calls[index] }))
+      .filter(({ context }) => context.name === 'by_conversationId_url' && context.objectStore.transaction.mode === 'readonly');
+
+    expect(readonlyImageTransactions).toHaveLength(1);
+    expect(readonlyGets.map(({ call }) => call?.[0])).toEqual([
+      [conversationId, firstUrl],
+      [conversationId, secondUrl],
+    ]);
+    expect(result.fromCacheCount).toBe(2);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(messages[0].contentMarkdown).toBe(`![](syncnos-asset://${firstId})`);
+    expect(messages[1].contentMarkdown).toBe(
+      `![](syncnos-asset://${firstId})\n\n![](syncnos-asset://${secondId})`,
+    );
+  });
+
+  it('prefetches only messages selected by onlyMessageKeys', async () => {
+    const conversationId = 51;
+    const skippedUrl = 'https://example.com/skipped.png';
+    const selectedUrl = 'https://example.com/selected.png';
+    const selectedId = await seedImageCacheRow({
+      conversationId,
+      url: selectedUrl,
+      blob: new Blob([Uint8Array.of(3)], { type: 'image/png' }),
+      byteSize: 1,
+      contentType: 'image/png',
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    const getSpy = vi.spyOn(IDBIndex.prototype, 'get');
+    const messages = [
+      { messageKey: 'skip', contentMarkdown: `![](${skippedUrl})`, role: 'assistant', sequence: 1 },
+      { messageKey: 'keep', contentMarkdown: `![](${selectedUrl})`, role: 'assistant', sequence: 2 },
+    ];
+
+    await inlineChatImagesInMessages({
+      conversationId,
+      messages,
+      onlyMessageKeys: new Set(['keep']),
+    });
+
+    const readonlyGets = getSpy.mock.contexts
+      .map((context, index) => ({ context: context as IDBIndex, call: getSpy.mock.calls[index] }))
+      .filter(({ context }) => context.name === 'by_conversationId_url' && context.objectStore.transaction.mode === 'readonly');
+    expect(readonlyGets.map(({ call }) => call?.[0])).toEqual([[conversationId, selectedUrl]]);
+    expect(messages[0].contentMarkdown).toBe(`![](${skippedUrl})`);
+    expect(messages[1].contentMarkdown).toBe(`![](syncnos-asset://${selectedId})`);
+  });
+
+  it('prefers the canonical data-image cache key over the legacy raw data URL row', async () => {
+    const conversationId = 52;
+    const bytes = Uint8Array.from([5, 6, 7]);
+    const dataImageUrl = `data:image/png;base64,${Buffer.from(bytes).toString('base64')}`;
+    const canonicalId = await seedImageCacheRow({
+      conversationId,
+      url: 'data:image/png;fnv1a64=ae12121853988e6f',
+      blob: new Blob([bytes], { type: 'image/png' }),
+      byteSize: 3,
+      contentType: 'image/png',
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    await seedImageCacheRow({
+      conversationId,
+      url: dataImageUrl,
+      dataUrl: dataImageUrl,
+      blob: new Blob([Uint8Array.of(9)], { type: 'image/png' }),
+      byteSize: 1,
+      contentType: 'image/png',
+      createdAt: 1,
+      updatedAt: 1,
+    });
+
+    const messages = [{ messageKey: 'm1', contentMarkdown: `![](${dataImageUrl})`, role: 'assistant', sequence: 1 }];
+    const result = await inlineChatImagesInMessages({ conversationId, messages, enableHttpImages: false });
+
+    expect(result.fromCacheCount).toBe(1);
+    expect(messages[0].contentMarkdown).toBe(`![](syncnos-asset://${canonicalId})`);
+  });
+
+  it('re-decodes a data-image cache miss only at materialization time instead of retaining its Blob from pre-scan', async () => {
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'atob');
+    const originalAtob = globalThis.atob;
+    expect(typeof originalAtob).toBe('function');
+    const atobSpy = vi.fn((input: string) => originalAtob(input));
+    Object.defineProperty(globalThis, 'atob', { configurable: true, writable: true, value: atobSpy });
+
+    try {
+      const dataImageUrl = `data:image/png;base64,${Buffer.from(Uint8Array.from([7, 8, 9])).toString('base64')}`;
+      const messages = [
+        { messageKey: 'm1', contentMarkdown: `![](${dataImageUrl})`, role: 'assistant', sequence: 1 },
+      ];
+      const result = await inlineChatImagesInMessages({ conversationId: 53, messages, enableHttpImages: false });
+
+      expect(result.downloadedCount).toBe(1);
+      expect(atobSpy).toHaveBeenCalledTimes(2);
+      expect(messages[0].contentMarkdown).toMatch(/^!\[\]\(syncnos-asset:\/\/\d+\)$/);
+    } finally {
+      if (descriptor) Object.defineProperty(globalThis, 'atob', descriptor);
+      else delete (globalThis as any).atob;
+    }
+  });
+
+  it('does not prefetch disabled HTTP candidates', async () => {
+    await openDb();
+    const transactionSpy = vi.spyOn(IDBDatabase.prototype, 'transaction');
+    const fetchMock = vi.fn();
+    // @ts-expect-error test global
+    globalThis.fetch = fetchMock;
+    const messages = [
+      {
+        messageKey: 'm1',
+        contentMarkdown: '![](https://example.com/disabled-a.png)\n\n![](https://example.com/disabled-b.png)',
+        role: 'assistant',
+        sequence: 1,
+      },
+    ];
+
+    await inlineChatImagesInMessages({ conversationId: 54, messages, enableHttpImages: false });
+
+    const readonlyImageTransactions = transactionSpy.mock.calls.filter(([storeNames, mode]) => {
+      const names = Array.isArray(storeNames) ? storeNames : [storeNames];
+      return names.includes('image_cache') && mode === 'readonly';
+    });
+    expect(readonlyImageTransactions).toHaveLength(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the prefetched cache transaction aborts instead of redownloading as cache misses', async () => {
+    await openDb();
+    const originalGet = IDBIndex.prototype.get;
+    vi.spyOn(IDBIndex.prototype, 'get').mockImplementation(function (this: IDBIndex, key: IDBValidKey | IDBKeyRange) {
+      const request = originalGet.call(this, key);
+      if (this.name === 'by_conversationId_url' && this.objectStore.transaction.mode === 'readonly') {
+        queueMicrotask(() => this.objectStore.transaction.abort());
+      }
+      return request;
+    });
+    const fetchMock = vi.fn();
+    // @ts-expect-error test global
+    globalThis.fetch = fetchMock;
+    const messages = [
+      {
+        messageKey: 'm1',
+        contentMarkdown: '![](https://example.com/cache-abort.png)',
+        role: 'assistant',
+        sequence: 1,
+      },
+    ];
+
+    await expect(inlineChatImagesInMessages({ conversationId: 55, messages })).rejects.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('reuses a valid Blob without metadata-only repair or revision bump', async () => {

--- a/tests/unit/notion-image-upload-upgrader.test.ts
+++ b/tests/unit/notion-image-upload-upgrader.test.ts
@@ -14,61 +14,119 @@ function externalImageBlock(url: string) {
   };
 }
 
+function makeAsset(id: number, contentType = 'image/png') {
+  return {
+    id,
+    conversationId: 1,
+    url: `https://example.com/${id}.png`,
+    blob: new Blob([Uint8Array.from([id, id + 1])], { type: contentType }),
+    byteSize: 2,
+    contentType,
+  };
+}
+
+function paragraphText(block: any): string {
+  return String(block?.paragraph?.rich_text?.[0]?.text?.content || '');
+}
+
 describe('notion-image-upload-upgrader', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('uploads syncnos-asset images from local bytes as file_upload blocks', async () => {
+  it('bulk-loads unique local assets once, reuses repeated URL uploads, and keeps serial upload order', async () => {
+    const events: string[] = [];
+    const bulkRead = vi.spyOn(imageCacheRead, 'getImageCacheAssetsByIds').mockResolvedValue(
+      new Map([
+        [42, makeAsset(42, 'image/webp')],
+        [43, makeAsset(43, 'image/png')],
+      ]) as any,
+    );
     const createExternalUrlUpload = vi
       .spyOn(notionFilesApi, 'createExternalURLUpload')
       .mockResolvedValue({ id: 'unused' } as any);
-    const createFileUpload = vi
-      .spyOn(notionFilesApi, 'createFileUpload')
-      .mockResolvedValue({ id: 'up-syncnos-1' } as any);
-    const sendFileUpload = vi.spyOn(notionFilesApi, 'sendFileUpload').mockResolvedValue({} as any);
-    const waitUntilUploaded = vi
-      .spyOn(notionFilesApi, 'waitUntilUploaded')
-      .mockResolvedValue({ id: 'up-syncnos-1' } as any);
+    const createFileUpload = vi.spyOn(notionFilesApi, 'createFileUpload').mockImplementation(async (input: any) => {
+      events.push(`create:${input.filename}`);
+      return { id: input.filename.includes('42') ? 'up-42' : 'up-43' } as any;
+    });
+    vi.spyOn(notionFilesApi, 'sendFileUpload').mockImplementation(async (input: any) => {
+      events.push(`send:${input.filename}`);
+      return {} as any;
+    });
+    vi.spyOn(notionFilesApi, 'waitUntilUploaded').mockImplementation(async (input: any) => {
+      events.push(`wait:${input.id}`);
+      return { id: input.id } as any;
+    });
 
-    vi.spyOn(imageCacheRead, 'getImageCacheAssetById').mockResolvedValue({
-      id: 42,
-      conversationId: 1,
-      url: 'https://example.com/image.webp',
-      blob: new Blob([Uint8Array.from([1, 2, 3])], { type: 'image/webp' }),
-      byteSize: 3,
-      contentType: 'image/webp',
-    } as any);
+    const out = await upgradeImageBlocksToFileUploads('token', [
+      externalImageBlock('syncnos-asset://42'),
+      externalImageBlock('syncnos-asset://43'),
+      externalImageBlock('syncnos-asset://42'),
+    ] as any);
 
-    const out = await upgradeImageBlocksToFileUploads('token', [externalImageBlock('syncnos-asset://42')] as any);
-
+    expect(bulkRead).toHaveBeenCalledTimes(1);
+    expect(bulkRead).toHaveBeenCalledWith({ ids: [42, 43] });
     expect(createExternalUrlUpload).not.toHaveBeenCalled();
-    expect(createFileUpload).toHaveBeenCalledWith(
-      expect.objectContaining({
-        accessToken: 'token',
-        filename: 'image-42.webp',
-        contentType: 'image/webp',
-      }),
-    );
-    expect(sendFileUpload).toHaveBeenCalledTimes(1);
-    const sendArgs = sendFileUpload.mock.calls[0]?.[0] || {};
-    expect(sendArgs.bytes).toBeInstanceOf(Uint8Array);
-    expect(waitUntilUploaded).toHaveBeenCalledWith({ accessToken: 'token', id: 'up-syncnos-1' });
-    expect(out[0]?.image?.type).toBe('file_upload');
-    expect(out[0]?.image?.file_upload?.id).toBe('up-syncnos-1');
+    expect(createFileUpload).toHaveBeenCalledTimes(2);
+    expect(events).toEqual([
+      'create:image-42.webp',
+      'send:image-42.webp',
+      'wait:up-42',
+      'create:image-43.png',
+      'send:image-43.png',
+      'wait:up-43',
+    ]);
+    expect(out.map((block: any) => block?.image?.file_upload?.id)).toEqual(['up-42', 'up-43', 'up-42']);
   });
 
-  it('falls back to placeholder paragraph when syncnos asset is missing', async () => {
-    const createFileUpload = vi
-      .spyOn(notionFilesApi, 'createFileUpload')
-      .mockResolvedValue({ id: 'up-syncnos-2' } as any);
-    vi.spyOn(imageCacheRead, 'getImageCacheAssetById').mockResolvedValue(null as any);
+  it('falls back to an omission paragraph when a local asset is missing', async () => {
+    const createFileUpload = vi.spyOn(notionFilesApi, 'createFileUpload').mockResolvedValue({ id: 'unused' } as any);
+    vi.spyOn(imageCacheRead, 'getImageCacheAssetsByIds').mockResolvedValue(new Map() as any);
 
     const out = await upgradeImageBlocksToFileUploads('token', [externalImageBlock('syncnos-asset://999')] as any);
 
     expect(createFileUpload).not.toHaveBeenCalled();
     expect(out[0]?.type).toBe('paragraph');
-    const text = String(out[0]?.paragraph?.rich_text?.[0]?.text?.content || '');
-    expect(text).toContain('local image upload failed');
+    expect(paragraphText(out[0])).toContain('local image upload failed');
+  });
+
+  it('degrades a bulk-reader rejection to omission paragraphs without leaking internal URLs', async () => {
+    vi.spyOn(imageCacheRead, 'getImageCacheAssetsByIds').mockRejectedValue(new Error('idb unavailable'));
+    const createFileUpload = vi.spyOn(notionFilesApi, 'createFileUpload').mockResolvedValue({ id: 'unused' } as any);
+
+    const out = await upgradeImageBlocksToFileUploads('token', [
+      externalImageBlock('syncnos-asset://42'),
+      externalImageBlock('syncnos-asset://43'),
+    ] as any);
+
+    expect(createFileUpload).not.toHaveBeenCalled();
+    expect(out).toHaveLength(2);
+    expect(out.every((block: any) => block?.type === 'paragraph')).toBe(true);
+    expect(out.every((block: any) => paragraphText(block).includes('local image upload failed'))).toBe(true);
+    expect(JSON.stringify(out)).not.toContain('syncnos-asset://');
+  });
+
+  it('keeps data and HTTP image upload behavior outside the local bulk reader', async () => {
+    const bulkRead = vi.spyOn(imageCacheRead, 'getImageCacheAssetsByIds');
+    const dataUrl = `data:image/png;base64,${Buffer.from(Uint8Array.from([1, 2, 3])).toString('base64')}`;
+    const createExternalUrlUpload = vi
+      .spyOn(notionFilesApi, 'createExternalURLUpload')
+      .mockResolvedValue({ id: 'up-http' } as any);
+    const createFileUpload = vi
+      .spyOn(notionFilesApi, 'createFileUpload')
+      .mockResolvedValue({ id: 'up-data' } as any);
+    const sendFileUpload = vi.spyOn(notionFilesApi, 'sendFileUpload').mockResolvedValue({} as any);
+    vi.spyOn(notionFilesApi, 'waitUntilUploaded').mockImplementation(async (input: any) => ({ id: input.id }) as any);
+
+    const out = await upgradeImageBlocksToFileUploads('token', [
+      externalImageBlock('https://example.com/remote.png'),
+      externalImageBlock(dataUrl),
+    ] as any);
+
+    expect(bulkRead).not.toHaveBeenCalled();
+    expect(createExternalUrlUpload).toHaveBeenCalledTimes(1);
+    expect(createFileUpload).toHaveBeenCalledTimes(1);
+    expect(sendFileUpload).toHaveBeenCalledTimes(1);
+    expect(out.map((block: any) => block?.image?.file_upload?.id)).toEqual(['up-http', 'up-data']);
   });
 });

--- a/tests/unit/notion-image-upload-upgrader.test.ts
+++ b/tests/unit/notion-image-upload-upgrader.test.ts
@@ -112,9 +112,7 @@ describe('notion-image-upload-upgrader', () => {
     const createExternalUrlUpload = vi
       .spyOn(notionFilesApi, 'createExternalURLUpload')
       .mockResolvedValue({ id: 'up-http' } as any);
-    const createFileUpload = vi
-      .spyOn(notionFilesApi, 'createFileUpload')
-      .mockResolvedValue({ id: 'up-data' } as any);
+    const createFileUpload = vi.spyOn(notionFilesApi, 'createFileUpload').mockResolvedValue({ id: 'up-data' } as any);
     const sendFileUpload = vi.spyOn(notionFilesApi, 'sendFileUpload').mockResolvedValue({} as any);
     vi.spyOn(notionFilesApi, 'waitUntilUploaded').mockImplementation(async (input: any) => ({ id: input.id }) as any);
 

--- a/tests/unit/notion-markdown-blocks.test.ts
+++ b/tests/unit/notion-markdown-blocks.test.ts
@@ -11,6 +11,20 @@ describe('notion-markdown-blocks', () => {
     expect(blocks[0]?.image?.external?.url).toBe('syncnos-asset://42');
   });
 
+  it('accepts angle-wrapped SyncNos asset targets through the shared parser', () => {
+    const blocks = markdownToNotionBlocks('![angle](<syncnos-asset://43>)');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.type).toBe('image');
+    expect(blocks[0]?.image?.external?.url).toBe('syncnos-asset://43');
+  });
+
+  it('does not accept malformed or non-positive SyncNos targets as local image blocks', () => {
+    for (const target of ['syncnos-asset://0', 'syncnos-asset://nope']) {
+      const blocks = markdownToNotionBlocks(`![](${target})`);
+      expect(blocks.some((block: any) => block?.type === 'image')).toBe(false);
+    }
+  });
+
   it('splits standalone image lines with trailing caption text into image + paragraph blocks', () => {
     const blocks = markdownToNotionBlocks(
       '![CleanShot](https://cdn3.linux.do/optimized/4X/5/1/2/example.png)CleanShot 828×1194 84 KB',

--- a/tests/unit/syncnos-asset-src-map.test.ts
+++ b/tests/unit/syncnos-asset-src-map.test.ts
@@ -5,14 +5,14 @@ import ReactDOM from 'react-dom/client';
 import { JSDOM } from 'jsdom';
 
 const mocks = vi.hoisted(() => ({
-  getImageCacheAssetById: vi.fn(),
+  getImageCacheAssetsByIds: vi.fn(),
   subscribeDataRevisionChanges: vi.fn(),
   whenDataRevisionObserverReady: vi.fn(),
   requestDataRevisionRetry: vi.fn(),
 }));
 
 vi.mock('@services/conversations/data/image-cache-read', () => ({
-  getImageCacheAssetById: (...args: any[]) => mocks.getImageCacheAssetById(...args),
+  getImageCacheAssetsByIds: (...args: any[]) => mocks.getImageCacheAssetsByIds(...args),
 }));
 
 vi.mock('@services/data-revisions/observer', () => ({
@@ -43,6 +43,10 @@ function makeAsset(id: number, conversationId: number, byte = id) {
     byteSize: 1,
     contentType: 'image/png',
   };
+}
+
+function makeAssetMap(...assets: ReturnType<typeof makeAsset>[]) {
+  return new Map(assets.map((asset) => [asset.id, asset]));
 }
 
 async function flushMicrotasks() {
@@ -106,7 +110,7 @@ describe('useSyncnosAssetSrcMap', () => {
     revisionListener = null;
     unsubscribe = vi.fn();
     objectUrlSequence = 0;
-    mocks.getImageCacheAssetById.mockReset();
+    mocks.getImageCacheAssetsByIds.mockReset();
     mocks.subscribeDataRevisionChanges.mockReset();
     mocks.whenDataRevisionObserverReady.mockReset();
     mocks.requestDataRevisionRetry.mockReset();
@@ -140,65 +144,80 @@ describe('useSyncnosAssetSrcMap', () => {
   it('subscribes before the first asset read and proceeds after degraded readiness', async () => {
     const readiness = deferred<{ baselineAvailable: boolean }>();
     mocks.whenDataRevisionObserverReady.mockReturnValue(readiness.promise);
-    mocks.getImageCacheAssetById.mockResolvedValue(makeAsset(7, 11));
+    mocks.getImageCacheAssetsByIds.mockResolvedValue(makeAssetMap(makeAsset(7, 11)));
 
     await renderProbe(11, ['![cached](syncnos-asset://7)']);
     expect(mocks.subscribeDataRevisionChanges).toHaveBeenCalledTimes(1);
-    expect(mocks.getImageCacheAssetById).not.toHaveBeenCalled();
+    expect(mocks.getImageCacheAssetsByIds).not.toHaveBeenCalled();
 
     await act(async () => {
       readiness.resolve({ baselineAvailable: false });
       await flushMicrotasks();
     });
 
-    expect(mocks.getImageCacheAssetById).toHaveBeenCalledWith({ id: 7, conversationId: 11 });
+    expect(mocks.getImageCacheAssetsByIds).toHaveBeenCalledWith({ ids: [7], conversationId: 11 });
     expect(latestMap.get(7)).toBe('blob:asset-1');
   });
 
   it('reads only the latest conversation and asset ids when identity changes while readiness is pending', async () => {
     const readiness = deferred<{ baselineAvailable: boolean }>();
     mocks.whenDataRevisionObserverReady.mockReturnValue(readiness.promise);
-    mocks.getImageCacheAssetById.mockImplementation(({ id, conversationId }: any) =>
-      Promise.resolve(makeAsset(id, conversationId)),
+    mocks.getImageCacheAssetsByIds.mockImplementation(({ ids, conversationId }: any) =>
+      Promise.resolve(makeAssetMap(...Array.from(ids, (id: any) => makeAsset(Number(id), conversationId)))),
     );
 
     await renderProbe(11, ['![old](syncnos-asset://1)']);
     await renderProbe(22, ['![new](syncnos-asset://2)']);
-    expect(mocks.getImageCacheAssetById).not.toHaveBeenCalled();
+    expect(mocks.getImageCacheAssetsByIds).not.toHaveBeenCalled();
 
     await act(async () => {
       readiness.resolve({ baselineAvailable: true });
       await flushMicrotasks();
     });
 
-    expect(mocks.getImageCacheAssetById).toHaveBeenCalledTimes(1);
-    expect(mocks.getImageCacheAssetById).toHaveBeenCalledWith({ id: 2, conversationId: 22 });
+    expect(mocks.getImageCacheAssetsByIds).toHaveBeenCalledTimes(1);
+    expect(mocks.getImageCacheAssetsByIds).toHaveBeenCalledWith({ ids: [2], conversationId: 22 });
     expect(latestMap.has(1)).toBe(false);
     expect(latestMap.get(2)).toBe('blob:asset-1');
   });
 
+  it('resolves multiple local assets through one bulk read per generation', async () => {
+    mocks.whenDataRevisionObserverReady.mockResolvedValue({ baselineAvailable: true });
+    mocks.getImageCacheAssetsByIds.mockResolvedValue(makeAssetMap(makeAsset(3, 11), makeAsset(4, 11)));
+
+    await renderProbe(11, [
+      '![first](syncnos-asset://3) ![duplicate](syncnos-asset://3)',
+      '![second](syncnos-asset://4)',
+    ]);
+
+    expect(mocks.getImageCacheAssetsByIds).toHaveBeenCalledTimes(1);
+    expect(mocks.getImageCacheAssetsByIds).toHaveBeenCalledWith({ ids: [3, 4], conversationId: 11 });
+    expect(latestMap.get(3)).toBe('blob:asset-1');
+    expect(latestMap.get(4)).toBe('blob:asset-2');
+  });
+
   it('re-resolves on image_cache revisions without replacing its observer subscription', async () => {
     mocks.whenDataRevisionObserverReady.mockResolvedValue({ baselineAvailable: true });
-    mocks.getImageCacheAssetById.mockResolvedValue(makeAsset(3, 11));
+    mocks.getImageCacheAssetsByIds.mockResolvedValue(makeAssetMap(makeAsset(3, 11)));
     await renderProbe(11, ['![cached](syncnos-asset://3)']);
-    expect(mocks.getImageCacheAssetById).toHaveBeenCalledTimes(1);
+    expect(mocks.getImageCacheAssetsByIds).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       revisionListener?.(['image_cache']);
       await flushMicrotasks();
     });
 
-    expect(mocks.getImageCacheAssetById).toHaveBeenCalledTimes(2);
+    expect(mocks.getImageCacheAssetsByIds).toHaveBeenCalledTimes(2);
     expect(mocks.subscribeDataRevisionChanges).toHaveBeenCalledTimes(1);
   });
 
   it('preserves last-good sources on read failure, requests retry, and replaces them on replay', async () => {
     mocks.whenDataRevisionObserverReady.mockResolvedValue({ baselineAvailable: true });
-    mocks.getImageCacheAssetById.mockResolvedValueOnce(makeAsset(4, 11));
+    mocks.getImageCacheAssetsByIds.mockResolvedValueOnce(makeAssetMap(makeAsset(4, 11)));
     await renderProbe(11, ['![cached](syncnos-asset://4)']);
     expect(latestMap.get(4)).toBe('blob:asset-1');
 
-    mocks.getImageCacheAssetById.mockRejectedValueOnce(new Error('idb unavailable'));
+    mocks.getImageCacheAssetsByIds.mockRejectedValueOnce(new Error('idb unavailable'));
     await act(async () => {
       revisionListener?.(['image_cache']);
       await flushMicrotasks();
@@ -209,7 +228,7 @@ describe('useSyncnosAssetSrcMap', () => {
     expect(revokeObjectUrl).not.toHaveBeenCalledWith('blob:asset-1');
 
     mocks.requestDataRevisionRetry.mockClear();
-    mocks.getImageCacheAssetById.mockResolvedValueOnce(makeAsset(4, 11, 9));
+    mocks.getImageCacheAssetsByIds.mockResolvedValueOnce(makeAssetMap(makeAsset(4, 11, 9)));
     await act(async () => {
       revisionListener?.(['image_cache']);
       await flushMicrotasks();
@@ -222,28 +241,28 @@ describe('useSyncnosAssetSrcMap', () => {
 
   it('does not reuse a prior conversation asset when the new conversation read rejects', async () => {
     mocks.whenDataRevisionObserverReady.mockResolvedValue({ baselineAvailable: true });
-    mocks.getImageCacheAssetById.mockResolvedValueOnce(makeAsset(4, 11));
+    mocks.getImageCacheAssetsByIds.mockResolvedValueOnce(makeAssetMap(makeAsset(4, 11)));
     await renderProbe(11, ['![cached](syncnos-asset://4)']);
     expect(latestMap.get(4)).toBe('blob:asset-1');
 
     renderedMaps = [];
-    mocks.getImageCacheAssetById.mockRejectedValueOnce(new Error('idb unavailable'));
+    mocks.getImageCacheAssetsByIds.mockRejectedValueOnce(new Error('idb unavailable'));
     await renderProbe(22, ['![cached](syncnos-asset://4)']);
 
     expect(renderedMaps.every((map) => !map.has(4))).toBe(true);
-    expect(mocks.getImageCacheAssetById).toHaveBeenLastCalledWith({ id: 4, conversationId: 22 });
+    expect(mocks.getImageCacheAssetsByIds).toHaveBeenLastCalledWith({ ids: [4], conversationId: 22 });
     expect(latestMap.has(4)).toBe(false);
     expect(revokeObjectUrl).toHaveBeenCalledWith('blob:asset-1');
     expect(mocks.requestDataRevisionRetry).toHaveBeenCalledWith(['image_cache']);
   });
 
-  it('treats resolved null as authoritative missing and revokes the old object URL', async () => {
+  it('treats a resolved missing bulk entry as authoritative and revokes the old object URL', async () => {
     mocks.whenDataRevisionObserverReady.mockResolvedValue({ baselineAvailable: true });
-    mocks.getImageCacheAssetById.mockResolvedValueOnce(makeAsset(5, 11));
+    mocks.getImageCacheAssetsByIds.mockResolvedValueOnce(makeAssetMap(makeAsset(5, 11)));
     await renderProbe(11, ['![cached](syncnos-asset://5)']);
     expect(latestMap.get(5)).toBe('blob:asset-1');
 
-    mocks.getImageCacheAssetById.mockResolvedValueOnce(null);
+    mocks.getImageCacheAssetsByIds.mockResolvedValueOnce(new Map());
     await act(async () => {
       revisionListener?.(['image_cache']);
       await flushMicrotasks();
@@ -257,19 +276,21 @@ describe('useSyncnosAssetSrcMap', () => {
   it('drops an old identity resolve and drains one trailing resolve for the latest identity', async () => {
     const oldRead = deferred<any>();
     mocks.whenDataRevisionObserverReady.mockResolvedValue({ baselineAvailable: true });
-    mocks.getImageCacheAssetById.mockImplementationOnce(() => oldRead.promise).mockResolvedValueOnce(makeAsset(8, 22));
+    mocks.getImageCacheAssetsByIds
+      .mockImplementationOnce(() => oldRead.promise)
+      .mockResolvedValueOnce(makeAssetMap(makeAsset(8, 22)));
 
     await renderProbe(11, ['![old](syncnos-asset://7)']);
-    expect(mocks.getImageCacheAssetById).toHaveBeenCalledTimes(1);
+    expect(mocks.getImageCacheAssetsByIds).toHaveBeenCalledTimes(1);
     await renderProbe(22, ['![new](syncnos-asset://8)']);
 
     await act(async () => {
-      oldRead.resolve(makeAsset(7, 11));
+      oldRead.resolve(makeAssetMap(makeAsset(7, 11)));
       await flushMicrotasks();
     });
 
-    expect(mocks.getImageCacheAssetById).toHaveBeenCalledTimes(2);
-    expect(mocks.getImageCacheAssetById.mock.calls[1]?.[0]).toEqual({ id: 8, conversationId: 22 });
+    expect(mocks.getImageCacheAssetsByIds).toHaveBeenCalledTimes(2);
+    expect(mocks.getImageCacheAssetsByIds.mock.calls[1]?.[0]).toEqual({ ids: [8], conversationId: 22 });
     expect(latestMap.has(7)).toBe(false);
     expect(latestMap.get(8)).toBe('blob:asset-1');
   });
@@ -277,7 +298,9 @@ describe('useSyncnosAssetSrcMap', () => {
   it('does not retry a rejected read from an old identity', async () => {
     const oldRead = deferred<any>();
     mocks.whenDataRevisionObserverReady.mockResolvedValue({ baselineAvailable: true });
-    mocks.getImageCacheAssetById.mockImplementationOnce(() => oldRead.promise).mockResolvedValueOnce(makeAsset(10, 22));
+    mocks.getImageCacheAssetsByIds
+      .mockImplementationOnce(() => oldRead.promise)
+      .mockResolvedValueOnce(makeAssetMap(makeAsset(10, 22)));
 
     await renderProbe(11, ['![old](syncnos-asset://9)']);
     await renderProbe(22, ['![new](syncnos-asset://10)']);
@@ -306,12 +329,12 @@ describe('useSyncnosAssetSrcMap', () => {
     await flushMicrotasks();
 
     expect(unsubscribe).toHaveBeenCalledTimes(1);
-    expect(mocks.getImageCacheAssetById).not.toHaveBeenCalled();
+    expect(mocks.getImageCacheAssetsByIds).not.toHaveBeenCalled();
   });
 
   it('revokes mounted object URLs on unmount', async () => {
     mocks.whenDataRevisionObserverReady.mockResolvedValue({ baselineAvailable: true });
-    mocks.getImageCacheAssetById.mockResolvedValue(makeAsset(13, 11));
+    mocks.getImageCacheAssetsByIds.mockResolvedValue(makeAssetMap(makeAsset(13, 11)));
     await renderProbe(11, ['![cached](syncnos-asset://13)']);
     expect(latestMap.get(13)).toBe('blob:asset-1');
 


### PR DESCRIPTION
## Related issue

N/A — 对应本地已确认的 performance-refractor P3 feature plan。

## Why

P3 目标是移除消息持久化与本地图片 materialization 路径中已经确认的 IndexedDB read amplification，同时保持 capture 完整性、provider 远端写入顺序、revision 一致性与现有失败语义不变。

## Scope

### In scope

- 复用 snapshot / sequence reconcile 已加载的消息 working set，避免重复 per-message IDB lookup。
- 新增 canonical `getImageCacheAssetsByIds()`，让 detail、Obsidian、Feishu、Notion、GitHub 使用批量本地图片读取。
- 将图片 backfill 改为 conditional Markdown batch patch，在一个 revision-tracked transaction 内提交，避免 lost-update。
- 将 `inlineChatImagesInMessages()` 的 cache candidate lookup 合并为单 readonly transaction。
- 删除被新实现替代的 provider 私有 SyncNos parser、single-loader contract、backfill progress callback 与旧 cache lookup 路径。

### Non-goals

- 不改变 ChatGPT / Google AI Studio capture 完整性和 snapshot/append 路由。
- 不引入新的 IndexedDB schema/index migration。
- 不并行化 provider 远端 upload/write。
- 不优化低频 local Markdown export；其 single reader 保留为 bulk wrapper。
- 不改变 backup 语义、manifest、权限或 OAuth scope。

## What changed

- `syncConversationMessages()` 在需要完整 working set 的 snapshot/reconcile 分支复用一次 sequence-index materialization，普通 delta 继续使用 per-key read。
- `getImageCacheAssetsByIds()` 使用单 readonly transaction 批量读取/归一化本地图片；`getImageCacheAssetById()` 只作为兼容 wrapper。
- Detail hook 在 whole-batch reject 时保留同 conversation last-good，在 identity switch 时清理旧 object URL。
- Obsidian / Feishu / Notion / GitHub 全部切换 canonical bulk image reader，并保持各自原有 hard-fail / degraded / placeholder 策略。
- Backfill 使用 `{messageKey,beforeMarkdown,afterMarkdown}` conditional patch；仅 durable updated 行计数并触发一次 post-commit signal。
- `inlineChatImagesInMessages()` 预扫描 eligible candidate key，一次读缓存；data URL 保持 canonical key 优先 legacy raw key，cache miss 再按原顺序 materialize。

## Architecture / invariants

- 保持 `viewmodels -> services -> platform/domain/client/shared` 依赖方向。
- 继续使用 canonical `openDb()` / `runTrackedTransaction()`，没有第二套 IndexedDB wrapper 或 revision/event channel。
- no-op 不 bump revision；message business change 与 revision 同事务提交。
- Provider manual/auto-sync 仍收敛到既有 orchestrator / SyncJob 生命周期。
- 批量化只发生在本地读取；provider 远端 write/upload 顺序仍保持串行和原有 deterministic order。

## Data, migration & recovery

- 无 schema 或 migration 变更。
- Backfill conditional patch 会在 latest Markdown 与初始 read 不一致时跳过冲突行，不覆盖更新后的消息；conflict-only/no-op 不 bump revision，也不发送 backfill signal。
- Bulk image read 的 missing/cross-conversation/malformed/zero-byte row 仍按 canonical miss 处理；transaction reject 按各 consumer 原有恢复策略处理。
- 现有本地数据格式保持兼容；single image reader 仍覆盖低频调用方。

## Permissions & privacy

N/A — 未修改 manifest、host permissions、OAuth scope、secret handling 或新的网络目标。

## Compatibility

- 影响本地图片 materialization 的 Detail、Obsidian、Feishu、Notion、GitHub 路径。
- 保留 positive finite image ID 的既有 single-reader 兼容域、conversation ownership 规则与 legacy Blob/ArrayBuffer/typed-array/dataUrl materialization。

## Demo

N/A — 无视觉行为变更。

## Drawbacks / risks

- Local bulk read 将同一批 IDB request 收敛到一个 transaction，因此 whole-batch transaction failure 会由 consumer 按既有 provider policy 处理；相关 reject/placeholder/last-good 分支均有回归测试。
- P3 明确不改变 remote upload concurrency，避免把本地性能优化扩展成远端行为变化。

## Tests & validation

### Automated

- P3 targeted matrix：21 files / 283 tests PASS。
- rebase 最新 `main` 后重新运行 `npm run gate:ci`：ESLint PASS、Prettier PASS、TypeScript PASS、268 files / 1931 tests PASS。
- P3 独立审计阶段运行 `npm run gate`：268 files / 1931 tests PASS；WXT 0.20.18 Chrome MV3 production build PASS。
- `git diff --check` PASS。
- P3 implementation independent audit Gate = Go。

### Manual

N/A — 本 PR 无视觉交互变化；本轮提交前未额外执行独立浏览器 UI smoke，reload-free/data-revision 与 provider 行为由 storage/smoke/integration 回归覆盖。

## Documentation

N/A — 没有 canonical 用户/开发文档因本次内部性能重构而失效；本地 feature plan/audit 位于 gitignored `.github/features/performance-refractor 2026-08-31/`，作为执行与审计证据保留。
