### PR TITLE
refactor: 清理 P8 冗余路径与多余围栏

### DIFF
--- a/src/collectors/web/article-fetch-background-handlers.ts
+++ b/src/collectors/web/article-fetch-background-handlers.ts
@@ -34,7 +34,10 @@ export function registerWebArticleHandlers(router: AnyRouter, deps: WebArticleHa
       const data = await fetchActiveTabArticle({ tabId: msg?.tabId });
 
       fireAndForget(
-        deps.onConversationChanged(data.conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.syncConversationMessages),
+        deps.onConversationChanged(
+          data.conversationId,
+          AUTO_SYNC_CONVERSATION_CHANGED_REASONS.syncConversationMessages,
+        ),
       );
 
       return router.ok(data);
@@ -49,7 +52,10 @@ export function registerWebArticleHandlers(router: AnyRouter, deps: WebArticleHa
 
       if (data.isNew) {
         fireAndForget(
-          deps.onConversationChanged(data.conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.syncConversationMessages),
+          deps.onConversationChanged(
+            data.conversationId,
+            AUTO_SYNC_CONVERSATION_CHANGED_REASONS.syncConversationMessages,
+          ),
         );
       }
 

--- a/src/collectors/web/article-fetch-background-handlers.ts
+++ b/src/collectors/web/article-fetch-background-handlers.ts
@@ -33,10 +33,9 @@ export function registerWebArticleHandlers(router: AnyRouter, deps: WebArticleHa
     try {
       const data = await fetchActiveTabArticle({ tabId: msg?.tabId });
 
-      const { conversationId } = data;
-      if (conversationId > 0) {
-        fireAndForget(deps.onConversationChanged(conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.syncConversationMessages));
-      }
+      fireAndForget(
+        deps.onConversationChanged(data.conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.syncConversationMessages),
+      );
 
       return router.ok(data);
     } catch (e) {
@@ -48,9 +47,10 @@ export function registerWebArticleHandlers(router: AnyRouter, deps: WebArticleHa
     try {
       const data = await resolveOrCaptureActiveTabArticle({ tabId: msg?.tabId });
 
-      const { conversationId, isNew } = data;
-      if (isNew && conversationId > 0) {
-        fireAndForget(deps.onConversationChanged(conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.syncConversationMessages));
+      if (data.isNew) {
+        fireAndForget(
+          deps.onConversationChanged(data.conversationId, AUTO_SYNC_CONVERSATION_CHANGED_REASONS.syncConversationMessages),
+        );
       }
 
       return router.ok(data);

--- a/src/collectors/web/article-fetch.ts
+++ b/src/collectors/web/article-fetch.ts
@@ -244,7 +244,7 @@ export async function fetchActiveTabArticle({ tabId }: { tabId?: number } = {}) 
 
   const body = textContent;
   const markdown = markdownContent || body;
-  const conversationId = Number((conversation as any).id);
+  const conversationId = conversation.id;
   let messagesToSave = [
     {
       messageKey: 'article_body',

--- a/src/collectors/web/article-fetch.ts
+++ b/src/collectors/web/article-fetch.ts
@@ -324,20 +324,19 @@ export async function resolveOrCaptureActiveTabArticle({ tabId }: { tabId?: numb
   const key = articleIdentity.conversationKey;
   try {
     const existing = await getConversationBySourceConversationKey(WEB_ARTICLE_SOURCE, key);
-    const existingId = Number((existing as any)?.id);
-    if (existing && Number.isFinite(existingId) && existingId > 0) {
-      const warningFlags = Array.isArray((existing as any)?.warningFlags)
-        ? (existing as any).warningFlags.map((x: any) => String(x || '').trim()).filter(Boolean)
+    if (existing) {
+      const warningFlags = Array.isArray(existing.warningFlags)
+        ? existing.warningFlags.map((item) => String(item || '').trim()).filter(Boolean)
         : [];
       return {
         isNew: false,
-        conversationId: existingId,
+        conversationId: existing.id,
         url: canonicalUrl,
-        title: normalizeText((existing as any)?.title || '') || fallbackTitle(canonicalUrl, (tab as any)?.title || ''),
-        author: normalizeText((existing as any)?.author || ''),
-        publishedAt: normalizeText((existing as any)?.publishedAt || ''),
+        title: normalizeText(existing.title || '') || fallbackTitle(canonicalUrl, tab.title || ''),
+        author: normalizeText(existing.author || ''),
+        publishedAt: normalizeText(existing.publishedAt || ''),
         warningFlags,
-        lastCapturedAt: Number((existing as any)?.lastCapturedAt) || null,
+        lastCapturedAt: Number(existing.lastCapturedAt) || null,
       };
     }
   } catch (_e) {

--- a/src/collectors/web/article-fetch.ts
+++ b/src/collectors/web/article-fetch.ts
@@ -6,7 +6,7 @@ import {
 import { buildCanonicalWebArticleIdentity, WEB_ARTICLE_SOURCE } from '@services/conversations/domain/article-identity';
 import { inlineChatImagesInMessages } from '@services/conversations/data/image-inline';
 import { DISCOURSE_OP_MISSING_WARNING_FLAG, DISCOURSE_OP_NOT_FOUND_ERROR } from '@collectors/web/article-fetch-errors';
-import { canonicalizeArticleUrl, normalizeHttpUrl } from '@services/url-cleaning/http-url';
+import { normalizeHttpUrl } from '@services/url-cleaning/http-url';
 import { scriptingExecuteScript } from '@platform/webext/scripting';
 import { tabsGet, tabsQuery, tabsSendMessage, tabsUpdate } from '@platform/webext/tabs';
 import { storageGet } from '@platform/storage/local';
@@ -182,7 +182,8 @@ export async function fetchActiveTabArticle({ tabId }: { tabId?: number } = {}) 
   const normalizedUrl = normalizeHttpUrl(tab.url || '');
   if (!normalizedUrl) throw toError('active tab must be an http(s) page');
   const discourseTopic = parseDiscourseTopicUrl(normalizedUrl);
-  const canonicalUrl = canonicalizeArticleUrl(normalizedUrl) || normalizedUrl;
+  const articleIdentity = buildCanonicalWebArticleIdentity(normalizedUrl)!;
+  const canonicalUrl = articleIdentity.url;
   const includeXiaohongshuComments = await shouldCaptureXiaohongshuComments();
 
   let readabilityInjected = false;
@@ -233,7 +234,7 @@ export async function fetchActiveTabArticle({ tabId }: { tabId?: number } = {}) 
   const conversation = await upsertConversation({
     sourceType: ARTICLE_SOURCE_TYPE,
     source: WEB_ARTICLE_SOURCE,
-    conversationKey: buildCanonicalWebArticleIdentity(canonicalUrl)?.conversationKey || '',
+    conversationKey: articleIdentity.conversationKey,
     title,
     url: canonicalUrl,
     author,
@@ -318,9 +319,9 @@ export async function resolveOrCaptureActiveTabArticle({ tabId }: { tabId?: numb
   const tab = await resolveTargetTab(tabId);
   const normalizedUrl = normalizeHttpUrl(tab.url || '');
   if (!normalizedUrl) throw toError('active tab must be an http(s) page');
-  const canonicalUrl = canonicalizeArticleUrl(normalizedUrl) || normalizedUrl;
-
-  const key = buildCanonicalWebArticleIdentity(canonicalUrl)?.conversationKey || '';
+  const articleIdentity = buildCanonicalWebArticleIdentity(normalizedUrl)!;
+  const canonicalUrl = articleIdentity.url;
+  const key = articleIdentity.conversationKey;
   try {
     const existing = await getConversationBySourceConversationKey(WEB_ARTICLE_SOURCE, key);
     const existingId = Number((existing as any)?.id);

--- a/src/platform/idb/schema.ts
+++ b/src/platform/idb/schema.ts
@@ -248,19 +248,18 @@ function migrateNotionAiThreadConversations({ tx }: MigrationContext, onDone: ()
           legacyKey: legacyKeepKey,
           stableKey,
           onDone: () => {
-            const duplicates = mergedConversations.filter((conversation) => Number(conversation?.id) !== keepId);
             let duplicateIndex = 0;
 
             const processNextDup = () => {
-              if (duplicateIndex >= duplicates.length) {
+              if (duplicateIndex >= mergedConversations.length) {
                 processNextThread();
                 return;
               }
-              const duplicate = duplicates[duplicateIndex];
+              const duplicate = mergedConversations[duplicateIndex];
               duplicateIndex += 1;
 
               const duplicateId = duplicate?.id ? Number(duplicate.id) : 0;
-              if (!Number.isFinite(duplicateId) || duplicateId <= 0) {
+              if (!Number.isFinite(duplicateId) || duplicateId <= 0 || duplicateId === keepId) {
                 processNextDup();
                 return;
               }
@@ -475,19 +474,18 @@ function migrateLegacyArticleConversations({ tx }: MigrationContext, onDone: () 
           canonicalKey,
           fallbackNotionPageId: safeString(mergedKeep.notionPageId),
           onDone: () => {
-            const duplicates = mergedConversations.filter((conversation) => Number(conversation?.id) !== keepId);
             let duplicateIndex = 0;
 
             const processNextDuplicate = () => {
-              if (duplicateIndex >= duplicates.length) {
+              if (duplicateIndex >= mergedConversations.length) {
                 processNextGroup();
                 return;
               }
-              const duplicate = duplicates[duplicateIndex];
+              const duplicate = mergedConversations[duplicateIndex];
               duplicateIndex += 1;
 
               const duplicateId = Number(duplicate?.id);
-              if (!Number.isFinite(duplicateId) || duplicateId <= 0) {
+              if (!Number.isFinite(duplicateId) || duplicateId <= 0 || duplicateId === keepId) {
                 processNextDuplicate();
                 return;
               }

--- a/src/platform/idb/schema.ts
+++ b/src/platform/idb/schema.ts
@@ -224,74 +224,71 @@ function migrateNotionAiThreadConversations({ tx }: MigrationContext, onDone: ()
           }
         }
 
-        const keepId = keepConversation?.id ? Number(keepConversation.id) : 0;
+        if (!keepConversation) {
+          processNextThread();
+          return;
+        }
+        const keepId = Number(keepConversation.id);
         if (!Number.isFinite(keepId) || keepId <= 0) {
           processNextThread();
           return;
         }
 
-        const keepReq = conversationsStore.get(keepId);
-          keepReq.onsuccess = () => {
-            const current = keepReq.result as Record<string, unknown> | undefined;
-            const legacyKeepKey = current ? String(current.conversationKey || '') : '';
+        const legacyKeepKey = String(keepConversation.conversationKey || '');
+        let changed = false;
+        if (legacyKeepKey !== stableKey) {
+          keepConversation.conversationKey = stableKey;
+          changed = true;
+        }
+        if (canonicalUrl && String(keepConversation.url || '') !== canonicalUrl) {
+          keepConversation.url = canonicalUrl;
+          changed = true;
+        }
+        if (changed) conversationsStore.put(keepConversation);
 
-            if (current) {
-              let changed = false;
-              if (String(current.conversationKey || '') !== stableKey) {
-                current.conversationKey = stableKey;
-                changed = true;
+        migrateMappingKey({
+          legacyKey: legacyKeepKey,
+          stableKey,
+          onDone: () => {
+            const duplicates = mergedConversations.filter((conversation) => Number(conversation?.id) !== keepId);
+            let duplicateIndex = 0;
+
+            const processNextDup = () => {
+              if (duplicateIndex >= duplicates.length) {
+                processNextThread();
+                return;
               }
-              if (canonicalUrl && String(current.url || '') !== canonicalUrl) {
-                current.url = canonicalUrl;
-                changed = true;
+              const duplicate = duplicates[duplicateIndex];
+              duplicateIndex += 1;
+
+              const duplicateId = duplicate?.id ? Number(duplicate.id) : 0;
+              if (!Number.isFinite(duplicateId) || duplicateId <= 0) {
+                processNextDup();
+                return;
               }
-              if (changed) conversationsStore.put(current);
-            }
 
-            migrateMappingKey({
-              legacyKey: legacyKeepKey,
-              stableKey,
-              onDone: () => {
-                const duplicates = mergedConversations.filter((conversation) => Number(conversation?.id) !== keepId);
-                let duplicateIndex = 0;
-
-                const processNextDup = () => {
-                  if (duplicateIndex >= duplicates.length) {
-                    processNextThread();
-                    return;
-                  }
-                  const duplicate = duplicates[duplicateIndex];
-                  duplicateIndex += 1;
-
-                  const duplicateId = duplicate?.id ? Number(duplicate.id) : 0;
-                  if (!Number.isFinite(duplicateId) || duplicateId <= 0) {
-                    processNextDup();
-                    return;
-                  }
-
-                  const legacyKey = String(duplicate.conversationKey || '');
-                  migrateDuplicateConversationMessages({
-                    messagesBySequenceIndex,
-                    messagesByKeyIndex,
-                    dupId: duplicateId,
-                    keepId,
+              const legacyKey = String(duplicate.conversationKey || '');
+              migrateDuplicateConversationMessages({
+                messagesBySequenceIndex,
+                messagesByKeyIndex,
+                dupId: duplicateId,
+                keepId,
+                onDone: () => {
+                  migrateMappingKey({
+                    legacyKey,
+                    stableKey,
                     onDone: () => {
-                      migrateMappingKey({
-                        legacyKey,
-                        stableKey,
-                        onDone: () => {
-                          conversationsStore.delete(duplicateId);
-                          processNextDup();
-                        },
-                      });
+                      conversationsStore.delete(duplicateId);
+                      processNextDup();
                     },
                   });
-                };
+                },
+              });
+            };
 
-                processNextDup();
-              },
-            });
-        };
+            processNextDup();
+          },
+        });
       };
 
       const stableReq = convoKeyIdx.get(['notionai', stableKey]);
@@ -458,78 +455,77 @@ function migrateLegacyArticleConversations({ tx }: MigrationContext, onDone: () 
           }
         }
 
-        const keepId = Number(keepConversation?.id);
+        if (!keepConversation) {
+          processNextGroup();
+          return;
+        }
+        const keepId = Number(keepConversation.id);
         if (!Number.isFinite(keepId) || keepId <= 0) {
           processNextGroup();
           return;
         }
 
-        const keepReq = conversationsStore.get(keepId);
-        keepReq.onsuccess = () => {
-          const currentKeep = (keepReq.result as Record<string, unknown> | undefined) || {};
-          const legacyKeepSource = safeString(currentKeep.source);
-          const legacyKeepKey = safeString(currentKeep.conversationKey);
+        const legacyKeepSource = safeString(keepConversation.source);
+        const legacyKeepKey = safeString(keepConversation.conversationKey);
+        let mergedKeep = {
+          ...keepConversation,
+          __canonicalUrl: canonicalUrl,
+          __canonicalKey: canonicalKey,
+        } as Record<string, unknown>;
+        for (const conversation of mergedConversations) {
+          mergedKeep = mergeConversationRecord(mergedKeep, conversation);
+        }
+        delete mergedKeep.__canonicalUrl;
+        delete mergedKeep.__canonicalKey;
+        mergedKeep = normalizeConversationListRecord(mergedKeep) as Record<string, unknown>;
+        conversationsStore.put(mergedKeep);
 
-          let mergedKeep = {
-            ...currentKeep,
-            __canonicalUrl: canonicalUrl,
-            __canonicalKey: canonicalKey,
-          } as Record<string, unknown>;
-          for (const conversation of mergedConversations) {
-            mergedKeep = mergeConversationRecord(mergedKeep, conversation);
-          }
-          delete mergedKeep.__canonicalUrl;
-          delete mergedKeep.__canonicalKey;
-          mergedKeep = normalizeConversationListRecord(mergedKeep) as Record<string, unknown>;
-          conversationsStore.put(mergedKeep);
+        migrateMappingToCanonical({
+          legacySource: legacyKeepSource,
+          legacyKey: legacyKeepKey,
+          canonicalKey,
+          fallbackNotionPageId: safeString(mergedKeep.notionPageId),
+          onDone: () => {
+            const duplicates = mergedConversations.filter((conversation) => Number(conversation?.id) !== keepId);
+            let duplicateIndex = 0;
 
-          migrateMappingToCanonical({
-            legacySource: legacyKeepSource,
-            legacyKey: legacyKeepKey,
-            canonicalKey,
-            fallbackNotionPageId: safeString(mergedKeep.notionPageId),
-            onDone: () => {
-              const duplicates = mergedConversations.filter((conversation) => Number(conversation?.id) !== keepId);
-              let duplicateIndex = 0;
+            const processNextDuplicate = () => {
+              if (duplicateIndex >= duplicates.length) {
+                processNextGroup();
+                return;
+              }
+              const duplicate = duplicates[duplicateIndex];
+              duplicateIndex += 1;
 
-              const processNextDuplicate = () => {
-                if (duplicateIndex >= duplicates.length) {
-                  processNextGroup();
-                  return;
-                }
-                const duplicate = duplicates[duplicateIndex];
-                duplicateIndex += 1;
+              const duplicateId = Number(duplicate?.id);
+              if (!Number.isFinite(duplicateId) || duplicateId <= 0) {
+                processNextDuplicate();
+                return;
+              }
 
-                const duplicateId = Number(duplicate?.id);
-                if (!Number.isFinite(duplicateId) || duplicateId <= 0) {
-                  processNextDuplicate();
-                  return;
-                }
+              migrateDuplicateConversationMessages({
+                messagesBySequenceIndex,
+                messagesByKeyIndex,
+                dupId: duplicateId,
+                keepId,
+                onDone: () => {
+                  migrateMappingToCanonical({
+                    legacySource: safeString(duplicate?.source),
+                    legacyKey: safeString(duplicate?.conversationKey),
+                    canonicalKey,
+                    fallbackNotionPageId: safeString(mergedKeep.notionPageId),
+                    onDone: () => {
+                      conversationsStore.delete(duplicateId);
+                      processNextDuplicate();
+                    },
+                  });
+                },
+              });
+            };
 
-                migrateDuplicateConversationMessages({
-                  messagesBySequenceIndex,
-                  messagesByKeyIndex,
-                  dupId: duplicateId,
-                  keepId,
-                  onDone: () => {
-                    migrateMappingToCanonical({
-                      legacySource: safeString(duplicate?.source),
-                      legacyKey: safeString(duplicate?.conversationKey),
-                      canonicalKey,
-                      fallbackNotionPageId: safeString(mergedKeep.notionPageId),
-                      onDone: () => {
-                        conversationsStore.delete(duplicateId);
-                        processNextDuplicate();
-                      },
-                    });
-                  },
-                });
-              };
-
-              processNextDuplicate();
-            },
-          });
-        };
+            processNextDuplicate();
+          },
+        });
       };
     };
 

--- a/src/platform/idb/schema.ts
+++ b/src/platform/idb/schema.ts
@@ -187,13 +187,12 @@ function migrateNotionAiThreadConversations({ tx }: MigrationContext, onDone: ()
       return;
     }
 
-    const threads = Array.from(groups.entries());
-    let threadIndex = 0;
+    const threads = groups.entries();
 
     const processNextThread = () => {
-      if (threadIndex >= threads.length) return onDone();
-      const [threadId, groupedConversations] = threads[threadIndex];
-      threadIndex += 1;
+      const nextThread = threads.next();
+      if (nextThread.done) return onDone();
+      const [threadId, groupedConversations] = nextThread.value;
 
       const stableKey = `notionai_t_${threadId}`;
       const canonicalUrl = `https://app.notion.com/chat?t=${threadId}&wfv=chat`;
@@ -407,13 +406,12 @@ function migrateLegacyArticleConversations({ tx }: MigrationContext, onDone: () 
       return;
     }
 
-    const entries = Array.from(groups.entries());
-    let groupIndex = 0;
+    const entries = groups.entries();
 
     const processNextGroup = () => {
-      if (groupIndex >= entries.length) return onDone();
-      const [canonicalKey, groupedConversations] = entries[groupIndex];
-      groupIndex += 1;
+      const nextGroup = entries.next();
+      if (nextGroup.done) return onDone();
+      const [canonicalKey, groupedConversations] = nextGroup.value;
       const canonicalUrl = safeString(groupedConversations[0]?.__canonicalUrl);
 
       const exactReq = convoKeyIdx.get(['web', canonicalKey]);

--- a/src/platform/idb/schema.ts
+++ b/src/platform/idb/schema.ts
@@ -238,7 +238,7 @@ function migrateNotionAiThreadConversations({ tx }: MigrationContext, onDone: ()
           keepConversation.conversationKey = stableKey;
           changed = true;
         }
-        if (canonicalUrl && String(keepConversation.url || '') !== canonicalUrl) {
+        if (String(keepConversation.url || '') !== canonicalUrl) {
           keepConversation.url = canonicalUrl;
           changed = true;
         }
@@ -335,13 +335,8 @@ function migrateLegacyArticleConversations({ tx }: MigrationContext, onDone: () 
   }): void {
     const legacySource = safeString(input.legacySource);
     const legacyKey = safeString(input.legacyKey);
-    const canonicalKey = safeString(input.canonicalKey);
+    const canonicalKey = input.canonicalKey;
     const fallbackNotionPageId = safeString(input.fallbackNotionPageId);
-
-    if (!canonicalKey) {
-      input.onDone();
-      return;
-    }
 
     const targetReq = mappingsBySourceConversationKeyIndex.get(['web', canonicalKey]);
     targetReq.onsuccess = () => {
@@ -395,8 +390,8 @@ function migrateLegacyArticleConversations({ tx }: MigrationContext, onDone: () 
       const row = cursor.value as Record<string, unknown> | undefined;
       if (safeString(row?.sourceType).toLowerCase() === 'article') {
         const canonicalUrl = normalizeHttpUrl(row?.url);
-        const canonicalKey = canonicalUrl ? `article:${canonicalUrl}` : '';
-        if (canonicalUrl && canonicalKey) {
+        if (canonicalUrl) {
+          const canonicalKey = `article:${canonicalUrl}`;
           const list = groups.get(canonicalKey) || [];
           list.push({ ...(row || {}), __canonicalUrl: canonicalUrl, __canonicalKey: canonicalKey });
           groups.set(canonicalKey, list);

--- a/src/platform/idb/schema.ts
+++ b/src/platform/idb/schema.ts
@@ -431,7 +431,8 @@ function migrateLegacyArticleConversations({ tx }: MigrationContext, onDone: () 
           const canonical =
             safeString(conversation?.source) === 'web' && safeString(conversation?.conversationKey) === canonicalKey;
           const bestCanonical =
-            safeString(keepConversation?.source) === 'web' && safeString(keepConversation?.conversationKey) === canonicalKey;
+            safeString(keepConversation?.source) === 'web' &&
+            safeString(keepConversation?.conversationKey) === canonicalKey;
           const mapped = !!safeString(conversation?.notionPageId);
           const bestMapped = !!safeString(keepConversation?.notionPageId);
           const capturedAt = Number(conversation?.lastCapturedAt) || 0;

--- a/src/platform/idb/schema.ts
+++ b/src/platform/idb/schema.ts
@@ -89,14 +89,20 @@ function normalizeConversationRecordsForV11({ tx }: MigrationContext): void {
     if (!cursor) return;
     const value = (cursor.value || {}) as Record<string, unknown>;
     const normalized = normalizeConversationListRecord(value);
-    const next = { ...normalized } as Record<string, unknown>;
-    let changed = normalized !== value;
-    for (const key of ['description', '__canonicalUrl', '__canonicalKey']) {
-      if (!Object.prototype.hasOwnProperty.call(next, key)) continue;
-      delete next[key];
-      changed = true;
+    const hasRetiredFields =
+      Object.prototype.hasOwnProperty.call(normalized, 'description') ||
+      Object.prototype.hasOwnProperty.call(normalized, '__canonicalUrl') ||
+      Object.prototype.hasOwnProperty.call(normalized, '__canonicalKey');
+    if (normalized === value && !hasRetiredFields) {
+      cursor.continue();
+      return;
     }
-    if (changed) cursor.update(next as any);
+
+    const next = { ...normalized } as Record<string, unknown>;
+    delete next.description;
+    delete next.__canonicalUrl;
+    delete next.__canonicalKey;
+    cursor.update(next as any);
     cursor.continue();
   };
 }

--- a/src/platform/idb/schema.ts
+++ b/src/platform/idb/schema.ts
@@ -207,17 +207,7 @@ function migrateNotionAiThreadConversations({ tx }: MigrationContext, onDone: ()
             ? groupedConversations.concat([stableExisting])
             : groupedConversations;
 
-        let keepConversation: Record<string, unknown> | null = null;
-        if (stableExisting?.id) {
-          keepConversation = stableExisting;
-        } else {
-          for (const conversation of mergedConversations) {
-            if (String(conversation.conversationKey || '') === stableKey) {
-              keepConversation = conversation;
-              break;
-            }
-          }
-        }
+        let keepConversation: Record<string, unknown> | null = stableExisting?.id ? stableExisting : null;
         if (!keepConversation) {
           for (const conversation of mergedConversations) {
             if (!keepConversation) {

--- a/src/platform/idb/schema.ts
+++ b/src/platform/idb/schema.ts
@@ -199,11 +199,10 @@ function migrateNotionAiThreadConversations({ tx }: MigrationContext, onDone: ()
       const canonicalUrl = `https://app.notion.com/chat?t=${threadId}&wfv=chat`;
 
       const proceedWithStableExisting = (stableExisting: Record<string, unknown> | null) => {
-        const seenIds = new Set(
-          groupedConversations.map((item) => Number(item?.id)).filter((id) => Number.isFinite(id) && id > 0),
-        );
         const mergedConversations =
-          stableExisting && stableExisting.id && !seenIds.has(Number(stableExisting.id))
+          stableExisting &&
+          stableExisting.id &&
+          !groupedConversations.some((item) => Number(item?.id) === Number(stableExisting.id))
             ? groupedConversations.concat([stableExisting])
             : groupedConversations;
 
@@ -420,11 +419,8 @@ function migrateLegacyArticleConversations({ tx }: MigrationContext, onDone: () 
       const exactReq = convoKeyIdx.get(['web', canonicalKey]);
       exactReq.onsuccess = () => {
         const exact = (exactReq.result as Record<string, unknown> | undefined) || null;
-        const seenIds = new Set(
-          groupedConversations.map((item) => Number(item?.id)).filter((id) => Number.isFinite(id) && id > 0),
-        );
         const mergedConversations =
-          exact && exact.id && !seenIds.has(Number(exact.id))
+          exact && exact.id && !groupedConversations.some((item) => Number(item?.id) === Number(exact.id))
             ? groupedConversations.concat([{ ...exact, __canonicalUrl: canonicalUrl, __canonicalKey: canonicalKey }])
             : groupedConversations;
 

--- a/src/services/conversations/background/handlers.ts
+++ b/src/services/conversations/background/handlers.ts
@@ -177,17 +177,14 @@ export function registerConversationHandlers(router: AnyRouter, deps: Conversati
     if (!payload.source) return router.err('missing conversation source');
     if (!payload.conversationKey) return router.err('missing conversationKey');
     const convo = await upsertConversation(payload);
-    const conversationId = Number((convo as any)?.id);
-    if (Number.isFinite(conversationId) && conversationId > 0) {
-      fireAndForget(
-        deps.onConversationChanged(
-          conversationId,
-          convo.__isNew
-            ? AUTO_SYNC_CONVERSATION_CHANGED_REASONS.createConversation
-            : AUTO_SYNC_CONVERSATION_CHANGED_REASONS.upsertConversation,
-        ),
-      );
-    }
+    fireAndForget(
+      deps.onConversationChanged(
+        convo.id,
+        convo.__isNew
+          ? AUTO_SYNC_CONVERSATION_CHANGED_REASONS.createConversation
+          : AUTO_SYNC_CONVERSATION_CHANGED_REASONS.upsertConversation,
+      ),
+    );
     return router.ok(convo);
   });
 

--- a/src/services/conversations/data/storage-idb.ts
+++ b/src/services/conversations/data/storage-idb.ts
@@ -172,10 +172,6 @@ function sortFacetItems(items: Array<{ key: string; label: string; count: number
   });
 }
 
-function isArticlePayload(payload: any): boolean {
-  return safeString(payload?.sourceType).toLowerCase() === 'article';
-}
-
 async function findExistingArticleConversationByUrl(
   conversationsStore: IDBObjectStore,
   rawUrl: unknown,
@@ -251,10 +247,11 @@ async function findExistingConversationForPayload(
   }
 
   const source = safeString(payload?.source);
+  const isArticle = safeString(payload?.sourceType).toLowerCase() === 'article';
   let conversationKey = safeString(payload?.conversationKey);
   if (!source) return null;
 
-  if (isArticlePayload(payload) && source.toLowerCase() === WEB_ARTICLE_SOURCE) {
+  if (isArticle && source.toLowerCase() === WEB_ARTICLE_SOURCE) {
     const identity = buildCanonicalWebArticleIdentity(payload?.url);
     if (identity) conversationKey = identity.conversationKey;
     conversationKey = normalizeWebArticleConversationKey(conversationKey);
@@ -263,9 +260,7 @@ async function findExistingConversationForPayload(
   if (!conversationKey) return null;
   const idx = conversationsStore.index('by_source_conversationKey');
   let existing: any = await reqToPromise(idx.get([source, conversationKey]) as any);
-  if (!existing && isArticlePayload(payload)) {
-    existing = await findExistingArticleConversationByUrl(conversationsStore, payload?.url);
-  }
+  if (!existing && isArticle) existing = await findExistingArticleConversationByUrl(conversationsStore, payload?.url);
   return existing || null;
 }
 

--- a/src/services/conversations/data/storage-idb.ts
+++ b/src/services/conversations/data/storage-idb.ts
@@ -180,11 +180,12 @@ async function findExistingArticleConversationByUrl(
   conversationsStore: IDBObjectStore,
   rawUrl: unknown,
 ): Promise<any | null> {
-  const normalizedUrl = canonicalizeArticleUrl(rawUrl);
-  if (!normalizedUrl) return null;
+  const identity = buildCanonicalWebArticleIdentity(rawUrl);
+  if (!identity) return null;
+  const normalizedUrl = identity.url;
   const siteKey = deriveConversationListStoredSiteKeyFromUrl(normalizedUrl);
-  if (!siteKey || siteKey === 'unknown') return null;
-  const canonicalConversationKey = buildCanonicalWebArticleIdentity(normalizedUrl)?.conversationKey || '';
+  if (siteKey === 'unknown') return null;
+  const canonicalConversationKey = identity.conversationKey;
 
   const index = conversationsStore.index('by_listSiteKey_lastCapturedAt_id');
   const range = globalThis.IDBKeyRange.bound(

--- a/src/services/conversations/data/storage-idb.ts
+++ b/src/services/conversations/data/storage-idb.ts
@@ -201,7 +201,8 @@ async function findExistingArticleConversationByUrl(
         canonicalizeArticleUrl(row?.url) === normalizedUrl
       ) {
         const rowCanonical =
-          safeString(row?.source) === WEB_ARTICLE_SOURCE && canonicalConversationKey === safeString(row?.conversationKey);
+          safeString(row?.source) === WEB_ARTICLE_SOURCE &&
+          canonicalConversationKey === safeString(row?.conversationKey);
         const bestCanonical =
           !!best &&
           safeString(best?.source) === WEB_ARTICLE_SOURCE &&

--- a/src/services/conversations/data/storage-idb.ts
+++ b/src/services/conversations/data/storage-idb.ts
@@ -1688,45 +1688,29 @@ export async function getConversationById(conversationId: number): Promise<Conve
   return row ? (normalizeConversationListRecord(row) as Conversation) : null;
 }
 
-export async function readConversationMentionCandidatePool(input: {
-  maxScan: number;
-  maxDurationMs: number;
-}): Promise<{
-  candidates: Array<{
-    conversationId: number;
-    title: string;
-    source: string;
-    domain: string;
-    lastCapturedAt: number;
-  }>;
-  revision: number;
-}> {
-  // ponytail: Item Mention intentionally searches only a bounded recent pool; FTS/global indexing stays out of scope.
+type ConversationMentionCandidate = {
+  conversationId: number;
+  title: string;
+  source: string;
+  domain: string;
+  lastCapturedAt: number;
+};
+
+function readConversationMentionCandidatesFromStore(
+  conversationsStore: IDBObjectStore,
+  input: { maxScan: number; maxDurationMs: number },
+): Promise<ConversationMentionCandidate[]> {
   const { maxScan, maxDurationMs } = input;
-
-  const db = await openDb();
-  const revisionStoreName = DATA_REVISION_STORE_BY_SCOPE.conversations;
-  const { t, stores } = tx(db, ['conversations', revisionStoreName], 'readonly');
-  const done = txDone(t);
-  const revisionPromise = reqToPromise(stores[revisionStoreName].get(DATA_REVISION_RECORD_KEY));
-  const idx = stores.conversations.index('by_lastCapturedAt_id');
-
-  const candidates: Array<{
-    conversationId: number;
-    title: string;
-    source: string;
-    domain: string;
-    lastCapturedAt: number;
-  }> = [];
+  const candidates: ConversationMentionCandidate[] = [];
   let scannedCount = 0;
   const startedAt = Date.now();
+  const cursorReq = conversationsStore.index('by_lastCapturedAt_id').openCursor(null, 'prev');
 
-  const cursorReq = idx.openCursor(null, 'prev');
-  const cursorDone = new Promise<void>((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     cursorReq.onerror = () => reject(cursorReq.error || new Error('cursor failed'));
     cursorReq.onsuccess = () => {
       const cursor = cursorReq.result as IDBCursorWithValue | null;
-      if (!cursor) return resolve();
+      if (!cursor) return resolve(candidates);
 
       scannedCount += 1;
       const record = cursor.value as any;
@@ -1742,15 +1726,41 @@ export async function readConversationMentionCandidatePool(input: {
         });
       }
 
-      const elapsed = Date.now() - startedAt;
-      if (scannedCount >= maxScan || elapsed >= maxDurationMs) return resolve();
-
+      if (scannedCount >= maxScan || Date.now() - startedAt >= maxDurationMs) return resolve(candidates);
       cursor.continue();
     };
   });
+}
 
+export async function readRecentConversationMentionCandidates(input: {
+  maxScan: number;
+  maxDurationMs: number;
+}): Promise<ConversationMentionCandidate[]> {
+  const db = await openDb();
+  const { t, stores } = tx(db, ['conversations'], 'readonly');
+  const done = txDone(t);
   try {
-    await cursorDone;
+    const candidates = await readConversationMentionCandidatesFromStore(stores.conversations, input);
+    await done;
+    return candidates;
+  } catch (error) {
+    await done.catch(() => undefined);
+    throw error;
+  }
+}
+
+export async function readConversationMentionCandidatePool(input: {
+  maxScan: number;
+  maxDurationMs: number;
+}): Promise<{ candidates: ConversationMentionCandidate[]; revision: number }> {
+  // ponytail: Item Mention intentionally searches only a bounded recent pool; FTS/global indexing stays out of scope.
+  const db = await openDb();
+  const revisionStoreName = DATA_REVISION_STORE_BY_SCOPE.conversations;
+  const { t, stores } = tx(db, ['conversations', revisionStoreName], 'readonly');
+  const done = txDone(t);
+  const revisionPromise = reqToPromise(stores[revisionStoreName].get(DATA_REVISION_RECORD_KEY));
+  try {
+    const candidates = await readConversationMentionCandidatesFromStore(stores.conversations, input);
     const revision = normalizeDataRevisionRecord(await revisionPromise).revision;
     await done;
     return { candidates, revision };

--- a/src/services/conversations/data/storage.ts
+++ b/src/services/conversations/data/storage.ts
@@ -46,6 +46,10 @@ export async function getConversationDetail(conversationId: number) {
   return { conversationId, messages };
 }
 
+export async function readRecentConversationMentionCandidates(input: { maxScan: number; maxDurationMs: number }) {
+  return await idb.readRecentConversationMentionCandidates(input);
+}
+
 export async function readConversationMentionCandidatePool(input: { maxScan: number; maxDurationMs: number }) {
   return await idb.readConversationMentionCandidatePool(input);
 }

--- a/src/services/conversations/domain/article-identity.ts
+++ b/src/services/conversations/domain/article-identity.ts
@@ -3,7 +3,7 @@ import { canonicalizeArticleUrl } from '@services/url-cleaning/http-url';
 export const WEB_ARTICLE_SOURCE = 'web' as const;
 const WEB_ARTICLE_CONVERSATION_KEY_PREFIX = 'article:';
 
-export type CanonicalWebArticleIdentity = {
+type CanonicalWebArticleIdentity = {
   source: typeof WEB_ARTICLE_SOURCE;
   conversationKey: string;
   url: string;

--- a/src/services/integrations/item-mention/background-handlers.ts
+++ b/src/services/integrations/item-mention/background-handlers.ts
@@ -3,6 +3,7 @@ import {
   getConversationById,
   getConversationDetail,
   readConversationMentionCandidatePool,
+  readRecentConversationMentionCandidates,
 } from '@services/conversations/data/storage';
 import { readDataRevision } from '@services/data-revisions/storage-idb';
 import { searchMentionCandidates } from '@services/integrations/item-mention/mention-search';
@@ -48,8 +49,8 @@ export function registerItemMentionHandlers(router: AnyRouter) {
         : Math.min(Math.floor(parsedLimit), 50);
 
     if (!normalizedQuery) {
-      const recentPool = await readConversationMentionCandidatePool({ maxScan: limit, maxDurationMs: 300 });
-      return respondWithPool(recentPool, normalizedQuery, limit);
+      const candidates = await readRecentConversationMentionCandidates({ maxScan: limit, maxDurationMs: 300 });
+      return router.ok(searchMentionCandidates({ query: normalizedQuery, candidates, limit }));
     }
 
     const observedRevision = await readDataRevision('conversations');

--- a/src/services/integrations/item-mention/background-handlers.ts
+++ b/src/services/integrations/item-mention/background-handlers.ts
@@ -50,7 +50,7 @@ export function registerItemMentionHandlers(router: AnyRouter) {
 
     if (!normalizedQuery) {
       const candidates = await readRecentConversationMentionCandidates({ maxScan: limit, maxDurationMs: 300 });
-      return router.ok(searchMentionCandidates({ query: normalizedQuery, candidates, limit }));
+      return router.ok({ candidates });
     }
 
     const observedRevision = await readDataRevision('conversations');

--- a/src/services/integrations/item-mention/background-handlers.ts
+++ b/src/services/integrations/item-mention/background-handlers.ts
@@ -5,7 +5,6 @@ import {
   readConversationMentionCandidatePool,
 } from '@services/conversations/data/storage';
 import { readDataRevision } from '@services/data-revisions/storage-idb';
-import type { MentionQuery } from '@services/integrations/item-mention/mention-contract';
 import { searchMentionCandidates } from '@services/integrations/item-mention/mention-search';
 import { formatConversationMarkdownForExternalOutput } from '@services/conversations/external-markdown';
 
@@ -36,12 +35,11 @@ export function registerItemMentionHandlers(router: AnyRouter) {
     return load;
   };
 
-  const respondWithPool = (pool: MentionCandidatePool, query: MentionQuery, limit: number) =>
+  const respondWithPool = (pool: MentionCandidatePool, query: string, limit: number) =>
     router.ok(searchMentionCandidates({ query, candidates: pool.candidates, limit }));
 
   router.register(ITEM_MENTION_MESSAGE_TYPES.SEARCH_MENTION_CANDIDATES, async (msg) => {
     const normalizedQuery = String(msg?.query ?? '').trim().toLowerCase();
-    const mentionQuery = { normalized: normalizedQuery, empty: !normalizedQuery };
     const rawLimit = msg?.limit;
     const parsedLimit = Number(rawLimit);
     const limit =
@@ -49,14 +47,14 @@ export function registerItemMentionHandlers(router: AnyRouter) {
         ? 20
         : Math.min(Math.floor(parsedLimit), 50);
 
-    if (mentionQuery.empty) {
+    if (!normalizedQuery) {
       const recentPool = await readConversationMentionCandidatePool({ maxScan: limit, maxDurationMs: 300 });
-      return respondWithPool(recentPool, mentionQuery, limit);
+      return respondWithPool(recentPool, normalizedQuery, limit);
     }
 
     const observedRevision = await readDataRevision('conversations');
     if (mentionCandidatePoolCache?.revision === observedRevision) {
-      return respondWithPool(mentionCandidatePoolCache, mentionQuery, limit);
+      return respondWithPool(mentionCandidatePoolCache, normalizedQuery, limit);
     }
 
     let pool = await loadMentionCandidatePoolSingleFlight();
@@ -65,7 +63,7 @@ export function registerItemMentionHandlers(router: AnyRouter) {
       if (pool.revision !== currentRevision) pool = await loadMentionCandidatePoolSingleFlight();
     }
 
-    return respondWithPool(pool, mentionQuery, limit);
+    return respondWithPool(pool, normalizedQuery, limit);
   });
 
   router.register(ITEM_MENTION_MESSAGE_TYPES.BUILD_MENTION_INSERT_TEXT, async (msg) => {

--- a/src/services/integrations/item-mention/background-handlers.ts
+++ b/src/services/integrations/item-mention/background-handlers.ts
@@ -46,7 +46,7 @@ export function registerItemMentionHandlers(router: AnyRouter) {
     const limit =
       rawLimit == null || rawLimit === '' || !Number.isFinite(parsedLimit) || parsedLimit <= 0
         ? 20
-        : Math.min(Math.floor(parsedLimit), 50);
+        : Math.max(1, Math.min(Math.floor(parsedLimit), 50));
 
     if (!normalizedQuery) {
       const candidates = await readRecentConversationMentionCandidates({ maxScan: limit, maxDurationMs: 300 });

--- a/src/services/integrations/item-mention/background-handlers.ts
+++ b/src/services/integrations/item-mention/background-handlers.ts
@@ -40,7 +40,9 @@ export function registerItemMentionHandlers(router: AnyRouter) {
     router.ok(searchMentionCandidates({ query, candidates: pool.candidates, limit }));
 
   router.register(ITEM_MENTION_MESSAGE_TYPES.SEARCH_MENTION_CANDIDATES, async (msg) => {
-    const normalizedQuery = String(msg?.query ?? '').trim().toLowerCase();
+    const normalizedQuery = String(msg?.query ?? '')
+      .trim()
+      .toLowerCase();
     const rawLimit = msg?.limit;
     const parsedLimit = Number(rawLimit);
     const limit =

--- a/src/services/integrations/item-mention/mention-contract.ts
+++ b/src/services/integrations/item-mention/mention-contract.ts
@@ -1,8 +1,3 @@
-export type MentionQuery = {
-  normalized: string;
-  empty: boolean;
-};
-
 export type MentionCandidate = {
   conversationId: number;
   title: string;

--- a/src/services/integrations/item-mention/mention-contract.ts
+++ b/src/services/integrations/item-mention/mention-contract.ts
@@ -10,8 +10,4 @@ export type MentionSearchResult = {
   candidates: MentionCandidate[];
 };
 
-export type MentionInsertPayload = {
-  conversationId: number;
-};
-
 

--- a/src/services/integrations/item-mention/mention-contract.ts
+++ b/src/services/integrations/item-mention/mention-contract.ts
@@ -9,5 +9,3 @@ export type MentionCandidate = {
 export type MentionSearchResult = {
   candidates: MentionCandidate[];
 };
-
-

--- a/src/services/integrations/item-mention/mention-search.ts
+++ b/src/services/integrations/item-mention/mention-search.ts
@@ -1,32 +1,23 @@
-import type {
-  MentionCandidate,
-  MentionQuery,
-  MentionSearchResult,
-} from '@services/integrations/item-mention/mention-contract';
+import type { MentionCandidate, MentionSearchResult } from '@services/integrations/item-mention/mention-contract';
 
 type MatchInfo = {
   matched: boolean;
   score: number;
 };
 
-function scoreField(fieldValue: string, query: MentionQuery, weight: number): MatchInfo {
+function scoreField(fieldValue: string, query: string, weight: number): MatchInfo {
   const value = fieldValue.toLowerCase();
   if (!value) return { matched: false, score: 0 };
-  const q = query.normalized;
-  if (!q) return { matched: true, score: 0 };
+  if (value === query) return { matched: true, score: weight + 80 };
+  if (value.startsWith(query)) return { matched: true, score: weight + 50 };
 
-  if (value === q) return { matched: true, score: weight + 80 };
-  if (value.startsWith(q)) return { matched: true, score: weight + 50 };
-
-  const idx = value.indexOf(q);
+  const idx = value.indexOf(query);
   if (idx < 0) return { matched: false, score: 0 };
   // Earlier match is better.
   return { matched: true, score: weight + 20 - Math.min(idx, 40) };
 }
 
-function scoreCandidate(candidate: MentionCandidate, query: MentionQuery): MatchInfo {
-  if (query.empty) return { matched: true, score: 0 };
-
+function scoreCandidate(candidate: MentionCandidate, query: string): MatchInfo {
   const titleScore = scoreField(candidate.title, query, 300);
   const domainScore = scoreField(candidate.domain, query, 200);
   const sourceScore = scoreField(candidate.source, query, 120);
@@ -37,12 +28,12 @@ function scoreCandidate(candidate: MentionCandidate, query: MentionQuery): Match
 }
 
 export function searchMentionCandidates(input: {
-  query: MentionQuery;
+  query: string;
   candidates: MentionCandidate[];
   limit: number;
 }): MentionSearchResult {
   const { query, candidates, limit } = input;
-  if (query.empty) return { candidates: candidates.slice(0, limit) };
+  if (!query) return { candidates: candidates.slice(0, limit) };
 
   const matched: Array<{ c: MentionCandidate; score: number }> = [];
   for (const c of candidates) {

--- a/src/services/integrations/item-mention/mention-search.ts
+++ b/src/services/integrations/item-mention/mention-search.ts
@@ -33,8 +33,6 @@ export function searchMentionCandidates(input: {
   limit: number;
 }): MentionSearchResult {
   const { query, candidates, limit } = input;
-  if (!query) return { candidates: candidates.slice(0, limit) };
-
   const matched: Array<{ c: MentionCandidate; score: number }> = [];
   for (const c of candidates) {
     const info = scoreCandidate(c, query);

--- a/tests/smoke/background-router-item-mention.test.ts
+++ b/tests/smoke/background-router-item-mention.test.ts
@@ -98,7 +98,7 @@ describe('background-router item mention', () => {
     const router = createRouter();
 
     const empty = await search(router, '', 3);
-    const whitespace = await search(router, ' \n\t ', 4);
+    await search(router, ' \n\t ', 4);
     const nonEmpty = await search(router, 'openai', 20);
     const cached = await search(router, 'open', 20);
 

--- a/tests/smoke/background-router-item-mention.test.ts
+++ b/tests/smoke/background-router-item-mention.test.ts
@@ -149,7 +149,10 @@ describe('background-router item mention', () => {
     });
 
     expect(response.ok).toBe(true);
-    expect(storageMocks.readRecentConversationMentionCandidates).toHaveBeenCalledWith({ maxScan: 2, maxDurationMs: 300 });
+    expect(storageMocks.readRecentConversationMentionCandidates).toHaveBeenCalledWith({
+      maxScan: 2,
+      maxDurationMs: 300,
+    });
     expect(storageMocks.readConversationMentionCandidatePool).not.toHaveBeenCalled();
     expect(revisionMocks.readDataRevision).not.toHaveBeenCalled();
   });

--- a/tests/smoke/background-router-item-mention.test.ts
+++ b/tests/smoke/background-router-item-mention.test.ts
@@ -6,6 +6,7 @@ import { registerItemMentionHandlers } from '@services/integrations/item-mention
 
 const storageMocks = vi.hoisted(() => ({
   readConversationMentionCandidatePool: vi.fn(),
+  readRecentConversationMentionCandidates: vi.fn(),
   getConversationById: vi.fn(),
   getConversationDetail: vi.fn(),
 }));
@@ -20,6 +21,7 @@ const externalMarkdownMocks = vi.hoisted(() => ({
 
 vi.mock('@services/conversations/data/storage', () => ({
   readConversationMentionCandidatePool: storageMocks.readConversationMentionCandidatePool,
+  readRecentConversationMentionCandidates: storageMocks.readRecentConversationMentionCandidates,
   getConversationById: storageMocks.getConversationById,
   getConversationDetail: storageMocks.getConversationDetail,
 }));
@@ -79,6 +81,7 @@ async function search(router: ReturnType<typeof createRouter>, query: string, li
 afterEach(() => {
   vi.restoreAllMocks();
   storageMocks.readConversationMentionCandidatePool.mockReset();
+  storageMocks.readRecentConversationMentionCandidates.mockReset();
   storageMocks.getConversationById.mockReset();
   storageMocks.getConversationDetail.mockReset();
   revisionMocks.readDataRevision.mockReset();
@@ -87,12 +90,10 @@ afterEach(() => {
 
 describe('background-router item mention', () => {
   it('keeps empty and whitespace-only queries on the small recent-read path without filling the full cache', async () => {
-    storageMocks.readConversationMentionCandidatePool
-      .mockResolvedValueOnce(pool(1, [candidate(1, 'Recent')]))
-      .mockResolvedValueOnce(pool(1, [candidate(2, 'Whitespace')]))
-      .mockResolvedValueOnce(pool(1, [candidate(3, 'OpenAI')]))
-      .mockResolvedValueOnce(pool(1, [candidate(4, 'OpenAI cached')]))
-      .mockResolvedValueOnce(pool(1, [candidate(5, 'OpenAI cached again')]));
+    storageMocks.readRecentConversationMentionCandidates
+      .mockResolvedValueOnce([candidate(1, 'Recent')])
+      .mockResolvedValueOnce([candidate(2, 'Whitespace')]);
+    storageMocks.readConversationMentionCandidatePool.mockResolvedValue(pool(1, [candidate(3, 'OpenAI')]));
     revisionMocks.readDataRevision.mockResolvedValue(1);
     const router = createRouter();
 
@@ -104,24 +105,24 @@ describe('background-router item mention', () => {
     expect(empty.ok).toBe(true);
     expect(nonEmpty.ok).toBe(true);
     expect(cached.ok).toBe(true);
-    expect(storageMocks.readConversationMentionCandidatePool).toHaveBeenNthCalledWith(1, {
+    expect(storageMocks.readRecentConversationMentionCandidates).toHaveBeenNthCalledWith(1, {
       maxScan: 3,
       maxDurationMs: 300,
     });
-    expect(storageMocks.readConversationMentionCandidatePool).toHaveBeenNthCalledWith(2, {
+    expect(storageMocks.readRecentConversationMentionCandidates).toHaveBeenNthCalledWith(2, {
       maxScan: 4,
       maxDurationMs: 300,
     });
-    expect(storageMocks.readConversationMentionCandidatePool).toHaveBeenNthCalledWith(3, {
+    expect(storageMocks.readConversationMentionCandidatePool).toHaveBeenCalledWith({
       maxScan: 2000,
       maxDurationMs: 300,
     });
-    expect(storageMocks.readConversationMentionCandidatePool).toHaveBeenCalledTimes(3);
+    expect(storageMocks.readConversationMentionCandidatePool).toHaveBeenCalledTimes(1);
     expect(revisionMocks.readDataRevision).toHaveBeenCalledTimes(2);
   });
 
   it('ignores the retired text query alias and uses the canonical query field only', async () => {
-    storageMocks.readConversationMentionCandidatePool.mockResolvedValue(pool(1, [candidate(1, 'Recent')]));
+    storageMocks.readRecentConversationMentionCandidates.mockResolvedValue([candidate(1, 'Recent')]);
     const router = createRouter();
 
     const response = await router.__handleMessageForTests({
@@ -131,7 +132,8 @@ describe('background-router item mention', () => {
     });
 
     expect(response.ok).toBe(true);
-    expect(storageMocks.readConversationMentionCandidatePool).toHaveBeenCalledWith({ maxScan: 2, maxDurationMs: 300 });
+    expect(storageMocks.readRecentConversationMentionCandidates).toHaveBeenCalledWith({ maxScan: 2, maxDurationMs: 300 });
+    expect(storageMocks.readConversationMentionCandidatePool).not.toHaveBeenCalled();
     expect(revisionMocks.readDataRevision).not.toHaveBeenCalled();
   });
 

--- a/tests/smoke/background-router-item-mention.test.ts
+++ b/tests/smoke/background-router-item-mention.test.ts
@@ -121,6 +121,23 @@ describe('background-router item mention', () => {
     expect(revisionMocks.readDataRevision).toHaveBeenCalledTimes(2);
   });
 
+  it('clamps fractional and oversized limits to the 1..50 contract', async () => {
+    storageMocks.readRecentConversationMentionCandidates.mockResolvedValue([]);
+    const router = createRouter();
+
+    await search(router, '', 0.5);
+    await search(router, '', 999);
+
+    expect(storageMocks.readRecentConversationMentionCandidates).toHaveBeenNthCalledWith(1, {
+      maxScan: 1,
+      maxDurationMs: 300,
+    });
+    expect(storageMocks.readRecentConversationMentionCandidates).toHaveBeenNthCalledWith(2, {
+      maxScan: 50,
+      maxDurationMs: 300,
+    });
+  });
+
   it('ignores the retired text query alias and uses the canonical query field only', async () => {
     storageMocks.readRecentConversationMentionCandidates.mockResolvedValue([candidate(1, 'Recent')]);
     const router = createRouter();

--- a/tests/storage/item-mention-search-storage.test.ts
+++ b/tests/storage/item-mention-search-storage.test.ts
@@ -6,6 +6,7 @@ import { closeDbForTests, openDb } from '@platform/idb/schema';
 import {
   __resetConversationStorageStateForTests,
   readConversationMentionCandidatePool,
+  readRecentConversationMentionCandidates,
   upsertConversation,
 } from '@services/conversations/data/storage-idb';
 
@@ -129,6 +130,26 @@ describe('item mention candidate pool storage', () => {
 
     expect(res.candidates).toHaveLength(51);
     expect(res.candidates[50]).toMatchObject({ title: 'OpenAI', source: 'chatgpt' });
+  });
+
+  it('reads empty-query recent candidates without opening the revision store', async () => {
+    await upsertConversation({
+      sourceType: 'chat',
+      source: 'chatgpt',
+      conversationKey: 'recent-only',
+      title: 'Recent only',
+      url: 'https://chatgpt.com/c/recent-only',
+      lastCapturedAt: 1,
+    });
+
+    const transactionSpy = vi.spyOn(IDBDatabase.prototype, 'transaction');
+    const candidates = await readRecentConversationMentionCandidates({ maxScan: 20, maxDurationMs: 10_000 });
+
+    expect(candidates).toHaveLength(1);
+    expect(transactionSpy).toHaveBeenCalledTimes(1);
+    const [storeNames, mode] = transactionSpy.mock.calls[0] || [];
+    expect(storeNames).toEqual(['conversations']);
+    expect(mode).toBe('readonly');
   });
 
   it('reads conversation rows and their revision in one readonly transaction', async () => {

--- a/tests/unit/item-mention-search.test.ts
+++ b/tests/unit/item-mention-search.test.ts
@@ -3,20 +3,6 @@ import { describe, expect, it } from 'vitest';
 import { searchMentionCandidates } from '../../src/services/integrations/item-mention/mention-search';
 
 describe('item-mention-search', () => {
-  it('preserves recent pool order for empty query', () => {
-    const res = searchMentionCandidates({
-      query: '',
-      candidates: [
-        { conversationId: 2, title: 'B', source: 'chatgpt', domain: 'b.com', lastCapturedAt: 3000 },
-        { conversationId: 3, title: 'C', source: 'web', domain: 'c.com', lastCapturedAt: 2000 },
-        { conversationId: 1, title: 'A', source: 'chatgpt', domain: 'a.com', lastCapturedAt: 1000 },
-      ],
-      limit: 10,
-    });
-
-    expect(res.candidates.map((c) => c.conversationId)).toEqual([2, 3, 1]);
-  });
-
   it('filters by title/source/domain and sorts by match score then recency', () => {
     const res = searchMentionCandidates({
       query: 'openai',
@@ -72,16 +58,4 @@ describe('item-mention-search', () => {
     expect(res.candidates[0]?.conversationId).toBe(56);
   });
 
-  it('applies the already-normalized final limit', () => {
-    const candidates = Array.from({ length: 200 }, (_, i) => ({
-      conversationId: i + 1,
-      title: `T${i + 1}`,
-      source: 'chatgpt',
-      domain: 'x.com',
-      lastCapturedAt: i + 1,
-    }));
-
-    const res = searchMentionCandidates({ query: '', candidates, limit: 50 });
-    expect(res.candidates).toHaveLength(50);
-  });
 });

--- a/tests/unit/item-mention-search.test.ts
+++ b/tests/unit/item-mention-search.test.ts
@@ -57,5 +57,4 @@ describe('item-mention-search', () => {
     expect(res.candidates).toHaveLength(20);
     expect(res.candidates[0]?.conversationId).toBe(56);
   });
-
 });

--- a/tests/unit/item-mention-search.test.ts
+++ b/tests/unit/item-mention-search.test.ts
@@ -5,7 +5,7 @@ import { searchMentionCandidates } from '../../src/services/integrations/item-me
 describe('item-mention-search', () => {
   it('preserves recent pool order for empty query', () => {
     const res = searchMentionCandidates({
-      query: { normalized: '', empty: true },
+      query: '',
       candidates: [
         { conversationId: 2, title: 'B', source: 'chatgpt', domain: 'b.com', lastCapturedAt: 3000 },
         { conversationId: 3, title: 'C', source: 'web', domain: 'c.com', lastCapturedAt: 2000 },
@@ -19,7 +19,7 @@ describe('item-mention-search', () => {
 
   it('filters by title/source/domain and sorts by match score then recency', () => {
     const res = searchMentionCandidates({
-      query: { normalized: 'openai', empty: false },
+      query: 'openai',
       candidates: [
         {
           conversationId: 1,
@@ -66,7 +66,7 @@ describe('item-mention-search', () => {
       lastCapturedAt: 10_000 - index,
     }));
 
-    const res = searchMentionCandidates({ query: { normalized: 'openai', empty: false }, candidates, limit: 20 });
+    const res = searchMentionCandidates({ query: 'openai', candidates, limit: 20 });
 
     expect(res.candidates).toHaveLength(20);
     expect(res.candidates[0]?.conversationId).toBe(56);
@@ -81,7 +81,7 @@ describe('item-mention-search', () => {
       lastCapturedAt: i + 1,
     }));
 
-    const res = searchMentionCandidates({ query: { normalized: '', empty: true }, candidates, limit: 50 });
+    const res = searchMentionCandidates({ query: '', candidates, limit: 50 });
     expect(res.candidates).toHaveLength(50);
   });
 });


### PR DESCRIPTION
## 概要

围绕 P8 完成冗余/老旧代码与多余安全围栏专项审查，并按真实生产调用链收敛实现。

- 收敛 Article identity fallback：same-site index cursor 单 pass 选 best，删除重复 canonicalization、旧 forwarding layer 与多余内部兼容判断。
- 收敛 v11/legacy migration：删除重复 schema guard、伪恢复、重复 I/O、排序/数组/Set 中间分配，并保持 versionchange fail-closed。
- 收敛 Item Mention candidate pool：删除死字段/死 API/重复 normalization，empty query 不再读取 revision，non-empty query 保留 revision-keyed cache/single-flight。
- 修正 Item Mention fractional limit 下界，维持 1..50 contract。

## 审查结果

- P8 findings：F-01～F-51 全部 Resolved（9 Medium / 42 Low）
- Open / Deferred：0 / 0
- 保留 load-bearing guard：Article historical fallback、migration transaction rollback、revision equality cache invalidation、bounded mention scan、single-flight/catch-up 等。

## 验证

- P8-T1：10 files / 193 tests PASS
- P8-T2：6 files / 37 tests PASS
- `npm run gate`：281 test files / 2115 tests PASS
- Chrome MV3 production build PASS
- fresh `check-dist` PASS
- architecture forbidden-import scan PASS
- `git diff --check` PASS
