### PR TITLE
fix: 修复网页域名二级筛选回退

### DIFF
--- a/src/ui/conversations/ConversationListPane.tsx
+++ b/src/ui/conversations/ConversationListPane.tsx
@@ -207,7 +207,6 @@ export function ConversationListPane({
     return [{ key: SITE_FILTER_ALL_KEY, label: t('allFilter') }, ...options];
   }, [listFacets, listSourceFilterKey]);
 
-  const siteOptionKeys = useMemo(() => new Set(siteOptions.map((opt) => String(opt.key || ''))), [siteOptions]);
   const filteredItems = items;
   const sidebarLocale = getCurrentLocale();
   const todayGroupLabel = t('insightRangeToday');
@@ -445,22 +444,6 @@ export function ConversationListPane({
     }
     void refreshList();
   };
-
-  useEffect(() => {
-    const sourceKey =
-      String(listSourceFilterKey || 'all')
-        .trim()
-        .toLowerCase() || 'all';
-    if (sourceKey !== 'web') return;
-
-    const current =
-      String(listSiteFilterKey || SITE_FILTER_ALL_KEY)
-        .trim()
-        .toLowerCase() || SITE_FILTER_ALL_KEY;
-    if (current === SITE_FILTER_ALL_KEY) return;
-    if (siteOptionKeys.has(current)) return;
-    setListSiteFilterKeyPersistent(SITE_FILTER_ALL_KEY);
-  }, [listSiteFilterKey, listSourceFilterKey, setListSiteFilterKeyPersistent, siteOptionKeys]);
 
   const activateRow = (conversationId: number) => {
     onListScrollTopChange?.(scrollRef.current?.scrollTop || 0);

--- a/src/viewmodels/conversations/conversations-context.tsx
+++ b/src/viewmodels/conversations/conversations-context.tsx
@@ -643,13 +643,27 @@ export function ConversationsProvider({
         if (requestSeq !== listRequestSeqRef.current) return;
 
         const list = Array.isArray(page?.items) ? page.items : [];
+        const nextFacets = normalizeConversationListFacets(page?.facets);
+        const selectedSiteAvailable =
+          sourceKey !== 'web' ||
+          siteKey === LIST_SITE_FILTER_ALL_KEY ||
+          nextFacets.sites.some(
+            (facet) =>
+              facet.key === siteKey ||
+              (siteKey !== 'unknown' && !siteKey.startsWith('domain:') && facet.key === `domain:${siteKey}`),
+          );
+        if (!selectedSiteAvailable) {
+          setListSiteFilterKeyPersistent(LIST_SITE_FILTER_ALL_KEY);
+          return;
+        }
+
         listSuccessRequestSeqRef.current = requestSeq;
         listCommittedFilterScopeRef.current = scope;
         setItems(list);
         setListCursor(page?.cursor ?? null);
         setListHasMore(Boolean(page?.hasMore));
         setListSummary(normalizeConversationListSummary(page?.summary));
-        setListFacets(normalizeConversationListFacets(page?.facets));
+        setListFacets(nextFacets);
 
         const ids = new Set(list.map((x) => Number(x.id)).filter((x) => Number.isFinite(x) && x > 0));
         setSelectedIds((prev) => prev.filter((id) => ids.has(Number(id))));
@@ -702,7 +716,13 @@ export function ConversationsProvider({
         }
       }
     },
-    [listSiteFilterKey, listSourceFilterKey, setActiveConversationSnapshot, setActiveId],
+    [
+      listSiteFilterKey,
+      listSourceFilterKey,
+      setActiveConversationSnapshot,
+      setActiveId,
+      setListSiteFilterKeyPersistent,
+    ],
   );
   refreshListRef.current = refreshList;
 

--- a/tests/unit/conversation-list-pagination.test.ts
+++ b/tests/unit/conversation-list-pagination.test.ts
@@ -226,6 +226,27 @@ describe('ConversationListPane pagination behaviors', () => {
     expect(loadMoreList).toHaveBeenCalledTimes(1);
   });
 
+  it('does not rewrite a selected web domain from a transient empty facet snapshot', async () => {
+    const setListSiteFilterKeyPersistent = vi.fn();
+    currentState = buildState({
+      listSourceFilterKey: 'web',
+      listSiteFilterKey: 'domain:example.com',
+      listFacets: {
+        sources: [{ key: 'web', label: 'web', count: 2 }],
+        sites: [],
+      },
+      loadingInitialList: true,
+      setListSiteFilterKeyPersistent,
+    });
+
+    await renderPane();
+    await act(async () => {
+      await flushMicrotasks();
+    });
+
+    expect(setListSiteFilterKeyPersistent).not.toHaveBeenCalled();
+  });
+
   it('does not attach selection or batch tooltips when nothing is selected', async () => {
     currentState = buildState({ selectedIds: [] });
     await renderPane();

--- a/tests/unit/conversations-provider-pagination.test.ts
+++ b/tests/unit/conversations-provider-pagination.test.ts
@@ -295,6 +295,38 @@ describe('ConversationsProvider pagination state', () => {
     expect((latestState.items as any[]).map((item) => Number(item.id))).toEqual([201]);
   });
 
+  it('validates a persisted web domain only against a successful facet snapshot', async () => {
+    window.localStorage.setItem('webclipper_conversations_source_filter_key', 'web');
+    window.localStorage.setItem('webclipper_conversations_site_filter_key', 'domain:missing.example');
+
+    getConversationListBootstrap.mockImplementation((query: any) => {
+      const siteKey = String(query?.siteKey || 'all')
+        .trim()
+        .toLowerCase();
+      const facets = {
+        sources: [{ key: 'web', label: 'web', count: 1 }],
+        sites: [{ key: 'domain:example.com', label: 'example.com', count: 1 }],
+      };
+      if (siteKey === 'domain:missing.example') return Promise.resolve(makePage([], facets));
+      return Promise.resolve(makePage([makeConversation(301, 'web', 'article-301')], facets));
+    });
+
+    await renderProvider();
+    await act(async () => {
+      await flushMicrotasks();
+      await flushMicrotasks();
+      await flushMicrotasks();
+    });
+
+    expect(String(latestState.listSourceFilterKey)).toBe('web');
+    expect(String(latestState.listSiteFilterKey)).toBe('all');
+    expect(window.localStorage.getItem('webclipper_conversations_site_filter_key')).toBeNull();
+    expect(getConversationListBootstrap.mock.calls.map(([query]) => query?.siteKey)).toEqual([
+      'domain:missing.example',
+      'all',
+    ]);
+  });
+
   it('merges a successful continuation page and commits its pagination bundle', async () => {
     const firstPage = {
       ...makePage([makeConversation(1, 'chatgpt', 'conv-1')], {


### PR DESCRIPTION
## Summary
- 修复网页文章二级域名筛选在切换后被错误重置为“全部”的问题
- 移除 UI 根据瞬时 facets 主动回写筛选状态的逻辑
- 将持久化域名有效性校验收敛到 ConversationsProvider，并仅基于成功 bootstrap 快照判定
- 补充 UI 与 ViewModel 回归测试

## Verification
- 用户已手动验收通过
- `npm run gate:ci`
- 284 test files passed
- 2149 tests passed
