### PR TITLE
refactor: 清理 P1 SyncJob 遗留兼容路径

### DIFF
--- a/src/services/bootstrap/background-services.ts
+++ b/src/services/bootstrap/background-services.ts
@@ -71,8 +71,8 @@ type SyncMaintenanceSurface = {
 export type NotionSyncOrchestrator = SyncOwnershipSurface &
   SyncMaintenanceSurface & {
     syncConversations: (input: { conversationIds?: unknown[]; instanceId: string }) => Promise<unknown>;
-    getSyncJobStatus: (input: { instanceId: string }) => Promise<unknown>;
-    clearSyncJobStatus: (input: { instanceId: string }) => Promise<unknown>;
+    getSyncJobStatus: () => Promise<unknown>;
+    clearSyncJobStatus: () => Promise<unknown>;
   };
 
 export type ObsidianSyncOrchestrator = SyncOwnershipSurface & {
@@ -81,16 +81,16 @@ export type ObsidianSyncOrchestrator = SyncOwnershipSurface & {
     forceFullConversationIds?: unknown[];
     instanceId: string;
   }) => Promise<unknown>;
-  getSyncStatus: (input: { instanceId: string }) => Promise<unknown>;
-  clearSyncStatus: (input: { instanceId: string }) => Promise<unknown>;
+  getSyncStatus: () => Promise<unknown>;
+  clearSyncStatus: () => Promise<unknown>;
   testConnection: (input: { instanceId: string }) => Promise<unknown>;
 };
 
 export type FeishuSyncOrchestrator = SyncOwnershipSurface &
   SyncMaintenanceSurface & {
     syncConversations: (input: { conversationIds?: unknown[]; instanceId: string }) => Promise<unknown>;
-    getSyncStatus: (input: { instanceId: string }) => Promise<unknown>;
-    clearSyncStatus: (input: { instanceId: string }) => Promise<unknown>;
+    getSyncStatus: () => Promise<unknown>;
+    clearSyncStatus: () => Promise<unknown>;
   };
 
 export type GithubSyncOrchestrator = ReturnType<typeof createGithubSyncOrchestrator>;

--- a/src/services/bootstrap/background-services.ts
+++ b/src/services/bootstrap/background-services.ts
@@ -57,7 +57,7 @@ import {
 } from '@services/sync/auto-sync/auto-sync-keys';
 import { storageGet } from '@services/shared/storage';
 
-type ExclusiveMaintenance = <T>(mutation: () => Promise<T>, options?: { clearStatusAfter?: boolean }) => Promise<T>;
+type ExclusiveMaintenance = <T>(mutation: () => Promise<T>) => Promise<T>;
 
 type SyncOwnershipSurface = {
   isRunActive: () => boolean;

--- a/src/services/sync/background-handlers.ts
+++ b/src/services/sync/background-handlers.ts
@@ -25,8 +25,8 @@ type Deps = {
   getInstanceId: () => string;
   notionSyncOrchestrator: {
     syncConversations: (input: { conversationIds?: unknown[]; instanceId: string }) => Promise<unknown>;
-    getSyncJobStatus: (input: { instanceId: string }) => Promise<unknown>;
-    clearSyncJobStatus: (input: { instanceId: string }) => Promise<unknown>;
+    getSyncJobStatus: () => Promise<unknown>;
+    clearSyncJobStatus: () => Promise<unknown>;
     isRunActive: () => boolean;
   };
   obsidianSyncOrchestrator: {
@@ -36,14 +36,14 @@ type Deps = {
       forceFullConversationIds?: unknown[];
       instanceId: string;
     }) => Promise<unknown>;
-    getSyncStatus: (input: { instanceId: string }) => Promise<unknown>;
-    clearSyncStatus: (input: { instanceId: string }) => Promise<unknown>;
+    getSyncStatus: () => Promise<unknown>;
+    clearSyncStatus: () => Promise<unknown>;
     isRunActive: () => boolean;
   };
   feishuSyncOrchestrator: {
     syncConversations: (input: { conversationIds?: unknown[]; instanceId: string }) => Promise<unknown>;
-    getSyncStatus: (input: { instanceId: string }) => Promise<unknown>;
-    clearSyncStatus: (input: { instanceId: string }) => Promise<unknown>;
+    getSyncStatus: () => Promise<unknown>;
+    clearSyncStatus: () => Promise<unknown>;
     isRunActive: () => boolean;
   };
   githubSyncOrchestrator: {
@@ -52,8 +52,8 @@ type Deps = {
       mode?: 'incremental' | 'reconcile';
       instanceId?: string;
     }) => Promise<unknown>;
-    getSyncStatus: (input: { instanceId?: string }) => Promise<unknown>;
-    clearSyncStatus: (input: { instanceId?: string }) => Promise<unknown>;
+    getSyncStatus: () => Promise<unknown>;
+    clearSyncStatus: () => Promise<unknown>;
     isRunActive: () => boolean;
   };
 };
@@ -147,7 +147,7 @@ export function registerSyncHandlers(router: AnyRouter, deps: Deps) {
 
   router.register(NOTION_MESSAGE_TYPES.GET_SYNC_JOB_STATUS, async () => {
     try {
-      const data: any = await deps.notionSyncOrchestrator.getSyncJobStatus({ instanceId: deps.getInstanceId() });
+      const data: any = await deps.notionSyncOrchestrator.getSyncJobStatus();
       return router.ok({ ...data, active: Boolean(notionDetachedRun) || deps.notionSyncOrchestrator.isRunActive() });
     } catch (error) {
       return toSyncErrorResponse(router, error);
@@ -156,7 +156,7 @@ export function registerSyncHandlers(router: AnyRouter, deps: Deps) {
 
   router.register(NOTION_MESSAGE_TYPES.CLEAR_SYNC_JOB_STATUS, async () => {
     try {
-      const data: any = await deps.notionSyncOrchestrator.clearSyncJobStatus({ instanceId: deps.getInstanceId() });
+      const data: any = await deps.notionSyncOrchestrator.clearSyncJobStatus();
       return router.ok({ ...data, active: false });
     } catch (error) {
       return toSyncErrorResponse(router, error);
@@ -165,7 +165,7 @@ export function registerSyncHandlers(router: AnyRouter, deps: Deps) {
 
   router.register(OBSIDIAN_MESSAGE_TYPES.GET_SYNC_STATUS, async () => {
     try {
-      const data: any = await deps.obsidianSyncOrchestrator.getSyncStatus({ instanceId: deps.getInstanceId() });
+      const data: any = await deps.obsidianSyncOrchestrator.getSyncStatus();
       return router.ok({
         ...data,
         active: Boolean(obsidianDetachedRun) || deps.obsidianSyncOrchestrator.isRunActive(),
@@ -177,7 +177,7 @@ export function registerSyncHandlers(router: AnyRouter, deps: Deps) {
 
   router.register(OBSIDIAN_MESSAGE_TYPES.CLEAR_SYNC_STATUS, async () => {
     try {
-      const data: any = await deps.obsidianSyncOrchestrator.clearSyncStatus({ instanceId: deps.getInstanceId() });
+      const data: any = await deps.obsidianSyncOrchestrator.clearSyncStatus();
       return router.ok({ ...data, active: false });
     } catch (error) {
       return toSyncErrorResponse(router, error);
@@ -288,7 +288,7 @@ export function registerSyncHandlers(router: AnyRouter, deps: Deps) {
 
   router.register(FEISHU_MESSAGE_TYPES.GET_SYNC_STATUS, async () => {
     try {
-      const data: any = await deps.feishuSyncOrchestrator.getSyncStatus({ instanceId: deps.getInstanceId() });
+      const data: any = await deps.feishuSyncOrchestrator.getSyncStatus();
       return router.ok({ ...data, active: Boolean(feishuDetachedRun) || deps.feishuSyncOrchestrator.isRunActive() });
     } catch (error) {
       return toSyncErrorResponse(router, error);
@@ -297,7 +297,7 @@ export function registerSyncHandlers(router: AnyRouter, deps: Deps) {
 
   router.register(FEISHU_MESSAGE_TYPES.CLEAR_SYNC_STATUS, async () => {
     try {
-      const data: any = await deps.feishuSyncOrchestrator.clearSyncStatus({ instanceId: deps.getInstanceId() });
+      const data: any = await deps.feishuSyncOrchestrator.clearSyncStatus();
       return router.ok({ ...data, active: false });
     } catch (error) {
       return toSyncErrorResponse(router, error);
@@ -341,7 +341,7 @@ export function registerSyncHandlers(router: AnyRouter, deps: Deps) {
 
   router.register(GITHUB_MESSAGE_TYPES.GET_SYNC_STATUS, async () => {
     try {
-      const data: any = await deps.githubSyncOrchestrator.getSyncStatus({ instanceId: deps.getInstanceId() });
+      const data: any = await deps.githubSyncOrchestrator.getSyncStatus();
       return router.ok({ ...data, active: Boolean(githubDetachedRun) || deps.githubSyncOrchestrator.isRunActive() });
     } catch (error) {
       return toSyncErrorResponse(router, error);
@@ -350,7 +350,7 @@ export function registerSyncHandlers(router: AnyRouter, deps: Deps) {
 
   router.register(GITHUB_MESSAGE_TYPES.CLEAR_SYNC_STATUS, async () => {
     try {
-      const data: any = await deps.githubSyncOrchestrator.clearSyncStatus({ instanceId: deps.getInstanceId() });
+      const data: any = await deps.githubSyncOrchestrator.clearSyncStatus();
       return router.ok({ ...data, active: false });
     } catch (error) {
       return toSyncErrorResponse(router, error);

--- a/src/services/sync/feishu/feishu-sync-orchestrator.ts
+++ b/src/services/sync/feishu/feishu-sync-orchestrator.ts
@@ -513,13 +513,10 @@ function clearSyncStatus() {
   });
 }
 
-function runExclusiveMaintenance<T>(
-  mutation: () => Promise<T>,
-  options: { clearStatusAfter?: boolean } = {},
-): Promise<T> {
+function runExclusiveMaintenance<T>(mutation: () => Promise<T>): Promise<T> {
   return feishuSyncOwnership.runExclusiveMutation(async () => {
     const result = await mutation();
-    if (options.clearStatusAfter === true && !(await feishuSyncJobStore.setJob(null))) throw buildJobPersistenceError();
+    if (!(await feishuSyncJobStore.setJob(null))) throw buildJobPersistenceError();
     return result;
   });
 }

--- a/src/services/sync/feishu/feishu-sync-orchestrator.ts
+++ b/src/services/sync/feishu/feishu-sync-orchestrator.ts
@@ -502,14 +502,14 @@ async function appendTextBlocks({
   return appended;
 }
 
-async function getSyncStatus({ instanceId }: { instanceId?: string } = {}) {
-  return { provider: SYNC_PROVIDER, job: await feishuSyncJobStore.getJob(), instanceId: safeString(instanceId) };
+async function getSyncStatus() {
+  return { provider: SYNC_PROVIDER, job: await feishuSyncJobStore.getJob() };
 }
 
-function clearSyncStatus({ instanceId }: { instanceId?: string } = {}) {
+function clearSyncStatus() {
   return feishuSyncOwnership.runExclusiveMutation(async () => {
     if (!(await feishuSyncJobStore.setJob(null))) throw buildJobPersistenceError();
-    return { provider: SYNC_PROVIDER, job: null, instanceId: safeString(instanceId) };
+    return { provider: SYNC_PROVIDER, job: null };
   });
 }
 

--- a/src/services/sync/feishu/settings-background-handlers.ts
+++ b/src/services/sync/feishu/settings-background-handlers.ts
@@ -14,7 +14,7 @@ type AnyRouter = {
 };
 
 type Deps = {
-  runExclusiveMaintenance: <T>(mutation: () => Promise<T>, options?: { clearStatusAfter?: boolean }) => Promise<T>;
+  runExclusiveMaintenance: <T>(mutation: () => Promise<T>) => Promise<T>;
 };
 
 function errorResponse(router: AnyRouter, error: unknown, fallback: string) {
@@ -64,9 +64,7 @@ export function registerFeishuSettingsHandlers(router: AnyRouter, deps: Deps) {
 
   router.register(FEISHU_MESSAGE_TYPES.DISCONNECT, async () => {
     try {
-      const clearedKeys = await deps.runExclusiveMaintenance(() => clearFeishuOAuthAttemptAndToken(), {
-        clearStatusAfter: true,
-      });
+      const clearedKeys = await deps.runExclusiveMaintenance(() => clearFeishuOAuthAttemptAndToken());
       return router.ok({ disconnected: true, clearedKeys });
     } catch (error) {
       return errorResponse(router, error, 'feishu disconnect failed');

--- a/src/services/sync/github/github-sync-orchestrator.ts
+++ b/src/services/sync/github/github-sync-orchestrator.ts
@@ -348,16 +348,8 @@ export function createGithubSyncOrchestrator(services: GithubOrchestratorService
     });
   }
 
-  function runExclusiveMaintenance<T>(
-    mutation: () => Promise<T>,
-    options: { clearStatusAfter?: boolean } = {},
-  ): Promise<T> {
-    return ownership.runExclusiveMutation(async () => {
-      const result = await mutation();
-      if (options.clearStatusAfter === true && !(await services.jobStore.setJob(null)))
-        throw buildJobPersistenceError();
-      return result;
-    });
+  function runExclusiveMaintenance<T>(mutation: () => Promise<T>): Promise<T> {
+    return ownership.runExclusiveMutation(mutation);
   }
 
   function reconcileStartupSyncJob() {

--- a/src/services/sync/github/github-sync-orchestrator.ts
+++ b/src/services/sync/github/github-sync-orchestrator.ts
@@ -337,18 +337,14 @@ export function createGithubSyncOrchestrator(services: GithubOrchestratorService
     };
   }
 
-  async function getSyncStatus(input: { instanceId?: string } = {}) {
-    return {
-      provider: 'github' as const,
-      job: await services.jobStore.getJob(),
-      instanceId: safeString(input.instanceId),
-    };
+  async function getSyncStatus() {
+    return { provider: 'github' as const, job: await services.jobStore.getJob() };
   }
 
-  function clearSyncStatus(input: { instanceId?: string } = {}) {
+  function clearSyncStatus() {
     return ownership.runExclusiveMutation(async () => {
       if (!(await services.jobStore.setJob(null))) throw buildJobPersistenceError();
-      return { provider: 'github' as const, job: null, instanceId: safeString(input.instanceId) };
+      return { provider: 'github' as const, job: null };
     });
   }
 

--- a/src/services/sync/github/settings-background-handlers.ts
+++ b/src/services/sync/github/settings-background-handlers.ts
@@ -40,7 +40,7 @@ type GithubSettingsServiceDeps = {
 };
 
 export type GithubSettingsHandlersDeps = Partial<GithubSettingsServiceDeps> & {
-  runExclusiveMaintenance: <T>(mutation: () => Promise<T>, options?: { clearStatusAfter?: boolean }) => Promise<T>;
+  runExclusiveMaintenance: <T>(mutation: () => Promise<T>) => Promise<T>;
 };
 
 const DEFAULT_DEPS: GithubSettingsServiceDeps = {

--- a/src/services/sync/models.ts
+++ b/src/services/sync/models.ts
@@ -58,5 +58,4 @@ export type SyncJobStatusResponse = {
   provider: SyncProvider;
   active: boolean;
   job: SyncJobSnapshot | null;
-  instanceId?: string;
 };

--- a/src/services/sync/models.ts
+++ b/src/services/sync/models.ts
@@ -36,9 +36,9 @@ export type SyncRunSummary = {
 };
 
 export type SyncJobSnapshot = {
-  id?: string;
+  id: string;
   provider: SyncProvider;
-  instanceId?: string;
+  instanceId: string;
   status: SyncJobPhase;
   startedAt: number;
   updatedAt: number;

--- a/src/services/sync/notion/notion-sync-orchestrator.ts
+++ b/src/services/sync/notion/notion-sync-orchestrator.ts
@@ -376,16 +376,14 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
     conversationKinds,
   } = services;
 
-  async function getSyncJobStatus(input: any) {
-    const instanceId = input && input.instanceId != null ? String(input.instanceId) : '';
-    return { provider: SYNC_PROVIDER, job: await notionJobStore.getJob(), instanceId };
+  async function getSyncJobStatus() {
+    return { provider: SYNC_PROVIDER, job: await notionJobStore.getJob() };
   }
 
-  function clearSyncJobStatus(input: any) {
-    const instanceId = input && input.instanceId != null ? String(input.instanceId) : '';
+  function clearSyncJobStatus() {
     return ownership.runExclusiveMutation(async () => {
       if (!(await notionJobStore.setJob(null))) throw buildJobPersistenceError();
-      return { provider: SYNC_PROVIDER, job: null, instanceId };
+      return { provider: SYNC_PROVIDER, job: null };
     });
   }
 

--- a/src/services/sync/notion/notion-sync-orchestrator.ts
+++ b/src/services/sync/notion/notion-sync-orchestrator.ts
@@ -387,13 +387,10 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
     });
   }
 
-  function runExclusiveMaintenance<T>(
-    mutation: () => Promise<T>,
-    options: { clearStatusAfter?: boolean } = {},
-  ): Promise<T> {
+  function runExclusiveMaintenance<T>(mutation: () => Promise<T>): Promise<T> {
     return ownership.runExclusiveMutation(async () => {
       const result = await mutation();
-      if (options.clearStatusAfter === true && !(await notionJobStore.setJob(null))) throw buildJobPersistenceError();
+      if (!(await notionJobStore.setJob(null))) throw buildJobPersistenceError();
       return result;
     });
   }

--- a/src/services/sync/notion/settings-background-handlers.ts
+++ b/src/services/sync/notion/settings-background-handlers.ts
@@ -12,7 +12,7 @@ type AnyRouter = {
 
 type Deps = {
   conversationKinds: { getNotionStorageKeys?: () => unknown[] } | null;
-  runExclusiveMaintenance: <T>(mutation: () => Promise<T>, options?: { clearStatusAfter?: boolean }) => Promise<T>;
+  runExclusiveMaintenance: <T>(mutation: () => Promise<T>) => Promise<T>;
 };
 
 function getNotionDisconnectStorageKeys(deps: Deps): string[] {
@@ -79,15 +79,12 @@ export function registerNotionSettingsHandlers(router: AnyRouter, deps: Deps) {
 
   router.register(NOTION_MESSAGE_TYPES.DISCONNECT, async () => {
     try {
-      const clearedKeys = await deps.runExclusiveMaintenance(
-        async () => {
-          const authKeys = await clearNotionOAuthAttemptAndToken();
-          const configKeys = getNotionDisconnectStorageKeys(deps);
-          await storageRemove(configKeys);
-          return [...authKeys, ...configKeys];
-        },
-        { clearStatusAfter: true },
-      );
+      const clearedKeys = await deps.runExclusiveMaintenance(async () => {
+        const authKeys = await clearNotionOAuthAttemptAndToken();
+        const configKeys = getNotionDisconnectStorageKeys(deps);
+        await storageRemove(configKeys);
+        return [...authKeys, ...configKeys];
+      });
       return router.ok({ disconnected: true, clearedKeys });
     } catch (error) {
       const message = String((error as any)?.message ?? error ?? 'notion disconnect failed');

--- a/src/services/sync/obsidian/obsidian-sync-orchestrator.ts
+++ b/src/services/sync/obsidian/obsidian-sync-orchestrator.ts
@@ -415,14 +415,14 @@ async function testConnection({ instanceId }: { instanceId?: string } = {}) {
   return { ok: true, data, message: okMessage, instanceId: safeString(instanceId) };
 }
 
-async function getSyncStatus({ instanceId }: { instanceId?: string } = {}) {
-  return { provider: SYNC_PROVIDER, job: await obsidianSyncJobStore.getJob(), instanceId: safeString(instanceId) };
+async function getSyncStatus() {
+  return { provider: SYNC_PROVIDER, job: await obsidianSyncJobStore.getJob() };
 }
 
-function clearSyncStatus({ instanceId }: { instanceId?: string } = {}) {
+function clearSyncStatus() {
   return obsidianSyncOwnership.runExclusiveMutation(async () => {
     if (!(await obsidianSyncJobStore.setJob(null))) throw buildJobPersistenceError();
-    return { provider: SYNC_PROVIDER, job: null, instanceId: safeString(instanceId) };
+    return { provider: SYNC_PROVIDER, job: null };
   });
 }
 

--- a/src/services/sync/sync-job-store.ts
+++ b/src/services/sync/sync-job-store.ts
@@ -86,7 +86,7 @@ export function normalizeSyncJobSnapshot(provider: SyncProvider, job: unknown): 
   if (!isRecord(job) || job.provider !== provider) return null;
   const status = job.status;
   if (status !== 'running' && status !== 'done' && status !== 'aborted') return null;
-  if (!isOptionalString(job.id) || !isOptionalString(job.instanceId)) return null;
+  if (typeof job.id !== 'string' || typeof job.instanceId !== 'string') return null;
   if (!isNonNegativeFiniteNumber(job.startedAt) || !isNonNegativeFiniteNumber(job.updatedAt)) return null;
   let finishedAt: number | null;
   if (status === 'running') {

--- a/src/viewmodels/conversations/useConversationSyncFeedback.ts
+++ b/src/viewmodels/conversations/useConversationSyncFeedback.ts
@@ -144,23 +144,12 @@ function buildAbortedMessage(job: SyncJobSnapshot) {
   return reason ? `${label} · ${t('syncStopped')}: ${reason}` : `${label} · ${t('syncStopped')}`;
 }
 
-function toFailureSummaries(summary: SyncRunSummary) {
-  if (Array.isArray(summary.failures) && summary.failures.length) return summary.failures;
-  return summary.results
-    .filter((result) => !result.ok)
-    .map((result) => ({
-      conversationId: Number(result.conversationId) || 0,
-      conversationTitle: String(result.conversationTitle || '').trim(),
-      error: String(result.error || 'unknown error'),
-    }));
-}
-
 function toWarningSummaries(summary: SyncRunSummary) {
   return toWarningSummariesFromRows(summary.results);
 }
 
 function toTerminalFeedback(summary: SyncRunSummary, total: number): ConversationSyncFeedbackState {
-  const failures = toFailureSummaries(summary);
+  const failures = summary.failures;
   const warnings = toWarningSummaries(summary);
   const phase: ConversationSyncFeedbackPhase =
     summary.failCount <= 0 ? 'success' : summary.okCount > 0 ? 'partial-failed' : 'failed';
@@ -240,18 +229,7 @@ function toFeedbackFromJob(job: SyncJobSnapshot): ConversationSyncFeedbackState 
     };
   }
 
-  return toTerminalFeedback(
-    {
-      provider: job.provider,
-      okCount: job.okCount,
-      failCount: job.failCount,
-      failures,
-      results: job.perConversation.slice(),
-      jobId: job.id,
-      instanceId: job.instanceId,
-    },
-    total,
-  );
+  return toTerminalFeedback(toSummaryFromJob(job)!, total);
 }
 
 type StatusObservation = {

--- a/tests/smoke/background-router-github-sync.test.ts
+++ b/tests/smoke/background-router-github-sync.test.ts
@@ -129,12 +129,11 @@ describe('background-router github sync routes', () => {
   it('delegates status and clear through the production sync contract', async () => {
     installStorage({});
     const githubSyncOrchestrator = {
-      getSyncStatus: vi.fn(async ({ instanceId }: any) => ({
+      getSyncStatus: vi.fn(async () => ({
         provider: 'github',
         job: { status: 'done' },
-        instanceId,
       })),
-      clearSyncStatus: vi.fn(async ({ instanceId }: any) => ({ provider: 'github', job: null, instanceId })),
+      clearSyncStatus: vi.fn(async () => ({ provider: 'github', job: null })),
       sync: vi.fn(async () => ({})),
       isRunActive: vi.fn(() => false),
     };
@@ -143,14 +142,14 @@ describe('background-router github sync routes', () => {
     const status = await router.__handleMessageForTests({ type: GITHUB_MESSAGE_TYPES.GET_SYNC_STATUS });
     expect(status).toMatchObject({
       ok: true,
-      data: { provider: 'github', active: false, job: { status: 'done' }, instanceId: 'instance-status' },
+      data: { provider: 'github', active: false, job: { status: 'done' } },
     });
 
     const cleared = await router.__handleMessageForTests({ type: GITHUB_MESSAGE_TYPES.CLEAR_SYNC_STATUS });
     expect(cleared).toMatchObject({
       ok: true,
-      data: { provider: 'github', active: false, job: null, instanceId: 'instance-status' },
+      data: { provider: 'github', active: false, job: null },
     });
-    expect(githubSyncOrchestrator.clearSyncStatus).toHaveBeenCalledWith({ instanceId: 'instance-status' });
+    expect(githubSyncOrchestrator.clearSyncStatus).toHaveBeenCalledWith();
   });
 });

--- a/tests/smoke/background-router-obsidian-sync.test.ts
+++ b/tests/smoke/background-router-obsidian-sync.test.ts
@@ -78,12 +78,12 @@ describe('background-router obsidian sync routes', () => {
           }
           return { ok: true, instanceId };
         },
-        async getSyncStatus({ instanceId }: any) {
+        async getSyncStatus() {
           calls.getSyncStatus += 1;
-          return { job: null, instanceId };
+          return { provider: 'obsidian', job: null };
         },
-        async clearSyncStatus({ instanceId }: any) {
-          return { job: null, instanceId };
+        async clearSyncStatus() {
+          return { provider: 'obsidian', job: null };
         },
         isRunActive: () => false,
         async syncConversations(payload: any) {
@@ -143,7 +143,6 @@ describe('background-router obsidian sync routes', () => {
     const statusRes = await router.__handleMessageForTests({ type: 'obsidianGetSyncStatus' });
     expect(statusRes.ok).toBe(true);
     expect(calls.getSyncStatus).toBe(1);
-    expect(typeof statusRes.data?.instanceId).toBe('string');
     expect(statusRes.data?.active).toBe(false);
 
     const syncRes = await router.__handleMessageForTests({

--- a/tests/smoke/background-router-sync-ownership.test.ts
+++ b/tests/smoke/background-router-sync-ownership.test.ts
@@ -291,17 +291,15 @@ describe('Feishu destructive settings ownership', () => {
       }),
     });
     registerFeishuSettingsHandlers(router as any, {
-      runExclusiveMaintenance: <T>(mutation: () => Promise<T>, options: { clearStatusAfter?: boolean } = {}) =>
+      runExclusiveMaintenance: <T>(mutation: () => Promise<T>) =>
         ownership.runExclusiveMutation(async () => {
           const result = await mutation();
-          if (options.clearStatusAfter === true) {
-            if (!clearSucceeds) {
-              throw Object.assign(new Error('feishu sync job persistence failed'), {
-                code: 'feishu_sync_job_persist_failed',
-              });
-            }
-            job = null;
+          if (!clearSucceeds) {
+            throw Object.assign(new Error('feishu sync job persistence failed'), {
+              code: 'feishu_sync_job_persist_failed',
+            });
           }
+          job = null;
           return result;
         }),
     });

--- a/tests/smoke/conversations-sync-feedback.test.ts
+++ b/tests/smoke/conversations-sync-feedback.test.ts
@@ -326,7 +326,9 @@ describe('Conversations sync feedback', () => {
 
   function notionRunningJob(overrides: Record<string, unknown> = {}) {
     return {
+      id: 'notion-job',
       provider: 'notion',
+      instanceId: 'notion-background',
       status: 'running',
       startedAt: Date.now(),
       updatedAt: Date.now(),
@@ -371,7 +373,9 @@ describe('Conversations sync feedback', () => {
 
   function githubJob(overrides: Record<string, unknown> = {}) {
     return {
+      id: 'github-job',
       provider: 'github',
+      instanceId: 'github-background',
       status: 'running',
       startedAt: Date.now() - 500,
       updatedAt: Date.now(),
@@ -540,7 +544,6 @@ describe('Conversations sync feedback', () => {
     getNotionSyncJobStatus.mockResolvedValue({
       provider: 'notion',
       active: true,
-      instanceId: 'notion-test',
       job: notionRunningJob({ currentConversationTitle: 'Preferred Notion' }),
     });
     await renderFeedbackProbe();
@@ -887,7 +890,6 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: true,
       job: notionRunningJob({ currentConversationTitle: 'Old poll response', okCount: 0, totalCount: 3 }),
-      instanceId: 'notion-test',
     });
     await act(async () => {
       await flushMicrotasks();
@@ -1076,7 +1078,6 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: true,
       job: notionRunningJob({ totalCount: 3, okCount: 0, currentConversationTitle: 'Older known read' }),
-      instanceId: 'notion-test',
     });
     await act(async () => {
       await startPromise;
@@ -1285,7 +1286,6 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: true,
       job: notionRunningJob({ totalCount: 3, okCount: 0, currentConversationTitle: 'Stale mount' }),
-      instanceId: 'old-mount',
     });
     await act(async () => {
       await flushMicrotasks();
@@ -1325,7 +1325,6 @@ describe('Conversations sync feedback', () => {
     getNotionSyncJobStatus.mockResolvedValue({
       provider: 'notion',
       active: true,
-      instanceId: 'notion-test',
       job: null,
     });
     selectFirstConversation();
@@ -1341,7 +1340,6 @@ describe('Conversations sync feedback', () => {
     getNotionSyncJobStatus.mockResolvedValue({
       provider: 'notion',
       active: true,
-      instanceId: 'notion-test',
       job: notionRunningJob(),
     });
 
@@ -1363,9 +1361,10 @@ describe('Conversations sync feedback', () => {
     getNotionSyncJobStatus.mockResolvedValue({
       provider: 'notion',
       active: false,
-      instanceId: 'notion-test',
       job: {
+        id: 'notion-success-job',
         provider: 'notion',
+        instanceId: 'notion-background',
         status: 'done',
         startedAt: Date.now() - 500,
         updatedAt: Date.now(),
@@ -1411,7 +1410,6 @@ describe('Conversations sync feedback', () => {
     getNotionSyncJobStatus.mockResolvedValue({
       provider: 'notion',
       active: true,
-      instanceId: 'notion-test',
       job: notionRunningJob(),
     });
     await renderPane();
@@ -1435,7 +1433,6 @@ describe('Conversations sync feedback', () => {
     getNotionSyncJobStatus.mockResolvedValue({
       provider: 'notion',
       active: true,
-      instanceId: 'notion-test',
       job: notionRunningJob({
         totalCount: 5,
         conversationIds: [],
@@ -1462,7 +1459,6 @@ describe('Conversations sync feedback', () => {
     getNotionSyncJobStatus.mockResolvedValue({
       provider: 'notion',
       active: false,
-      instanceId: 'notion-test',
       job: notionRunningJob({ updatedAt: Date.now() - 10 * 60_000 }),
     });
 
@@ -1476,7 +1472,6 @@ describe('Conversations sync feedback', () => {
     getNotionSyncJobStatus.mockResolvedValue({
       provider: 'notion',
       active: true,
-      instanceId: 'notion-test',
       job: null,
     });
 
@@ -1496,7 +1491,9 @@ describe('Conversations sync feedback', () => {
 
   it('keeps a terminal snapshot non-dismissible while ownership is active and exposes it only after settle', async () => {
     const terminalJob = {
+      id: 'notion-terminal-job',
       provider: 'notion',
+      instanceId: 'notion-background',
       status: 'done',
       startedAt: Date.now() - 500,
       updatedAt: Date.now(),
@@ -1520,7 +1517,6 @@ describe('Conversations sync feedback', () => {
     getNotionSyncJobStatus.mockResolvedValue({
       provider: 'notion',
       active: true,
-      instanceId: 'notion-test',
       job: terminalJob,
     });
 
@@ -1531,7 +1527,6 @@ describe('Conversations sync feedback', () => {
     getNotionSyncJobStatus.mockResolvedValue({
       provider: 'notion',
       active: false,
-      instanceId: 'notion-test',
       job: terminalJob,
     });
     await act(async () => {
@@ -1552,7 +1547,6 @@ describe('Conversations sync feedback', () => {
     getNotionSyncJobStatus.mockResolvedValue({
       provider: 'notion',
       active: true,
-      instanceId: 'notion-test',
       job: notionRunningJob(),
     });
     await renderFeedbackProbe();
@@ -1569,7 +1563,6 @@ describe('Conversations sync feedback', () => {
     getNotionSyncJobStatus.mockResolvedValue({
       provider: 'notion',
       active: false,
-      instanceId: 'notion-test',
       job: null,
     });
     await act(async () => {
@@ -1596,7 +1589,6 @@ describe('Conversations sync feedback', () => {
     staleMount.resolve({
       provider: 'notion',
       active: true,
-      instanceId: 'stale-mount',
       job: notionRunningJob({ id: 'stale-running' }),
     });
     await act(async () => {
@@ -1612,9 +1604,10 @@ describe('Conversations sync feedback', () => {
     getNotionSyncJobStatus.mockResolvedValue({
       provider: 'notion',
       active: false,
-      instanceId: 'notion-test',
       job: {
+        id: 'notion-aborted-job',
         provider: 'notion',
+        instanceId: 'notion-background',
         status: 'aborted',
         startedAt: Date.now() - 2_000,
         updatedAt: Date.now(),
@@ -1652,7 +1645,6 @@ describe('Conversations sync feedback', () => {
     getNotionSyncJobStatus.mockResolvedValue({
       provider: 'notion',
       active: true,
-      instanceId: 'notion-test',
       job: notionRunningJob(),
     });
 
@@ -1679,9 +1671,10 @@ describe('Conversations sync feedback', () => {
     getNotionSyncJobStatus.mockResolvedValue({
       provider: 'notion',
       active: false,
-      instanceId: 'notion-test',
       job: {
+        id: 'notion-failed-job',
         provider: 'notion',
+        instanceId: 'notion-background',
         status: 'done',
         startedAt: Date.now() - 800,
         updatedAt: Date.now(),
@@ -1735,13 +1728,15 @@ describe('Conversations sync feedback', () => {
     getNotionSyncJobStatus.mockResolvedValue({
       provider: 'notion',
       active: false,
-      instanceId: 'notion-test',
       job: {
+        id: 'notion-warning-job',
         provider: 'notion',
+        instanceId: 'notion-background',
         status: 'done',
         startedAt: Date.now() - 800,
         updatedAt: Date.now(),
         finishedAt: Date.now(),
+        totalCount: 1,
         conversationIds: [11],
         okCount: 1,
         failCount: 0,
@@ -1825,7 +1820,6 @@ describe('Conversations sync feedback', () => {
     getGithubSyncStatus.mockResolvedValue({
       provider: 'github',
       active: true,
-      instanceId: 'github-test',
       job: githubJob(),
     });
 
@@ -1843,7 +1837,6 @@ describe('Conversations sync feedback', () => {
     getGithubSyncStatus.mockResolvedValue({
       provider: 'github',
       active: false,
-      instanceId: 'github-test',
       job: githubJob({
         status: 'done',
         finishedAt: Date.now(),
@@ -1865,7 +1858,6 @@ describe('Conversations sync feedback', () => {
     getGithubSyncStatus.mockResolvedValue({
       provider: 'github',
       active: false,
-      instanceId: 'github-test',
       job: githubJob({
         status: 'done',
         finishedAt: Date.now(),
@@ -1932,13 +1924,11 @@ describe('Conversations sync feedback', () => {
     getNotionSyncJobStatus.mockResolvedValue({
       provider: 'notion',
       active: true,
-      instanceId: 'notion-test',
       job: notionRunningJob({ updatedAt: Date.now() + 10_000 }),
     });
     getGithubSyncStatus.mockResolvedValue({
       provider: 'github',
       active: true,
-      instanceId: 'github-test',
       job: githubJob({ updatedAt: Date.now() }),
     });
 

--- a/tests/smoke/conversations-sync-feedback.test.ts
+++ b/tests/smoke/conversations-sync-feedback.test.ts
@@ -201,40 +201,34 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: false,
       job: null,
-      instanceId: 'notion-test',
     });
     clearObsidianSyncStatus.mockResolvedValue({
       provider: 'obsidian',
       active: false,
       job: null,
-      instanceId: 'obsidian-test',
     });
     clearFeishuSyncStatus.mockResolvedValue({
       provider: 'feishu',
       active: false,
       job: null,
-      instanceId: 'feishu-test',
     });
     clearGithubSyncStatus.mockResolvedValue({
       provider: 'github',
       active: false,
       job: null,
-      instanceId: 'github-test',
     });
     getNotionSyncJobStatus.mockResolvedValue({
       provider: 'notion',
       active: false,
       job: null,
-      instanceId: 'notion-test',
     });
     getObsidianSyncStatus.mockResolvedValue({
       provider: 'obsidian',
       active: false,
       job: null,
-      instanceId: 'obsidian-test',
     });
-    getFeishuSyncStatus.mockResolvedValue({ provider: 'feishu', active: false, job: null, instanceId: 'feishu-test' });
-    getGithubSyncStatus.mockResolvedValue({ provider: 'github', active: false, job: null, instanceId: 'github-test' });
+    getFeishuSyncStatus.mockResolvedValue({ provider: 'feishu', active: false, job: null });
+    getGithubSyncStatus.mockResolvedValue({ provider: 'github', active: false, job: null });
   });
 
   afterEach(() => {
@@ -411,7 +405,7 @@ describe('Conversations sync feedback', () => {
     'converges a successful %s start with only the target provider status read',
     async (provider, starter, getter) => {
       starter.mockResolvedValue({ provider, started: true });
-      getter.mockResolvedValue({ provider, active: true, job: null, instanceId: `${provider}-test` });
+      getter.mockResolvedValue({ provider, active: true, job: null });
       await renderFeedbackProbe();
       clearStatusGetterCalls();
 
@@ -433,7 +427,6 @@ describe('Conversations sync feedback', () => {
       provider: 'obsidian',
       active: true,
       job: null,
-      instanceId: 'obsidian-test',
     });
     await renderFeedbackProbe();
     clearStatusGetterCalls();
@@ -572,16 +565,14 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: true,
       job: null,
-      instanceId: 'notion-test',
     });
     getObsidianSyncStatus.mockResolvedValue({
       provider: 'obsidian',
       active: true,
       job: null,
-      instanceId: 'obsidian-test',
     });
-    getFeishuSyncStatus.mockResolvedValue({ provider: 'feishu', active: true, job: null, instanceId: 'feishu-test' });
-    getGithubSyncStatus.mockResolvedValue({ provider: 'github', active: true, job: null, instanceId: 'github-test' });
+    getFeishuSyncStatus.mockResolvedValue({ provider: 'feishu', active: true, job: null });
+    getGithubSyncStatus.mockResolvedValue({ provider: 'github', active: true, job: null });
 
     await renderFeedbackProbe();
 
@@ -596,7 +587,6 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: true,
       job: terminal,
-      instanceId: 'notion-test',
     });
 
     await emitStorageChanges({ [SYNC_JOB_STORAGE_KEYS.notion]: { newValue: terminal } });
@@ -610,7 +600,6 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: false,
       job: terminal,
-      instanceId: 'notion-test',
     });
     await act(async () => {
       vi.advanceTimersByTime(500);
@@ -639,7 +628,6 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: false,
       job: terminal,
-      instanceId: 'notion-test',
     });
     await act(async () => {
       vi.advanceTimersByTime(500);
@@ -659,8 +647,8 @@ describe('Conversations sync feedback', () => {
     });
     clearStatusGetterCalls();
     getNotionSyncJobStatus
-      .mockResolvedValueOnce({ provider: 'notion', active: false, job: terminal, instanceId: 'notion-test' })
-      .mockResolvedValueOnce({ provider: 'notion', active: false, job: null, instanceId: 'notion-test' });
+      .mockResolvedValueOnce({ provider: 'notion', active: false, job: terminal })
+      .mockResolvedValueOnce({ provider: 'notion', active: false, job: null });
 
     await act(async () => {
       vi.advanceTimersByTime(500);
@@ -681,7 +669,7 @@ describe('Conversations sync feedback', () => {
     });
     clearStatusGetterCalls();
     getNotionSyncJobStatus
-      .mockResolvedValueOnce({ provider: 'notion', active: false, job: terminal, instanceId: 'notion-test' })
+      .mockResolvedValueOnce({ provider: 'notion', active: false, job: terminal })
       .mockRejectedValueOnce(new Error('handoff read failed'));
 
     await act(async () => {
@@ -701,7 +689,6 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: true,
       job: notionRunningJob({ currentConversationTitle: 'Notion still owns' }),
-      instanceId: 'notion-test',
     });
     await renderFeedbackProbe();
     clearStatusGetterCalls();
@@ -709,13 +696,11 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: true,
       job: terminal,
-      instanceId: 'notion-test',
     });
     getGithubSyncStatus.mockResolvedValue({
       provider: 'github',
       active: true,
       job: githubJob({ currentConversationTitle: 'Hidden GitHub' }),
-      instanceId: 'github-test',
     });
 
     await emitStorageChanges({ [SYNC_JOB_STORAGE_KEYS.notion]: { newValue: terminal } });
@@ -731,7 +716,6 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: false,
       job: terminal,
-      instanceId: 'notion-test',
     });
     await act(async () => {
       vi.advanceTimersByTime(500);
@@ -753,7 +737,6 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: true,
       job: notionRunningJob({ currentConversationTitle: 'Notion preferred' }),
-      instanceId: 'notion-test',
     });
     await renderFeedbackProbe();
     clearStatusGetterCalls();
@@ -762,7 +745,6 @@ describe('Conversations sync feedback', () => {
       provider: 'github',
       active: true,
       job: githubJob({ currentConversationTitle: 'GitHub must wait' }),
-      instanceId: 'github-test',
     });
 
     await emitStorageChanges({ [SYNC_JOB_STORAGE_KEYS.notion]: { newValue: terminal } });
@@ -777,7 +759,6 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: false,
       job: terminal,
-      instanceId: 'notion-test',
     });
     await act(async () => {
       vi.advanceTimersByTime(500);
@@ -794,7 +775,6 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: false,
       job: terminal,
-      instanceId: 'notion-test',
     });
     await renderFeedbackProbe();
     expect(latestFeedback?.feedback).toMatchObject({ provider: 'notion', phase: 'success' });
@@ -808,7 +788,6 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: false,
       job: null,
-      instanceId: 'notion-test',
     });
     await emitStorageChanges({ [SYNC_JOB_STORAGE_KEYS.notion]: { newValue: null } });
     expectStatusGetterCalls({ notion: 1, obsidian: 1, feishu: 1, github: 1 });
@@ -823,7 +802,6 @@ describe('Conversations sync feedback', () => {
         provider: 'notion',
         active: true,
         job: notionRunningJob({ currentConversationTitle: 'Current Notion' }),
-        instanceId: 'notion-test',
       });
       await renderFeedbackProbe();
       clearStatusGetterCalls();
@@ -831,13 +809,11 @@ describe('Conversations sync feedback', () => {
         provider: 'notion',
         active: false,
         job: terminal,
-        instanceId: 'notion-test',
       });
       getGithubSyncStatus.mockResolvedValue({
         provider: 'github',
         active: true,
         job: githubJob({ currentConversationTitle: 'Surviving GitHub' }),
-        instanceId: 'github-test',
       });
       const terminalChange = [SYNC_JOB_STORAGE_KEYS.notion, { newValue: terminal }] as const;
       const runningChange = [SYNC_JOB_STORAGE_KEYS.github, { newValue: githubJob() }] as const;
@@ -858,7 +834,6 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: true,
       job: notionRunningJob(),
-      instanceId: 'notion-test',
     });
     await renderFeedbackProbe();
     clearStatusGetterCalls();
@@ -877,7 +852,7 @@ describe('Conversations sync feedback', () => {
     });
     expectStatusGetterCalls({ notion: 1 });
 
-    poll.resolve({ provider: 'notion', active: true, job: notionRunningJob(), instanceId: 'notion-test' });
+    poll.resolve({ provider: 'notion', active: true, job: notionRunningJob() });
     await act(async () => {
       await flushMicrotasks();
       await flushMicrotasks();
@@ -889,7 +864,6 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: true,
       job: notionRunningJob({ currentConversationTitle: 'Initial' }),
-      instanceId: 'notion-test',
     });
     await renderFeedbackProbe();
     clearStatusGetterCalls();
@@ -929,7 +903,6 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: true,
       job: notionRunningJob(),
-      instanceId: 'notion-test',
     });
     await renderFeedbackProbe();
     clearStatusGetterCalls();
@@ -945,7 +918,7 @@ describe('Conversations sync feedback', () => {
     });
     expect(getNotionSyncJobStatus).toHaveBeenCalledTimes(1);
 
-    handoffRead.resolve({ provider: 'notion', active: false, job: terminal, instanceId: 'notion-test' });
+    handoffRead.resolve({ provider: 'notion', active: false, job: terminal });
     await act(async () => {
       await flushMicrotasks();
       await flushMicrotasks();
@@ -960,7 +933,6 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: true,
       job: notionRunningJob(),
-      instanceId: 'notion-test',
     });
     await renderFeedbackProbe();
     clearStatusGetterCalls();
@@ -974,7 +946,7 @@ describe('Conversations sync feedback', () => {
     await emitStorageChanges({ [SYNC_JOB_STORAGE_KEYS.notion]: { newValue: secondTerminal } });
     expect(getNotionSyncJobStatus).toHaveBeenCalledTimes(2);
 
-    firstRead.resolve({ provider: 'notion', active: false, job: firstTerminal, instanceId: 'notion-test' });
+    firstRead.resolve({ provider: 'notion', active: false, job: firstTerminal });
     await act(async () => {
       await flushMicrotasks();
       vi.advanceTimersByTime(500);
@@ -982,7 +954,7 @@ describe('Conversations sync feedback', () => {
     });
     expect(getNotionSyncJobStatus).toHaveBeenCalledTimes(2);
 
-    secondRead.resolve({ provider: 'notion', active: false, job: secondTerminal, instanceId: 'notion-test' });
+    secondRead.resolve({ provider: 'notion', active: false, job: secondTerminal });
     await act(async () => {
       await flushMicrotasks();
       await flushMicrotasks();
@@ -999,7 +971,6 @@ describe('Conversations sync feedback', () => {
       provider: 'obsidian',
       active: true,
       job: null,
-      instanceId: 'obsidian-test',
     });
     await renderFeedbackProbe();
     clearStatusGetterCalls();
@@ -1018,7 +989,6 @@ describe('Conversations sync feedback', () => {
       provider: 'obsidian',
       active: false,
       job: null,
-      instanceId: 'obsidian-test',
     });
     await act(async () => {
       vi.advanceTimersByTime(500);
@@ -1068,7 +1038,6 @@ describe('Conversations sync feedback', () => {
       provider: 'github',
       active: false,
       job: githubJob({ currentConversationTitle: 'Residue GitHub' }),
-      instanceId: 'github-test',
     });
     await act(async () => {
       vi.advanceTimersByTime(500);
@@ -1123,14 +1092,13 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: true,
       job: notionRunningJob({ currentConversationTitle: 'Before terminal' }),
-      instanceId: 'notion-test',
     });
     await renderFeedbackProbe();
     clearStatusGetterCalls();
     const oldPoll = deferred<any>();
     getNotionSyncJobStatus
       .mockImplementationOnce(() => oldPoll.promise)
-      .mockResolvedValueOnce({ provider: 'notion', active: false, job: terminal, instanceId: 'notion-test' });
+      .mockResolvedValueOnce({ provider: 'notion', active: false, job: terminal });
 
     await act(async () => {
       vi.advanceTimersByTime(500);
@@ -1145,7 +1113,6 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: true,
       job: notionRunningJob({ currentConversationTitle: 'Stale running poll' }),
-      instanceId: 'notion-test',
     });
     await act(async () => {
       await flushMicrotasks();
@@ -1169,7 +1136,6 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: false,
       job: notionTerminal,
-      instanceId: 'notion-test',
     });
     await renderFeedbackProbe();
     clearStatusGetterCalls();
@@ -1187,7 +1153,6 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: false,
       job: terminal,
-      instanceId: 'notion-test',
     });
     await renderFeedbackProbe();
     clearStatusGetterCalls();
@@ -1210,7 +1175,6 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: false,
       job: terminal,
-      instanceId: 'notion-test',
     });
     await renderFeedbackProbe();
     const listener = storageEventMocks.listener;
@@ -1219,13 +1183,11 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: false,
       job: null,
-      instanceId: 'notion-test',
     });
     getGithubSyncStatus.mockResolvedValue({
       provider: 'github',
       active: true,
       job: githubJob({ currentConversationTitle: 'Surviving after clear' }),
-      instanceId: 'github-test',
     });
 
     await emitStorageChanges({ [SYNC_JOB_STORAGE_KEYS.notion]: { newValue: null } });
@@ -1251,7 +1213,6 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: true,
       job: terminal,
-      instanceId: 'notion-test',
     });
 
     await act(async () => {
@@ -1266,7 +1227,6 @@ describe('Conversations sync feedback', () => {
       provider: 'notion',
       active: false,
       job: terminal,
-      instanceId: 'notion-test',
     });
     await act(async () => {
       vi.advanceTimersByTime(500);
@@ -1289,7 +1249,7 @@ describe('Conversations sync feedback', () => {
       conflict.code = 'sync_already_running';
       conflict.extra = { code: 'sync_already_running' };
       starter.mockRejectedValue(conflict);
-      getter.mockResolvedValue({ provider, active: true, job: null, instanceId: `${provider}-test` });
+      getter.mockResolvedValue({ provider, active: true, job: null });
       await renderFeedbackProbe();
       clearStatusGetterCalls();
 
@@ -1341,7 +1301,6 @@ describe('Conversations sync feedback', () => {
       provider: 'github',
       active: false,
       job: githubJob({ currentConversationTitle: 'Ownerless residue' }),
-      instanceId: 'github-test',
     });
     await renderFeedbackProbe();
     clearStatusGetterCalls();

--- a/tests/smoke/github-sync-orchestrator.test.ts
+++ b/tests/smoke/github-sync-orchestrator.test.ts
@@ -660,7 +660,7 @@ describe('github sync orchestrator job lifecycle', () => {
     });
     const orchestrator = createGithubSyncOrchestrator(services);
 
-    await expect(orchestrator.clearSyncStatus({ instanceId: 'clear-test' })).rejects.toMatchObject({
+    await expect(orchestrator.clearSyncStatus()).rejects.toMatchObject({
       code: 'github_sync_job_persist_failed',
     });
     expect(getPersistedJob()).toEqual(residue);

--- a/tests/smoke/notion-sync-orchestrator-kind-routing.test.ts
+++ b/tests/smoke/notion-sync-orchestrator-kind-routing.test.ts
@@ -569,11 +569,11 @@ describe('notion-sync-orchestrator kind routing', () => {
       jobStore,
     });
 
-    const status = await orchestrator.getSyncJobStatus({ instanceId: 'background-new' });
+    const status = await orchestrator.getSyncJobStatus();
     expect(status.job?.status).toBe('running');
 
     await orchestrator.reconcileStartupSyncJob();
-    const reconciled = await orchestrator.getSyncJobStatus({ instanceId: 'background-new' });
+    const reconciled = await orchestrator.getSyncJobStatus();
     expect(reconciled.job?.status).toBe('aborted');
     expect(reconciled.job?.abortedReason).toBe('extension reloaded');
   });

--- a/tests/smoke/obsidian-sync-orchestrator.test.ts
+++ b/tests/smoke/obsidian-sync-orchestrator.test.ts
@@ -215,7 +215,7 @@ describe('obsidian-sync-orchestrator', () => {
       conversationIds: [],
       perConversation: [],
     });
-    expect((await orch.getSyncStatus({ instanceId: 'first' })).job).toBeNull();
+    expect((await orch.getSyncStatus()).job).toBeNull();
 
     let conflict: unknown = null;
     try {
@@ -251,7 +251,7 @@ describe('obsidian-sync-orchestrator', () => {
       perConversation: [expect.objectContaining({ conversationId: 1, ok: true })],
     });
     expect(orch.isRunActive()).toBe(false);
-    expect((await orch.getSyncStatus({ instanceId: 'first' })).job).toBeNull();
+    expect((await orch.getSyncStatus()).job).toBeNull();
   });
 
   it('materializes SyncNos image refs through the shared Markdown helper without changing Obsidian naming', async () => {
@@ -527,7 +527,7 @@ describe('obsidian-sync-orchestrator', () => {
     expect(putBody).toContain('# Conversations');
     expect(putBody).toContain('## 1 assistant');
 
-    const status = await orch.getSyncStatus({ instanceId: 'x' });
+    const status = await orch.getSyncStatus();
     expect(status.job?.status).toBe('done');
   });
 
@@ -552,7 +552,7 @@ describe('obsidian-sync-orchestrator', () => {
     });
     const orch = await loadModule('@services/sync/obsidian/obsidian-sync-orchestrator.ts');
 
-    const status = await orch.getSyncStatus({ instanceId: 'background-new' });
+    const status = await orch.getSyncStatus();
     expect(status.job?.status).toBe('running');
     expect((await jobStore.getJob())?.status).toBe('running');
 
@@ -918,7 +918,7 @@ describe('obsidian-sync-orchestrator', () => {
       ok: true,
       mode: 'full_rebuild',
     });
-    const status = await orch.getSyncStatus({ instanceId: 'x' });
+    const status = await orch.getSyncStatus();
     expect(status.job?.perConversation?.[0]).toMatchObject({
       conversationId: 1,
       conversationTitle: 'Isolation 1',

--- a/tests/unit/feishu-skip-unchanged.test.ts
+++ b/tests/unit/feishu-skip-unchanged.test.ts
@@ -172,7 +172,7 @@ describe('feishu skip unchanged', () => {
       perConversation: [expect.objectContaining({ conversationId: 1, ok: true })],
     });
     expect(orch.isRunActive()).toBe(false);
-    expect(await orch.getSyncStatus({ instanceId: 'first' })).toMatchObject({ provider: 'feishu', job: null });
+    expect(await orch.getSyncStatus()).toMatchObject({ provider: 'feishu', job: null });
   });
 
   it('skips syncing when content hash unchanged and docId exists', async () => {

--- a/tests/unit/sync-job-store-normalize.test.ts
+++ b/tests/unit/sync-job-store-normalize.test.ts
@@ -108,6 +108,8 @@ describe('normalizeSyncJobSnapshot', () => {
 
   it.each([
     ['provider mismatch', { provider: 'github' }],
+    ['missing job id', { id: undefined }],
+    ['missing background instance id', { instanceId: undefined }],
     ['missing totalCount', { totalCount: undefined }],
     ['fractional totalCount', { totalCount: 1.5 }],
     ['coerced timestamp', { startedAt: '1' }],
@@ -164,7 +166,7 @@ describe('normalizeSyncJobSnapshot', () => {
     await expect(createSyncJobStore('notion').getJob()).resolves.toBeNull();
   });
 
-  it('materializes a current orphan running job as aborted without instance or age heuristics', async () => {
+  it('materializes a current orphan running job as aborted without instance ownership or age heuristics', async () => {
     const { createSyncJobStore, SYNC_JOB_STORAGE_KEYS } = await import('@services/sync/sync-job-store');
     storageState[SYNC_JOB_STORAGE_KEYS.notion] = runningJob({ currentConversationId: undefined });
 


### PR DESCRIPTION
## Related issue

N/A — 本次是仓库内已完成 P1 SyncJob performance-refactor 的执行后 correctness / compatibility cleanup；没有对应的已约定 GitHub Issue。

## Why

P1 已将 provider 同步生命周期收敛到 canonical v2 SyncJob、process-local ownership 与直接 durable status consumption，但执行后专项复审仍发现少量旧兼容和重复 surface：GET/CLEAR status 的无消费者 instanceId 回显、可选 maintenance 分支、terminal failure 双真源、以及 strict v2 reader 对缺失 durable identity 的容忍。这些路径会扩大协议面、掩盖内部状态漂移，并让测试继续认可 production 不可能产生的旧 snapshot。

本 PR 删除这些残留，使当前 producer、durable reader、background status DTO 与 UI feedback 使用单一 P1 contract。

## Scope

### In scope

- 删除 GET/CLEAR sync status 顶层 `instanceId` echo 与对应无意义参数链。
- 固定 Notion / Feishu / GitHub maintenance 的真实 production 语义，删除 `clearStatusAfter?` 动态分支。
- 删除 terminal feedback 对 `summary.results` 的 failure fallback，统一消费 required `summary.failures`。
- 将 canonical v2 `SyncJobSnapshot.id` / `instanceId` 收紧为 required，并让 parser 对缺失 identity fail closed。
- 清理 feedback / status 测试中仍构造旧 SyncJob shape 或旧 status DTO 的 fixtures。

### Non-goals

- 不改变 provider 远端同步事务、重试、并发或 mapping 语义。
- 不改变 manual / auto-sync 共用 orchestrator 的 ownership 模型。
- 不恢复基于 `updatedAt` 或 `instanceId` 的 lease / lock。
- 不修改 SyncJob storage key、IndexedDB schema、备份格式、manifest、权限或 OAuth scope。
- 不改 UI 文案或视觉样式。

## What changed

- 四 provider 的 GET/CLEAR status contract 不再把 background instance 作为无消费者顶层字段回显；durable `job.instanceId` 仍保留用于诊断 / reload attribution。
- Notion / Feishu maintenance 在成功 destructive mutation 后固定清 SyncJob；GitHub maintenance 固定只占 ownership，不再维护不存在的 runtime option matrix。
- terminal feedback 直接使用 required `SyncRunSummary.failures`，done path 复用唯一 summary materialization，删除 results-based fallback 重算。
- canonical v2 SyncJob durable identity 改为 required string；`normalizeSyncJobSnapshot()` 对缺 `id` / `instanceId` 的 snapshot 返回 `null`，不做 hydration / repair。
- 测试 fixtures 同步改为当前 v2 compact / terminal contract，避免 mock 绕过 strict store 后继续认可旧 payload。

## Architecture / invariants

本 PR保持 `AGENTS.md` 的 provider sync lifecycle contract：manual 与 auto-sync 继续收敛到同一 orchestrator / SyncJob lifecycle；scheduler、handler、UI 没有新增第二套 progress / terminal state。

`job.instanceId` 仍只是 durable diagnostics，不承担 ownership；process-local ownership slot 仍是 active-run authority。startup reconciliation、clear/disconnect 与 run admission 继续走同一 provider ownership primitive。

P1 已淘汰的 v1 SyncJob、旧 5 分钟 lease、initial claim readback、retired fine-grained durable stage、message-based ownership conflict、status-response instance echo 与 UI compatibility fallback 已做 production 0-hit 复核。

## Data, migration & recovery

没有 IndexedDB、backup、revision 或 SyncJob storage-key migration。

本 PR有意继续执行 P1 follow-up 的“删除 SyncJob backward compatibility”决策：只有 canonical v2 SyncJob 被接受。缺少 required `id` / `instanceId` 的 malformed v2 status snapshot 会被视为 `null`，不会被修补。当前四 provider producer 本来就始终写这两个字段，因此合法现行数据不需要迁移。

SyncJob 仅是同步进度 / terminal 状态，不承载 conversation 本体数据；拒绝 malformed snapshot 不会删除 conversation、message 或 provider mapping 数据。startup recovery 仍只对可正常解析的 ownerless running v2 job 做 running → aborted materialization。

## Permissions & privacy

N/A — manifest / host permissions / OAuth scopes / secrets / network destinations 均未变化，也没有让新的本地数据离开设备。

## Compatibility

影响 Notion、Feishu、Obsidian、GitHub 四个 provider 的共享 SyncJob/status contract，但不改变各 provider 的远端业务行为。

有意不兼容 P1 已淘汰的 malformed / historical SyncJob shape；当前 canonical v2 producer 不受影响。Chrome/Firefox/Safari 的 single-background-actor 假设继续由现有 `wxt-config` regression 保护。

## Demo

N/A — no visual behavior changed.

## Drawbacks / risks

- 手工伪造、旧测试 fixture 或非 canonical producer 写出的缺 identity SyncJob 将不再被 UI hydration；这是 P1 follow-up 明确要求的 fail-closed 行为。
- 当前 ownership 仍依赖单 background actor；未来若引入 split-incognito / 多 background actor，需要重新设计跨 actor ownership，不能恢复 `updatedAt` lease。

## Tests & validation

### Automated

- `rtk npm test -- <plan-p1 phase matrix>` → **20 files / 287 tests PASS**
- `rtk npm run compile` → PASS
- `rtk npm run gate` → PASS
  - ESLint PASS
  - Prettier PASS
  - TypeScript PASS
  - Vitest **281 files / 2109 tests PASS**
  - Chrome MV3 production build PASS
- `rtk node .github/scripts/webclipper/check-dist.mjs --root=.output/chrome-mv3` → `[check] ok`
- P1 task commit reachability / `todo validate` / `phase-complete p1` → PASS
- Retired P1 production-path scans → 0 hits for old SyncJob compatibility / lease / status echo / fine-grained durable stage paths covered by this audit.

### Manual

N/A — no browser-specific visual or site collector behavior changed; provider lifecycle, status routing, startup recovery, manual/auto ownership and feedback arbitration are covered by the P1 phase matrix and full gate. No manual browser flow was claimed.

## Documentation

The local feature audit (`.github/features/performance-refractor 2026-08-31/audit-p1.md`) was updated with F-04–F-13 and the final Gate=Go evidence, but the feature directory is intentionally gitignored and is not part of this PR.

No canonical user-facing or architecture document became stale: the PR removes residual implementations to match the already-established P1 contract rather than introducing a new public behavior or storage format.
