### PR TITLE
fix(article): 修复表格 Markdown 与语义标题提取

### DIFF
--- a/src/collectors/web/article-extract/defuddle.ts
+++ b/src/collectors/web/article-extract/defuddle.ts
@@ -35,6 +35,21 @@ function pickTextFromHtml(content: string) {
   return normalizeText((wrapper as any).innerText || wrapper.textContent || '');
 }
 
+function normalizeTitleText(value: unknown) {
+  return normalizeText(value).replace(/\s+/g, ' ');
+}
+
+function pickSemanticTitleFromContent(content: string) {
+  const wrapper = document.createElement('div');
+  wrapper.innerHTML = content;
+  const heading = wrapper.querySelector?.('h1,h2');
+  const candidate = normalizeTitleText(heading?.textContent || '');
+  if (!candidate || typeof document.querySelectorAll !== 'function') return '';
+
+  const pageH1s = Array.from(document.querySelectorAll('h1'));
+  return pageH1s.some((node) => normalizeTitleText(node.textContent || '') === candidate) ? candidate : '';
+}
+
 export function extractByDefuddle(baseHref: string): DefuddleArticlePayload | null {
   try {
     const cloned = document.cloneNode(true) as Document;
@@ -53,7 +68,7 @@ export function extractByDefuddle(baseHref: string): DefuddleArticlePayload | nu
     if (!content && !text) return null;
 
     return {
-      title: normalizeText(parsed.title || document.title || ''),
+      title: pickSemanticTitleFromContent(content) || normalizeText(parsed.title || document.title || ''),
       author: normalizeText(parsed.author || ''),
       publishedAt: normalizeText(parsed.published || ''),
       excerpt: normalizeText(parsed.description || ''),

--- a/src/collectors/web/article-extract/markdown-turndown.ts
+++ b/src/collectors/web/article-extract/markdown-turndown.ts
@@ -90,10 +90,10 @@ function createTurndownService() {
     return normalizeText(value).replace(/\s+/g, ' ');
   }
 
-  turndown.addRule('syncnos-table-section', {
+  turndown.addRule('syncnos-table-block-wrapper', {
     filter(node) {
       const name = String((node as any)?.nodeName || '').toLowerCase();
-      if (name !== 'section') return false;
+      if (name !== 'p' && name !== 'section' && name !== 'div') return false;
       return isInsideTable(node);
     },
     replacement(content) {
@@ -110,6 +110,18 @@ function createTurndownService() {
     },
     replacement() {
       return ' ';
+    },
+  });
+
+  turndown.addRule('syncnos-redundant-strong', {
+    filter(node) {
+      const name = String((node as any)?.nodeName || '').toLowerCase();
+      if (name !== 'b' && name !== 'strong') return false;
+      const parent = (node as Element)?.parentElement;
+      return Boolean(parent?.closest?.('b,strong'));
+    },
+    replacement(content) {
+      return content;
     },
   });
 

--- a/tests/collectors/article-extract-markdown.test.ts
+++ b/tests/collectors/article-extract-markdown.test.ts
@@ -259,6 +259,36 @@ describe('article-extract markdown', () => {
     expect(md).not.toContain('<table');
   });
 
+  it('keeps block-wrapped table cells on one markdown row', () => {
+    const html = `
+      <article>
+        <table>
+          <tbody>
+            <tr>
+              <th><p><span>词语</span></p></th>
+              <th><p><span>在本项目中的含义</span></p></th>
+            </tr>
+            <tr>
+              <td><p><b><strong>MJCF</strong></b></p></td>
+              <td><p><span>描述机器人刚体、关节、质量、惯量、网格和碰撞关系的 XML 模型</span></p></td>
+            </tr>
+          </tbody>
+        </table>
+      </article>
+    `;
+
+    const dom = new JSDOM(`<body>${html}</body>`, { url: 'https://example.com/article' });
+    setupDom(dom);
+
+    const md = htmlToMarkdownTurndown(html, 'https://example.com/article');
+    const lines = md.split('\n');
+    expect(lines.find((line) => line.includes('词语'))).toMatch(/^\|[ \t]+词语[ \t]+\|[ \t]+在本项目中的含义[ \t]+\|$/);
+    expect(lines.find((line) => line.includes('MJCF'))).toMatch(
+      /^\|[ \t]+\*\*MJCF\*\*[ \t]+\|[ \t]+描述机器人刚体、关节、质量、惯量、网格和碰撞关系的 XML 模型[ \t]+\|$/,
+    );
+    expect(md).not.toContain('****MJCF****');
+  });
+
   it('converts wechat rich_media tables with nested <section>/<span> into markdown tables', () => {
     const html = `
       <article>

--- a/tests/unit/article-extract-defuddle-local-only.test.ts
+++ b/tests/unit/article-extract-defuddle-local-only.test.ts
@@ -1,3 +1,4 @@
+import { JSDOM } from 'jsdom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => {
@@ -54,5 +55,40 @@ describe('article-extract Defuddle local-only policy', () => {
     expect(mocks.Defuddle).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ useAsync: false }));
     expect(mocks.parse).toHaveBeenCalledOnce();
     expect(mocks.parseAsync).not.toHaveBeenCalled();
+  });
+
+  it('prefers a semantic page h1 that Defuddle preserved as the leading article heading', () => {
+    const dom = new JSDOM(
+      '<!doctype html><html><head><title>Site chrome title</title></head><body><h1>Actual article title</h1></body></html>',
+    );
+    vi.stubGlobal('document', dom.window.document);
+    mocks.parse.mockReturnValueOnce({
+      title: 'Author on Site',
+      author: '',
+      published: '',
+      description: '',
+      content: '<article><h2>Actual article title</h2><p>Captured locally</p></article>',
+    });
+
+    expect(extractByDefuddle('https://example.com/article')).toMatchObject({
+      title: 'Actual article title',
+      textContent: 'Actual article titleCaptured locally',
+    });
+  });
+
+  it('keeps Defuddle title when the extracted heading is not the page h1', () => {
+    const dom = new JSDOM('<!doctype html><html><body><h1>Actual article title</h1></body></html>');
+    vi.stubGlobal('document', dom.window.document);
+    mocks.parse.mockReturnValueOnce({
+      title: 'Parser article title',
+      author: '',
+      published: '',
+      description: '',
+      content: '<article><h2>First section</h2><p>Captured locally</p></article>',
+    });
+
+    expect(extractByDefuddle('https://example.com/article')).toMatchObject({
+      title: 'Parser article title',
+    });
   });
 });


### PR DESCRIPTION
## Related issue
N/A — 两项已有、可复现的文章提取修复。

## Why
- 表格单元格内的块级包装会被转换为 Markdown 换行，破坏表格行结构。
- Defuddle 保留的文章主标题可能与其推断标题不同，导致正文首个语义标题未被用作文章标题。

## Scope

### In scope
- 修复表格内 `p`、`section`、`div` 的 Markdown 转换。
- 在提取内容的首个语义标题与真实页面 `h1` 完全一致时，使用该标题。

### Non-goals
- 不改变非表格块级元素的 Markdown 规则。
- 不为无法与页面 `h1` 精确匹配的章节标题猜测文章标题。

## What changed
- 将表格内块级包装内容归一为单个空格，保持单行 Markdown 表格。
- 消除嵌套 `b`/`strong` 产生的重复加粗标记。
- 从提取内容中识别经真实页面 `h1` 校验的首个 `h1`/`h2`，否则保留既有 Defuddle 标题回退。
- 为表格嵌套块和语义标题匹配/不匹配路径补充回归测试。

## Architecture / invariants
- 改动仅位于 `src/collectors/**`，保持 `collectors -> services/shared` 依赖方向。
- 标题仅在与真实页面 `h1` 精确匹配时覆盖，避免把正文分节标题误判为文章标题。

## Data, migration & recovery
N/A — 不涉及存储、数据迁移或恢复路径。

## Permissions, network & privacy
N/A — 不涉及权限、网络请求或隐私数据处理变更。

## Compatibility
- 含块级包装的 HTML 表格保持同一 Markdown 行。
- 不满足语义标题校验的页面继续使用原有标题提取结果。

## Demo
N/A — 无视觉界面改动。

## Drawbacks / risks
- 语义标题采用保守的精确文本匹配；匹配失败时会使用既有标题回退，而不会猜测。

## Tests & verification

### Automated
- `npm run gate:ci`
- `npm run test -- tests/collectors/article-extract-markdown.test.ts tests/unit/article-extract-defuddle-local-only.test.ts`

### Manual
N/A — 未改浏览器注入、交互、权限或网络路径；使用 production-shaped JSDOM fixtures 覆盖确定性的 DOM 转换和标题提取。

## Documentation
N/A — 未改变对外行为契约或用户文档。