### PR TITLE
优化 Insights 统计的 IndexedDB key-only 读取

### DIFF
--- a/src/services/insight/insight-stats-source.ts
+++ b/src/services/insight/insight-stats-source.ts
@@ -29,11 +29,11 @@ async function readAllConversations(store: IDBObjectStore): Promise<Conversation
   return ((await reqToPromise(store.getAll())) as Conversation[]) || [];
 }
 
-async function readCountsByConversationId(store: IDBObjectStore): Promise<Map<number, number>> {
+async function readCountsByConversationId(index: IDBIndex): Promise<Map<number, number>> {
   const counts = new Map<number, number>();
 
   await new Promise<void>((resolve, reject) => {
-    const request = store.openCursor();
+    const request = index.openKeyCursor();
     request.onsuccess = () => {
       const cursor = request.result;
       if (!cursor) {
@@ -41,7 +41,8 @@ async function readCountsByConversationId(store: IDBObjectStore): Promise<Map<nu
         return;
       }
 
-      const conversationId = Number((cursor.value as { conversationId?: unknown } | undefined)?.conversationId);
+      const key = cursor.key;
+      const conversationId = Array.isArray(key) ? Number(key[0]) : Number.NaN;
       if (Number.isFinite(conversationId) && conversationId > 0) {
         counts.set(conversationId, (counts.get(conversationId) || 0) + 1);
       }
@@ -56,16 +57,17 @@ async function readCountsByConversationId(store: IDBObjectStore): Promise<Map<nu
 export async function getInsightStatsSourceData(): Promise<InsightStatsSourceData> {
   const db = await openDb();
   const transaction = db.transaction(['conversations', 'messages', 'article_comments'], 'readonly');
+  const done = txDone(transaction);
   const conversationsStore = transaction.objectStore('conversations');
-  const messagesStore = transaction.objectStore('messages');
-  const commentsStore = transaction.objectStore('article_comments');
+  const messagesIndex = transaction.objectStore('messages').index('by_conversationId_sequence');
+  const commentsIndex = transaction.objectStore('article_comments').index('by_conversationId_createdAt');
 
-  const [conversations, messageCounts, commentCounts] = await Promise.all([
+  const reads = Promise.all([
     readAllConversations(conversationsStore),
-    readCountsByConversationId(messagesStore),
-    readCountsByConversationId(commentsStore),
+    readCountsByConversationId(messagesIndex),
+    readCountsByConversationId(commentsIndex),
   ]);
-  await txDone(transaction);
+  const [[conversations, messageCounts, commentCounts]] = await Promise.all([reads, done]);
 
   return { conversations, messageCounts, commentCounts };
 }

--- a/tests/storage/insight-stats.test.ts
+++ b/tests/storage/insight-stats.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { IDBKeyRange, indexedDB } from 'fake-indexeddb';
+import { IDBIndex, IDBKeyRange, IDBObjectStore, indexedDB } from 'fake-indexeddb';
 import { closeDbForTests } from '@platform/idb/schema';
 
 import {
@@ -82,6 +82,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   __resetConversationStorageStateForTests();
   closeDbForTests();
 });
@@ -129,6 +130,156 @@ describe('insight stats', () => {
     const source = await getInsightStatsSourceData();
     expect(source.conversations.some((item) => Number(item.id) === Number(conversation.id))).toBe(true);
     expect(source.commentCounts.get(Number(conversation.id))).toBe(1);
+  });
+
+  it('counts messages and comments from compound index keys without materializing payload values', async () => {
+    const chatId = await seedConversation({
+      sourceType: 'chat',
+      source: 'ChatGPT',
+      conversationKey: 'chat-key-only',
+      title: 'Key only chat',
+      lastCapturedAt: 1,
+    });
+    const articleId = await seedConversation({
+      sourceType: 'article',
+      source: 'web',
+      conversationKey: 'article-key-only',
+      title: 'Key only article',
+      url: 'https://example.com/key-only',
+      lastCapturedAt: 2,
+    });
+    const videoId = await seedConversation({
+      sourceType: 'video',
+      source: 'YouTube',
+      conversationKey: 'video-key-only',
+      title: 'Key only video',
+      url: 'https://youtube.com/watch?v=key-only',
+      lastCapturedAt: 3,
+    });
+
+    const largeMarkdown = `# payload\n\n${'markdown '.repeat(20_000)}`;
+    await syncConversationMessages(chatId, [
+      {
+        messageKey: 'chat-key-only-m1',
+        role: 'user',
+        contentText: 'small text',
+        contentMarkdown: largeMarkdown,
+        sequence: 1,
+        updatedAt: 1,
+      },
+      {
+        messageKey: 'chat-key-only-m2',
+        role: 'assistant',
+        contentMarkdown: largeMarkdown,
+        sequence: 2,
+        updatedAt: 2,
+      },
+    ]);
+    await addArticleComment({
+      conversationId: articleId,
+      canonicalUrl: 'https://example.com/key-only',
+      commentText: 'article '.repeat(20_000),
+      createdAt: 10,
+    });
+    await addArticleComment({
+      conversationId: videoId,
+      canonicalUrl: 'https://youtube.com/watch?v=key-only',
+      commentText: 'video comment',
+      createdAt: 11,
+    });
+    const orphan = await addArticleComment({
+      conversationId: null,
+      canonicalUrl: 'https://example.com/orphan-key-only',
+      commentText: 'orphan '.repeat(20_000),
+      createdAt: 12,
+    });
+    expect(orphan.conversationId).toBeNull();
+
+    const openKeyCursorSpy = vi.spyOn(IDBIndex.prototype, 'openKeyCursor');
+    const objectStoreCursorSpy = vi.spyOn(IDBObjectStore.prototype, 'openCursor');
+    const getAllKeysSpy = vi.spyOn(IDBIndex.prototype, 'getAllKeys');
+
+    const first = await getInsightStatsSourceData();
+
+    expect(first.messageCounts.get(chatId)).toBe(2);
+    expect(first.commentCounts.get(articleId)).toBe(1);
+    expect(first.commentCounts.get(videoId)).toBe(1);
+    expect(Array.from(first.commentCounts.values()).reduce((sum, count) => sum + count, 0)).toBe(2);
+    expect(openKeyCursorSpy.mock.instances.map((index) => index.name)).toEqual([
+      'by_conversationId_sequence',
+      'by_conversationId_createdAt',
+    ]);
+    expect(objectStoreCursorSpy).not.toHaveBeenCalled();
+    expect(getAllKeysSpy).not.toHaveBeenCalled();
+
+    objectStoreCursorSpy.mockRestore();
+    getAllKeysSpy.mockRestore();
+    openKeyCursorSpy.mockRestore();
+
+    await syncConversationMessages(chatId, [
+      {
+        messageKey: 'chat-key-only-m1',
+        role: 'user',
+        contentText: 'small text',
+        contentMarkdown: largeMarkdown,
+        sequence: 1,
+        updatedAt: 1,
+      },
+      {
+        messageKey: 'chat-key-only-m2',
+        role: 'assistant',
+        contentMarkdown: largeMarkdown,
+        sequence: 2,
+        updatedAt: 2,
+      },
+      {
+        messageKey: 'chat-key-only-m3',
+        role: 'assistant',
+        contentText: 'new message',
+        sequence: 3,
+        updatedAt: 3,
+      },
+    ]);
+    await addArticleComment({
+      conversationId: articleId,
+      canonicalUrl: 'https://example.com/key-only',
+      commentText: 'second article comment',
+      createdAt: 13,
+    });
+
+    const second = await getInsightStatsSourceData();
+    expect(second.messageCounts.get(chatId)).toBe(3);
+    expect(second.commentCounts.get(articleId)).toBe(2);
+  });
+
+  it('rejects the whole source read when its readonly transaction aborts', async () => {
+    await seedConversation({
+      sourceType: 'chat',
+      source: 'ChatGPT',
+      conversationKey: 'chat-abort',
+      title: 'Abort chat',
+      lastCapturedAt: 1,
+      messageCount: 2,
+    });
+
+    const originalOpenKeyCursor = IDBIndex.prototype.openKeyCursor;
+    let aborted = false;
+    const openKeyCursorSpy = vi.spyOn(IDBIndex.prototype, 'openKeyCursor').mockImplementation(function (
+      this: IDBIndex,
+      ...args: Parameters<IDBIndex['openKeyCursor']>
+    ) {
+      const request = originalOpenKeyCursor.apply(this, args);
+      if (!aborted && this.name === 'by_conversationId_sequence') {
+        aborted = true;
+        queueMicrotask(() => this.objectStore.transaction.abort());
+      }
+      return request;
+    });
+
+    await expect(getInsightStatsSourceData()).rejects.toBeInstanceOf(Error);
+    expect(aborted).toBe(true);
+
+    openKeyCursorSpy.mockRestore();
   });
 
   it('aggregates mixed chat and article data', async () => {


### PR DESCRIPTION
## Related issue

N/A — P4 是已审定 performance-refractor feature plan 中的局部读路径性能优化，不新增产品行为。

## Why

Insights 统计 message/comment 数量时此前通过 object-store value cursor 遍历完整 row，会为只需要 `conversationId` 的计数 structured-clone 大段 Markdown、comment text 与 locator payload。现有 compound index 已包含计数所需的 conversationId，因此可以只遍历 index keys，降低 Settings Insights 打开和 revision refresh 时的 IndexedDB 读取成本。

## Scope

### In scope

- Messages 通过 `by_conversationId_sequence.openKeyCursor()` 聚合 per-conversation count。
- Article comments 通过 `by_conversationId_createdAt.openKeyCursor()` 聚合 per-conversation count。
- Conversations 继续 `getAll()`，因为 Insights 需要 title/source/url/lastCapturedAt metadata。
- 同一个 readonly transaction 同时读取 conversation metadata 与两组 key counts，并观察 transaction completion/abort。
- 删除旧 object-store `openCursor()` + `cursor.value.conversationId` count path。
- 增加 request-shape、orphan comment、large payload、mutation reread 与 transaction abort regression。

### Non-goals

- 不新增 IndexedDB index 或升级 DB version。
- 不增加 derived counter、cache 或第二套统计真源。
- 不改变 `buildInsightStats()` 的 totals/ranking/range/distribution/trend 口径。
- 不改变 Settings data-revision subscription、last-good、retry 生命周期。
- 不为绕过 canonical writers 直接注入的 malformed raw-IDB row 增加 full-store fallback。

## What changed

`readCountsByConversationId()` 从 `IDBObjectStore.openCursor()` 收敛为唯一的 `IDBIndex.openKeyCursor()` 路径，只读取 compound key 第一维并聚合 conversationId。`getInsightStatsSourceData()` 继续使用 canonical `openDb()` 和单个 readonly transaction，transaction 创建后立即建立 completion/abort observer，再并行启动 conversations full-row read 与两组 key-only count。

测试直接 spy fake-indexeddb 的 `IDBIndex.prototype.openKeyCursor` / `IDBObjectStore.prototype.openCursor`，因此未来若恢复 value cursor，即使统计结果仍相同也会失败。

## Architecture / invariants

保持 `services -> platform` 依赖方向；没有新增 UI/viewmodel 到 platform 的依赖。仍借用 `src/platform/idb/schema.ts` canonical connection，不 close borrowed DB，不引入自定义一致性事件。`InsightStatsSourceData` shape 与 `conversations/messages/article_comments` revision scopes 均未改变。

## Data, migration & recovery

无 schema/version/migration/write-path 变更，仅优化 readonly source。Canonical message writers、backup merge/import 会保证 `sequence` 可索引；comment writers/archive import 会保证 `createdAt` 可索引。Orphan comment 的 `conversationId=null` 不形成 conversation compound-index entry，因此仍自然排除于 per-conversation count。

Readonly transaction abort/error 会使整个 source read reject，不返回 partial stats；现有 Settings consumer 会保留 last-good 并请求 scoped retry。

## Permissions & privacy

N/A — manifest、权限、OAuth、secret、网络目的地均未改变；数据仍完全在现有本地 IndexedDB read path 中处理。

## Compatibility

不改变浏览器、站点或 provider 支持范围。Persisted-data contract 延续仓库 canonical writers/import 支持的数据；不新增 raw-IDB corruption fallback。

## Demo

N/A — no visual behavior changed.

## Drawbacks / risks

Key-only count 依赖 repository-supported durable rows 能形成现有 compound index key。该前提已对 canonical writers、backup imports 与历史 schema/writers 审查并由 storage/schema regression 覆盖；直接绕过仓库写入层制造的 malformed IndexedDB row 不在兼容范围内。

## Tests & validation

### Automated

- `npm test -- tests/storage/insight-stats.test.ts tests/unit/settings-controller-insight-revisions.test.ts tests/storage/schema-migration.test.ts tests/domains/backup-article-comments.test.ts tests/domains/backup-service.test.ts tests/storage/conversations-idb.test.ts` → 6 files / 127 tests PASS
- `npm run compile` → PASS
- scoped Prettier + `git diff --check` → PASS
- rebase latest `main` 后 `npm run gate:ci` → 268 files / 1933 tests PASS
- P4 implementation audit：Go，无新增 finding

### Manual

N/A — storage-only performance change with no visual/site-specific behavior; request shape and consumer lifecycle are covered by IndexedDB + Settings controller regression tests.

## Documentation

N/A — no canonical long-term documentation became stale. P4 plan/audit evidence stays in the local feature workspace and is intentionally not part of the PR.
