### PR TITLE
P2：清理评论存储兼容路径并收紧身份契约

### DIFF
--- a/src/services/comments/background/handlers.ts
+++ b/src/services/comments/background/handlers.ts
@@ -40,14 +40,15 @@ export function registerArticleCommentsHandlers(router: AnyRouter, deps: Article
     const canonicalUrl = canonicalizeArticleUrl(msg?.canonicalUrl);
     const conversationId = Number(msg?.conversationId);
 
-    // Canonical URL is preferred. When unavailable, fall back to conversationId
-    // so legacy contexts can still load comments.
     if (canonicalUrl) {
       const items = await listArticleCommentsByCanonicalUrl(canonicalUrl);
       return router.ok(items.map(serializeArticleCommentDto));
     }
 
-    if (Number.isFinite(conversationId) && conversationId > 0) {
+    if (msg?.conversationId != null && (!Number.isSafeInteger(conversationId) || conversationId <= 0)) {
+      return router.err('invalid conversationId');
+    }
+    if (Number.isSafeInteger(conversationId) && conversationId > 0) {
       const items = await listArticleCommentsByConversationId(conversationId);
       return router.ok(items.map(serializeArticleCommentDto));
     }
@@ -109,7 +110,7 @@ export function registerArticleCommentsHandlers(router: AnyRouter, deps: Article
     const canonicalUrl = canonicalizeArticleUrl(msg?.canonicalUrl);
     const conversationId = Number(msg?.conversationId);
     if (!canonicalUrl) return router.err('missing canonicalUrl');
-    if (!Number.isFinite(conversationId) || conversationId <= 0) return router.err('invalid conversationId');
+    if (!Number.isSafeInteger(conversationId) || conversationId <= 0) return router.err('invalid conversationId');
     const res = await attachOrphanCommentsToConversation(canonicalUrl, conversationId);
     if (Number(res.updated) > 0) {
       fireAndForget(
@@ -126,7 +127,7 @@ export function registerArticleCommentsHandlers(router: AnyRouter, deps: Article
     if (!fromCanonicalUrl) return router.err('missing fromCanonicalUrl');
     if (!toCanonicalUrl) return router.err('missing toCanonicalUrl');
 
-    if (conversationId == null || !Number.isFinite(conversationId) || conversationId <= 0) {
+    if (conversationId == null || !Number.isSafeInteger(conversationId) || conversationId <= 0) {
       return router.err('invalid conversationId');
     }
     const res = await migrateArticleCommentsCanonicalUrl({ fromCanonicalUrl, toCanonicalUrl, conversationId });

--- a/src/services/comments/data/storage-idb.ts
+++ b/src/services/comments/data/storage-idb.ts
@@ -137,10 +137,8 @@ export async function listArticleCommentsByCanonicalUrl(canonicalUrl: string): P
   const { t, stores } = tx(db, ['article_comments'], 'readonly');
 
   const idx = stores.article_comments.index('by_canonicalUrl_createdAt');
-  const range = globalThis.IDBKeyRange?.bound
-    ? globalThis.IDBKeyRange.bound([normalized, -Infinity] as any, [normalized, Infinity] as any)
-    : null;
-  const rows = range ? await reqToPromise<any[]>(idx.getAll(range) as any) : [];
+  const range = globalThis.IDBKeyRange.bound([normalized, -Infinity] as any, [normalized, Infinity] as any);
+  const rows = await reqToPromise<any[]>(idx.getAll(range) as any);
   await txDone(t);
   return (Array.isArray(rows) ? rows : []).map(toComment);
 }
@@ -153,10 +151,8 @@ export async function listArticleCommentsByConversationId(conversationId: number
   const { t, stores } = tx(db, ['article_comments'], 'readonly');
 
   const idx = stores.article_comments.index('by_conversationId_createdAt');
-  const range = globalThis.IDBKeyRange?.bound
-    ? globalThis.IDBKeyRange.bound([id, -Infinity] as any, [id, Infinity] as any)
-    : null;
-  const rows = range ? await reqToPromise<any[]>(idx.getAll(range) as any) : [];
+  const range = globalThis.IDBKeyRange.bound([id, -Infinity] as any, [id, Infinity] as any);
+  const rows = await reqToPromise<any[]>(idx.getAll(range) as any);
   await txDone(t);
   return (Array.isArray(rows) ? rows : []).map(toComment);
 }
@@ -233,15 +229,7 @@ export async function hasAnyArticleCommentsForCanonicalUrl(canonicalUrl: string)
   const db = await openDb();
   const { t, stores } = tx(db, ['article_comments'], 'readonly');
   const idx = stores.article_comments.index('by_canonicalUrl_createdAt');
-
-  const range = globalThis.IDBKeyRange?.bound
-    ? globalThis.IDBKeyRange.bound([normalized, -Infinity] as any, [normalized, Infinity] as any)
-    : null;
-  if (!range) {
-    await txDone(t);
-    return false;
-  }
-
+  const range = globalThis.IDBKeyRange.bound([normalized, -Infinity] as any, [normalized, Infinity] as any);
   const count = await reqToPromise<number>(idx.count(range) as any);
   await txDone(t);
   return Number(count) > 0;
@@ -261,11 +249,10 @@ export async function attachOrphanCommentsToConversation(
     async ({ stores, markChanged }) => {
       const store = stores.article_comments;
       const idx = store.index('by_canonicalUrl_createdAt');
-      const range = globalThis.IDBKeyRange?.bound
-        ? globalThis.IDBKeyRange.bound([normalizedUrl, -Infinity] as any, [normalizedUrl, Infinity] as any)
-        : null;
-      if (!range) return { updated: 0 };
-
+      const range = globalThis.IDBKeyRange.bound(
+        [normalizedUrl, -Infinity] as any,
+        [normalizedUrl, Infinity] as any,
+      );
       const rows = (await reqToPromise<any[]>(idx.getAll(range) as any)) || [];
       let updated = 0;
       const now = Date.now();
@@ -303,11 +290,7 @@ export async function migrateArticleCommentsCanonicalUrl(input: {
     async ({ stores, markChanged }) => {
       const store = stores.article_comments;
       const idx = store.index('by_canonicalUrl_createdAt');
-      const range = globalThis.IDBKeyRange?.bound
-        ? globalThis.IDBKeyRange.bound([from, -Infinity] as any, [from, Infinity] as any)
-        : null;
-      if (!range) return { updated: 0 };
-
+      const range = globalThis.IDBKeyRange.bound([from, -Infinity] as any, [from, Infinity] as any);
       const rows = (await reqToPromise<any[]>(idx.getAll(range) as any)) || [];
       const now = Date.now();
       let updated = 0;

--- a/src/services/comments/data/storage-idb.ts
+++ b/src/services/comments/data/storage-idb.ts
@@ -144,8 +144,8 @@ export async function listArticleCommentsByCanonicalUrl(canonicalUrl: string): P
 }
 
 export async function listArticleCommentsByConversationId(conversationId: number): Promise<ArticleComment[]> {
-  const id = Number(conversationId);
-  if (!Number.isFinite(id) || id <= 0) return [];
+  const id = normalizeConversationId(conversationId);
+  if (id == null) return [];
 
   const db = await openDb();
   const { t, stores } = tx(db, ['article_comments'], 'readonly');
@@ -164,7 +164,7 @@ type ArticleCommentDeleteResult = {
 
 export async function deleteArticleCommentById(id: number): Promise<ArticleCommentDeleteResult> {
   const commentId = Number(id);
-  if (!Number.isFinite(commentId) || commentId <= 0) return { deleted: false, conversationId: null };
+  if (!Number.isSafeInteger(commentId) || commentId <= 0) return { deleted: false, conversationId: null };
 
   const db = await openDb();
   return runTrackedTransaction(

--- a/src/services/comments/data/storage-idb.ts
+++ b/src/services/comments/data/storage-idb.ts
@@ -222,19 +222,6 @@ export async function deleteArticleCommentById(id: number): Promise<ArticleComme
   );
 }
 
-export async function hasAnyArticleCommentsForCanonicalUrl(canonicalUrl: string): Promise<boolean> {
-  const normalized = normalizeCanonicalUrl(canonicalUrl);
-  if (!normalized) return false;
-
-  const db = await openDb();
-  const { t, stores } = tx(db, ['article_comments'], 'readonly');
-  const idx = stores.article_comments.index('by_canonicalUrl_createdAt');
-  const range = globalThis.IDBKeyRange.bound([normalized, -Infinity] as any, [normalized, Infinity] as any);
-  const count = await reqToPromise<number>(idx.count(range) as any);
-  await txDone(t);
-  return Number(count) > 0;
-}
-
 export async function attachOrphanCommentsToConversation(
   canonicalUrl: string,
   conversationId: number,

--- a/src/services/comments/data/storage-idb.ts
+++ b/src/services/comments/data/storage-idb.ts
@@ -235,10 +235,7 @@ export async function attachOrphanCommentsToConversation(
     async ({ stores, markChanged }) => {
       const store = stores.article_comments;
       const idx = store.index('by_canonicalUrl_createdAt');
-      const range = globalThis.IDBKeyRange.bound(
-        [normalizedUrl, -Infinity] as any,
-        [normalizedUrl, Infinity] as any,
-      );
+      const range = globalThis.IDBKeyRange.bound([normalizedUrl, -Infinity] as any, [normalizedUrl, Infinity] as any);
       const rows = (await reqToPromise<any[]>(idx.getAll(range) as any)) || [];
       let updated = 0;
       const now = Date.now();

--- a/src/services/comments/data/storage-idb.ts
+++ b/src/services/comments/data/storage-idb.ts
@@ -2,7 +2,6 @@ import type { AddArticleCommentInput, ArticleComment } from '@services/comments/
 import { openDb } from '@platform/idb/schema';
 import { canonicalizeArticleUrl } from '@services/url-cleaning/http-url';
 import { normalizeArticleCommentLocator } from '@services/comments/domain/comment-locator';
-import { serializeArticleCommentDto } from '@services/comments/domain/comment-dto';
 import { runTrackedTransaction } from '@services/data-revisions/transaction';
 
 export class ArticleCommentInvariantError extends Error {
@@ -79,7 +78,7 @@ function toComment(row: any): ArticleComment {
     createdAt: Number(row?.createdAt) || 0,
     updatedAt: Number(row?.updatedAt) || 0,
   };
-  return serializeArticleCommentDto(comment);
+  return comment;
 }
 
 export async function addArticleComment(input: AddArticleCommentInput): Promise<ArticleComment> {

--- a/src/services/comments/data/storage.ts
+++ b/src/services/comments/data/storage.ts
@@ -17,10 +17,6 @@ export async function deleteArticleCommentById(id: number) {
   return await idb.deleteArticleCommentById(id);
 }
 
-export async function hasAnyArticleCommentsForCanonicalUrl(canonicalUrl: string) {
-  return await idb.hasAnyArticleCommentsForCanonicalUrl(canonicalUrl);
-}
-
 export async function attachOrphanCommentsToConversation(canonicalUrl: string, conversationId: number) {
   return await idb.attachOrphanCommentsToConversation(canonicalUrl, conversationId);
 }

--- a/tests/smoke/background-router-article-comments.test.ts
+++ b/tests/smoke/background-router-article-comments.test.ts
@@ -66,6 +66,43 @@ describe('article comments background handler mutation side effects', () => {
     expect(onConversationChanged).not.toHaveBeenCalled();
   });
 
+  it('rejects fractional conversation ids before comment list/attach/migrate storage calls', async () => {
+    const onConversationChanged = vi.fn();
+    const { router, handlers } = createRouter();
+    registerArticleCommentsHandlers(router, { onConversationChanged });
+
+    const listResponse = await handlers.get(COMMENTS_MESSAGE_TYPES.LIST_ARTICLE_COMMENTS)?.({ conversationId: 1.5 });
+    const attachResponse = await handlers.get(COMMENTS_MESSAGE_TYPES.ATTACH_ORPHAN_ARTICLE_COMMENTS)?.({
+      canonicalUrl: 'https://example.com/article',
+      conversationId: 1.5,
+    });
+    const migrateResponse = await handlers.get(COMMENTS_MESSAGE_TYPES.MIGRATE_ARTICLE_COMMENTS_CANONICAL_URL)?.({
+      fromCanonicalUrl: 'https://example.com/old',
+      toCanonicalUrl: 'https://example.com/new',
+      conversationId: 1.5,
+    });
+
+    expect(listResponse).toEqual({
+      ok: false,
+      data: null,
+      error: { message: 'invalid conversationId', extra: null },
+    });
+    expect(attachResponse).toEqual({
+      ok: false,
+      data: null,
+      error: { message: 'invalid conversationId', extra: null },
+    });
+    expect(migrateResponse).toEqual({
+      ok: false,
+      data: null,
+      error: { message: 'invalid conversationId', extra: null },
+    });
+    expect(storageMocks.listArticleCommentsByConversationId).not.toHaveBeenCalled();
+    expect(storageMocks.attachOrphanCommentsToConversation).not.toHaveBeenCalled();
+    expect(storageMocks.migrateArticleCommentsCanonicalUrl).not.toHaveBeenCalled();
+    expect(onConversationChanged).not.toHaveBeenCalled();
+  });
+
   it('returns ok=false for a missing delete without scheduling auto-sync', async () => {
     storageMocks.deleteArticleCommentById.mockResolvedValue({ deleted: false, conversationId: null });
     const onConversationChanged = vi.fn();

--- a/tests/storage/article-comments-idb.test.ts
+++ b/tests/storage/article-comments-idb.test.ts
@@ -433,6 +433,28 @@ describe('article comments storage-idb', () => {
     expect(await hasAnyArticleCommentsForCanonicalUrl(url)).toBe(true);
   });
 
+  it('fails instead of fabricating empty comment results when IDBKeyRange is unavailable', async () => {
+    const url = 'https://example.com/required-key-range';
+    await addArticleComment({ conversationId: null, canonicalUrl: url, commentText: 'x' });
+    const previousKeyRange = globalThis.IDBKeyRange;
+    // @ts-expect-error simulate a broken IndexedDB runtime invariant
+    globalThis.IDBKeyRange = undefined;
+    try {
+      await expect(listArticleCommentsByCanonicalUrl(url)).rejects.toThrow();
+      await expect(hasAnyArticleCommentsForCanonicalUrl(url)).rejects.toThrow();
+      await expect(attachOrphanCommentsToConversation(url, 42)).rejects.toThrow();
+      await expect(
+        migrateArticleCommentsCanonicalUrl({
+          fromCanonicalUrl: url,
+          toCanonicalUrl: 'https://example.com/required-key-range-next',
+          conversationId: 42,
+        }),
+      ).rejects.toThrow();
+    } finally {
+      globalThis.IDBKeyRange = previousKeyRange;
+    }
+  });
+
   it('attaches orphan comments to conversation', async () => {
     const url = 'https://example.com/a';
     const orphan1 = await addArticleComment({

--- a/tests/storage/article-comments-idb.test.ts
+++ b/tests/storage/article-comments-idb.test.ts
@@ -8,7 +8,6 @@ import {
   addArticleComment,
   attachOrphanCommentsToConversation,
   deleteArticleCommentById,
-  hasAnyArticleCommentsForCanonicalUrl,
   listArticleCommentsByCanonicalUrl,
   listArticleCommentsByConversationId,
   migrateArticleCommentsCanonicalUrl,
@@ -426,22 +425,15 @@ describe('article comments storage-idb', () => {
     expect(await listArticleCommentsByCanonicalUrl(url)).toEqual([]);
   });
 
-  it('hasAnyForCanonicalUrl returns true when exists', async () => {
-    const url = 'https://example.com/a';
-    expect(await hasAnyArticleCommentsForCanonicalUrl(url)).toBe(false);
-    await addArticleComment({ conversationId: null, canonicalUrl: url, commentText: 'x' });
-    expect(await hasAnyArticleCommentsForCanonicalUrl(url)).toBe(true);
-  });
-
   it('fails instead of fabricating empty comment results when IDBKeyRange is unavailable', async () => {
     const url = 'https://example.com/required-key-range';
-    await addArticleComment({ conversationId: null, canonicalUrl: url, commentText: 'x' });
+    await addArticleComment({ conversationId: 42, canonicalUrl: url, commentText: 'x' });
     const previousKeyRange = globalThis.IDBKeyRange;
     // @ts-expect-error simulate a broken IndexedDB runtime invariant
     globalThis.IDBKeyRange = undefined;
     try {
       await expect(listArticleCommentsByCanonicalUrl(url)).rejects.toThrow();
-      await expect(hasAnyArticleCommentsForCanonicalUrl(url)).rejects.toThrow();
+      await expect(listArticleCommentsByConversationId(42)).rejects.toThrow();
       await expect(attachOrphanCommentsToConversation(url, 42)).rejects.toThrow();
       await expect(
         migrateArticleCommentsCanonicalUrl({


### PR DESCRIPTION
## Related issue

N/A — 本次由仓库内已确认的 performance-refractor P2 feature plan 的执行后审计与兼容代码清理驱动，未单独建立 GitHub Issue。

## Why

P2 已经把会话列表 summary/facets、文章评论批量读取和评论删除 working set 收敛到新的 IndexedDB 路径，但执行后复审仍发现评论存储外围存在静默平台 fallback、宽松 ID 边界、无生产消费者 API 和重复 DTO normalization。这些残留会掩盖 IndexedDB 平台故障、让非法 conversationId 穿透消息边界，并继续维护没有生产价值的兼容面。

## Scope

### In scope

- 删除 article comments data path 对缺失 `IDBKeyRange` 的静默空结果/零更新 fallback。
- LIST / ATTACH / MIGRATE comment message boundary 统一要求 positive safe-integer `conversationId`。
- data-layer list/delete 输入同步收紧到同一 identity contract。
- 删除无生产消费者的 `hasAnyArticleCommentsForCanonicalUrl()` API 与对应 test-only surface。
- 删除 storage `toComment()` 中与 background message boundary 重复的 DTO serialization。
- 保留 P2 已有的 indexed summary/facets、page-level comment batching、single-materialization cascade delete 和 revision transaction contract。

### Non-goals

- 不修改 IndexedDB schema 或 migration version。
- 不改变 comment persisted record shape、backup format 或 revision scope。
- 不改变 App/Inpage 通过 canonical URL / conversationId 加载评论的现行能力。
- 不改变评论 UI、视觉样式、provider sync 或 auto-sync 调度算法。

## What changed

- comment storage 直接依赖受支持 IndexedDB runtime 的 `IDBKeyRange`，平台 invariant 破坏时失败而不是伪造 `[]` / `false` / `{ updated: 0 }`。
- comment router 在调用 storage 前拒绝 fractional/unsafe `conversationId`；conversationId 查询能力本身继续保留。
- 删除只被 storage facade 和测试引用、没有 production caller 的 `hasAnyArticleCommentsForCanonicalUrl()`。
- `toComment()` 直接返回已经正规化的 `ArticleComment`；DTO serialization 仅保留在 background message boundary。
- 补充缺失 `IDBKeyRange` 与 fractional conversationId regression，并完成格式 gate 修正。

## Architecture / invariants

- 保持 `services -> platform/domain/shared` 依赖方向，没有新增跨层依赖。
- IndexedDB 仍只通过 `src/platform/idb/schema.ts` 的 canonical connection 访问。
- 受 revision 跟踪的 attach/migrate mutation 仍通过既有 `runTrackedTransaction` 与 `article_comments` revision 同事务提交。
- 没有恢复 P2 已删除的 full-value list scan、serial comment hydration、delete-context pre-read 或第二套 cascade path。
- 删除了一个没有生产消费者的新 API surface，符合 `AGENTS.md` 对 production wiring 的约束。

## Data, migration & recovery

没有 schema、migration 或 persisted record shape 变更。现有评论数据不被重写。

正常 IndexedDB runtime 下读写语义保持不变；若 `IDBKeyRange` 平台 invariant 被破坏，现在请求会失败并暴露错误，而不是返回看似有效的空评论/零更新结果。attach/migrate 仍在原有 revision-tracked transaction 内提交，失败时不会产生部分业务 mutation + revision 分离。

## Permissions & privacy

N/A — manifest、host permissions、OAuth scopes、secrets、network destinations 和本地数据外发行为均未变化。

## Compatibility

支持目标不变。唯一有意的 compatibility 决策是删除“不存在 `IDBKeyRange` 仍伪造成功结果”以及 fractional `conversationId` 的宽松兼容；受支持的浏览器 IndexedDB runtime 与 canonical positive safe-integer comment identity contract 不依赖这些 fallback。

## Demo

N/A — no visual behavior changed.

## Drawbacks / risks

- 在损坏或不完整的 IndexedDB runtime 中，comment read/mutation 现在会显式失败，而不是静默返回空结果；这是有意的 fail-closed 行为。
- 本 PR 不尝试修复历史损坏 comment rows；现有 safe-integer normalization 继续负责拒绝无效 owner/parent identity。

## Tests & validation

### Automated

- P2 phase matrix：10 files / 86 tests PASS。
- `npm run gate:ci`：PASS，281 files / 2116 tests。
- `npm run build`：PASS，Chrome MV3 production build。
- `check-dist`：PASS（`[check] ok`）。
- `todo validate`：PASS。
- `phase-complete p2`：PASS。
- 定向 regression 覆盖：缺失 `IDBKeyRange` 不再静默空结果；LIST / ATTACH / MIGRATE fractional `conversationId` 在 storage 前被拒绝；comment storage/revision/reload-free 路径继续通过。
- P2 retired-path static scan：旧 delete-context helper/type、optional `IDBKeyRange` fallback、dead `hasAnyArticleCommentsForCanonicalUrl`、storage duplicate serializer 均 0 命中。

### Manual

N/A — 本次没有视觉、站点适配器或浏览器交互行为变化；修改集中在 IndexedDB comment data/message boundary，已由 storage、router、integration 与全量 gate 覆盖。

## Documentation

N/A — canonical 产品/架构文档没有因本次内部 P2 audit cleanup 变得过时；feature-local `audit-p2.md` 已在本地审计记录中更新，但该 feature 目录按仓库规则受 `.gitignore` 管理，不作为运行时代码 PR 文件提交。
