### PR TITLE
refactor: 清理 P3 图片缓存冗余路径

### DIFF
--- a/src/services/conversations/data/image-cache-read.ts
+++ b/src/services/conversations/data/image-cache-read.ts
@@ -211,8 +211,6 @@ export async function getImageCacheAssetById(input: {
   id: number;
   conversationId?: number | null;
 }): Promise<ImageCacheAsset | null> {
-  const id = Number(input.id);
-  if (!Number.isFinite(id) || id <= 0) return null;
-  const assets = await getImageCacheAssetsByIds({ ids: [id], conversationId: input.conversationId });
-  return assets.get(id) ?? null;
+  const assets = await getImageCacheAssetsByIds({ ids: [input.id], conversationId: input.conversationId });
+  return assets.values().next().value ?? null;
 }

--- a/src/services/conversations/data/image-inline.ts
+++ b/src/services/conversations/data/image-inline.ts
@@ -224,21 +224,13 @@ async function getCachedImagesByUrls(
   conversationId: number,
   urls: readonly string[],
 ): Promise<Map<string, ImageCacheRow>> {
-  const lookupUrls: string[] = [];
-  const seen = new Set<string>();
-  for (const rawUrl of urls) {
-    const url = String(rawUrl || '').trim();
-    if (!url || seen.has(url)) continue;
-    seen.add(url);
-    lookupUrls.push(url);
-  }
-  if (!lookupUrls.length) return new Map();
+  if (!urls.length) return new Map();
 
   const db = await openDb();
   const { t, stores } = tx(db, ['image_cache'], 'readonly');
   const done = txDone(t);
   const idx = stores.image_cache.index('by_conversationId_url');
-  const requests = lookupUrls.map((url) =>
+  const requests = urls.map((url) =>
     reqToPromise(idx.get([conversationId, url]) as IDBRequest<ImageCacheRow | undefined>).then(
       (row) => [url, row] as const,
     ),

--- a/src/services/conversations/data/image-inline.ts
+++ b/src/services/conversations/data/image-inline.ts
@@ -59,12 +59,6 @@ function isDataImageUrl(url: unknown): boolean {
   return /^data:image\/[a-z0-9.+-]+(?:;charset=[a-z0-9._-]+)?(?:;base64)?,/i.test(text);
 }
 
-function isSyncnosAssetUrl(url: unknown): boolean {
-  const text = String(url || '').trim();
-  if (!text) return false;
-  return /^syncnos-asset:\/\/\d+$/i.test(text);
-}
-
 function stripAngleBrackets(url: string): string {
   const text = String(url || '').trim();
   if (text.startsWith('<') && text.endsWith('>')) return text.slice(1, -1).trim();
@@ -87,7 +81,6 @@ function extractInlineCandidateUrlsFromMarkdown(markdown: string): string[] {
   while ((match = MARKDOWN_IMAGE_RE.exec(raw)) != null) {
     const urlPart = match[2] ? String(match[2]) : '';
     const url = stripAngleBrackets(urlPart);
-    if (isSyncnosAssetUrl(url)) continue;
     if (!isDataImageUrl(url) && !isHttpUrl(url)) continue;
     if (seen.has(url)) continue;
     seen.add(url);

--- a/tests/storage/image-cache-read.test.ts
+++ b/tests/storage/image-cache-read.test.ts
@@ -213,6 +213,7 @@ describe('image cache bulk reader', () => {
       conversationId: 42,
       byteSize: 3,
     });
+    await expect(getImageCacheAssetById({ id: '10' as any, conversationId: 42 })).resolves.toMatchObject({ id: 10 });
     await expect(getImageCacheAssetById({ id: 10, conversationId: 99 })).resolves.toBeNull();
     await expect(getImageCacheAssetById({ id: 404, conversationId: 42 })).resolves.toBeNull();
     await expect(getImageCacheAssetById({ id: 0, conversationId: 42 })).resolves.toBeNull();

--- a/tests/unit/image-inline.test.ts
+++ b/tests/unit/image-inline.test.ts
@@ -62,6 +62,19 @@ describe('image-inline', () => {
     expect(hasReusableImageCachePayload({ byteSize: 10 })).toBe(false);
   });
 
+  it('ignores existing internal asset refs without opening image-cache transactions', async () => {
+    const transactionSpy = vi.spyOn(IDBDatabase.prototype, 'transaction');
+    const messages = [
+      { messageKey: 'm1', contentMarkdown: '![](syncnos-asset://123)', role: 'assistant', sequence: 1 },
+    ];
+
+    const result = await inlineChatImagesInMessages({ conversationId: 1, messages });
+
+    expect(result).toMatchObject({ inlinedCount: 0, fromCacheCount: 0, downloadedCount: 0, inlinedBytes: 0 });
+    expect(messages[0].contentMarkdown).toBe('![](syncnos-asset://123)');
+    expect(transactionSpy).not.toHaveBeenCalled();
+  });
+
   it('replaces http(s)/data images with internal asset refs and reuses cache', async () => {
     const fetchMock = vi.fn(async () => {
       return new Response(Uint8Array.from([1, 2, 3, 4]), {


### PR DESCRIPTION
## Related issue

N/A — P3 post-implementation cleanup audit; this PR is mechanical maintenance of already-agreed behavior.

## Why

P3 replaced several per-item image-cache paths with canonical bulk readers, but a follow-up audit found three small residual branches that still duplicated normalization or filtering already owned by the new canonical path. Keeping them would preserve unnecessary parallel logic and create future drift risk.

## Scope

### In scope

- Make `getImageCacheAssetById()` a true thin wrapper over `getImageCacheAssetsByIds()` with no second ID-normalization path.
- Remove a dead `syncnos-asset://` pre-filter in inline image candidate extraction that was already implied by the HTTP/data scheme gate.
- Remove a second lookup-key trim/dedupe pass from the inline cache bulk helper; the invocation-level collector remains the single dedupe source.
- Add focused regressions for numeric coercion compatibility and already-materialized internal image refs.

### Non-goals

- No local Markdown export redesign; it remains the intentional low-frequency consumer of the single-reader wrapper.
- No provider upload/write concurrency changes.
- No IndexedDB schema, migration, revision, backup, or persisted-data format changes.
- No visual behavior changes.

## What changed

- `getImageCacheAssetById()` now delegates the raw single ID to the canonical bulk reader and returns the only materialized asset from that result.
- Deleted the private `isSyncnosAssetUrl()` helper and its redundant branch from inline candidate extraction.
- Simplified `getCachedImagesByUrls()` to consume the already-normalized, already-deduped lookup-key array produced by its sole caller.
- Added regressions proving string-coercible IDs keep existing single-reader behavior and existing `syncnos-asset://` references trigger no cache read or rewrite.

## Architecture / invariants

Preserves the P3 invariant that image-cache row/ID normalization has one canonical bulk implementation and that provider/detail hot paths do not reintroduce single-item fallback loops. The only production `getImageCacheAssetById()` consumer remains local Markdown export, which is an explicit P3 non-goal.

No dependency direction or provider synchronization lifecycle contract changed.

## Data, migration & recovery

N/A — no storage schema, writer, migration, revision, backup, or recovery behavior changed. Image-cache reads continue to use the existing canonical IndexedDB connection and bulk-reader materialization rules.

## Permissions & privacy

N/A — no manifest permissions, OAuth scopes, secrets, network destinations, or data-sharing behavior changed.

## Compatibility

Existing single-reader numeric coercion, missing-row, ownership-filter, Blob/ArrayBuffer/typed-array, and legacy `dataUrl` behavior is preserved through the canonical bulk reader. Provider behavior is unchanged.

## Demo

N/A — no visual behavior changed.

## Drawbacks / risks

Low risk. The changes only delete duplicated filtering/normalization. Focused tests cover the compatibility boundaries that could otherwise regress.

## Tests & validation

### Automated

- P3 focused phase matrix: 21 files / 291 tests PASS.
- `npm run gate`: PASS — ESLint, Prettier, TypeScript compile, 281 files / 2117 tests, Chrome MV3 production build.
- `.github/scripts/webclipper/check-dist.mjs --root=.output/chrome-mv3`: PASS.
- `git diff --check`: PASS.
- Final obsolete-path scan confirmed no P3 progress callbacks, old GitHub single loader, old per-URL cache helper, or provider private SyncNos asset parser remains in the migrated paths.

### Manual

N/A — no visual or browser-interaction behavior changed; this is internal cleanup with targeted and full automated coverage.

## Documentation

N/A — no canonical runtime documentation became stale. `plan-p3.md` already specifies the thin-wrapper / single-normalization and cleanup invariants enforced here.
