### PR TITLE
修复 GitHub 同步提交数量并收敛冗余状态

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ YouTube and Bilibili pages can capture transcripts/subtitles that the page has a
 | **Notion** | Syncs local content through the Notion API after OAuth. Manual sync is always available; optional auto-sync can be enabled. |
 | **Obsidian** | Writes Markdown and local image attachments to your vault through the localhost Local REST API. See [setup](docs/guide/obsidian/LocalRestAPI.en.md). |
 | **Feishu** | Syncs local content to Feishu DocX after OAuth. Manual sync is always available; optional auto-sync can be enabled. See [setup](docs/guide/feishu/DocxSync.en.md). |
-| **GitHub** | Writes the local projection to an authorized repository/branch through the SyncNos GitHub App. Manual sync is always available; optional auto-sync can be enabled. |
+| **GitHub** | Writes the local projection to an authorized repository/branch through the SyncNos GitHub App. Manual sync is always available; optional auto-sync can be enabled. Sync-generated commits use the fixed message `SyncNos GitHub sync`; GitHub's final diff is authoritative for which files actually changed. |
 | **Markdown / Zip** | Exports individual content or a local backup package. |
 
 ## Screenshots

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ YouTube and Bilibili pages can capture transcripts/subtitles that the page has a
 | **Notion** | Syncs local content through the Notion API after OAuth. Manual sync is always available; optional auto-sync can be enabled. |
 | **Obsidian** | Writes Markdown and local image attachments to your vault through the localhost Local REST API. See [setup](docs/guide/obsidian/LocalRestAPI.en.md). |
 | **Feishu** | Syncs local content to Feishu DocX after OAuth. Manual sync is always available; optional auto-sync can be enabled. See [setup](docs/guide/feishu/DocxSync.en.md). |
-| **GitHub** | Writes the local projection to an authorized repository/branch through the SyncNos GitHub App. Manual sync is always available; optional auto-sync can be enabled. Sync-generated commits use the fixed message `SyncNos GitHub sync`; GitHub's final diff is authoritative for which files actually changed. |
+| **GitHub** | Writes the local projection to an authorized repository/branch through the SyncNos GitHub App. Manual sync is always available; optional auto-sync can be enabled. |
 | **Markdown / Zip** | Exports individual content or a local backup package. |
 
 ## Screenshots

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -69,7 +69,7 @@ YouTube 和 Bilibili 页面可采集页面已经加载的字幕 / 转录内容�
 | **Notion** | OAuth 后通过 Notion API 同步本地内容；始终可手动同步，也可显式开启自动同步。 |
 | **Obsidian** | 通过本机 Local REST API 把 Markdown 和本地图片附件写入 vault。参见[配置指南](docs/guide/obsidian/LocalRestAPI.zh.md)。 |
 | **飞书** | OAuth 后同步本地内容到飞书 DocX；始终可手动同步，也可显式开启自动同步。参见[配置指南](docs/guide/feishu/DocxSync.zh.md)。 |
-| **GitHub** | 通过 SyncNos GitHub App 把本地 projection 写入已授权的 repository/branch；始终可手动同步，也可显式开启自动同步。 |
+| **GitHub** | 通过 SyncNos GitHub App 把本地 projection 写入已授权的 repository/branch；始终可手动同步，也可显式开启自动同步。SyncNos 生成的 commit 固定使用 `SyncNos GitHub sync`，实际改变了哪些文件以 GitHub 最终 diff 为准。 |
 | **Markdown / Zip** | 导出单条内容或本地备份包。 |
 
 ## 界面预览

--- a/docs/GENERATION.md
+++ b/docs/GENERATION.md
@@ -7,8 +7,8 @@ This file records the source baseline and ownership rules used for the long-term
 | Field | Value |
 | --- | --- |
 | Repository | `SyncNos` WebClipper codebase (origin: `chiimagnus/SyncNos`) |
-| Commit hash | `529c39c486a64662c41499fb9815c0af7f25f7ec` |
-| Generated at | `2026-08-31` |
+| Commit hash | `2e75adfdd9bfc36503c164def288ec1e0fcc638e` |
+| Generated at | `2026-09-05` |
 
 The commit above is the code baseline at the start of this documentation reconciliation. Documentation-only edits do not advance it.
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -34,8 +34,11 @@ GitHub 的 repository 与 branch 属于非敏感配置，可按现有 storage ba
 
 Inpage 显示设置只使用 `inpage_display_mode`（`supported | all | off`）。运行时、Settings、context menu 与 backup 都只读取和写入这一 canonical key；backup 会丢弃其它退役的 `inpage_*` storage residue。无设置或值非法时使用运行默认 `all`，startup 会清理非法 canonical residue，但不会为了默认值凭空物化 storage key。
 
-## GitHub 恢复状态
+## GitHub 同步与恢复边界
 
+- 手动 GitHub 同步使用 `reconcile`，会重新声明已知受管 projection 以恢复远端删除或漂移；自动同步和 cleanup 使用 `incremental`。两者都进入同一 GitHub orchestrator / SyncJob lifecycle，不能为了减少远端操作或显示数量而拆成第二套同步状态机。
+- SyncNos 创建 GitHub commit 时固定使用 `SyncNos GitHub sync`。选中的 conversations、planner staged operations、Git tree entries 与最终 changed files 不保证一一对应；不要把其中任一候选数量写进 commit message，实际远端变化以 GitHub 最终 tree diff 为准。
+- GitHub sync mapping 只在 transport 为本次 staged operations 返回完整 final-file resolution 后 acknowledgement。远端 commit 失败、resolution 不完整或 mapping patch 失败时，本地采集内容仍是真源，既有 continuity 不得被伪造为成功状态。
 - GitHub auth/pending state 存在 `chrome.storage.local` 的 `github_auth_state_v1`，属于 secret/runtime state，不进入 Zip backup。
 - pending Device Flow 的 remote-state discovery 不得把单个 UI timer 当成 correctness 唯一来源。设置页面在重新可见、重新获得焦点或 pageshow 时，只在持久化 `nextPollAt` 已到期后补做 reconcile；poll interval、`slow_down`、expiry 与跨调用 claim 仍由 Device Flow service 和 durable auth state 最终裁决。timer / lifecycle wake 的并发触发必须合并，且授权收敛不得因无关设置操作而长期阻塞。
 - mount hydration、auth storage wake 与 poll-error recovery 可能并发读取 GitHub safe auth snapshot；较旧响应不得覆盖更新的已应用 auth 状态。较新的读取失败只保留 last-good，不得把失败解释成 disconnected，也不能让乱序响应把 connected 回退为 pending。

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,6 +10,7 @@
 | Vitest 不退出 | 未释放的 timer、listener 或 React root；超时不是 PASS。 |
 | manifest/version 发布失败 | `wxt.config.ts`、tag 和 workflow 的版本校验。 |
 | OAuth Connect 无响应 | client id、redirect URI、pending state、Worker endpoint 和浏览器日志。 |
+| GitHub 手动同步选中了多条，但 commit 的 changed files 更少 | 这是可能的正常结果：手动同步使用 `reconcile`，未变化的受管路径也可能参与声明，但 GitHub 最终 tree diff 只显示真正变化的文件。SyncNos commit message 固定为 `SyncNos GitHub sync`，不再用选中数或 staged 数冒充 changed-file 数。 |
 | article 只有文本没有图片 | 图片设置、anti-hotlink rule、referer 与下载 warning；文本成功仍是成功。 |
 | 视频提示没有字幕 | 先在页面开启并等待字幕请求加载，再 capture。 |
 | `Could not establish connection` / `Receiving end does not exist` | 先按发送方向和生命周期分类：content → background 冷启动、background → content 尚未注入、port 已建立后关闭、旧 context 失效是不同问题。不要用通用 retry 掩盖 background cold-start，也不要把 `message port closed` 或 `Extension context invalidated` 当成 missing receiver。 |

--- a/src/services/sync/auto-sync/github-auto-sync-scheduler.ts
+++ b/src/services/sync/auto-sync/github-auto-sync-scheduler.ts
@@ -20,7 +20,6 @@ export const GITHUB_AUTO_SYNC_TRANSIENT_RETRY_MS = 2 * 60_000;
 export const GITHUB_AUTO_SYNC_ACTION_REQUIRED_RETRY_MS = 15 * 60_000;
 export const GITHUB_CLEANUP_BATCH_CONTINUE_DELAY_MS = 1_000;
 export const GITHUB_CLEANUP_BUSY_RETRY_MS = 60_000;
-export const GITHUB_CLEANUP_UNKNOWN_FAILURE_RETRY_MS = 5 * 60_000;
 
 const TRANSIENT_CODES = new Set([
   'github_network_error',
@@ -41,29 +40,12 @@ export function getGithubAutoSyncFailureRetryDelayMs(error: unknown): number {
     : GITHUB_AUTO_SYNC_ACTION_REQUIRED_RETRY_MS;
 }
 
-function resultFailureCode(result: any): string {
-  const items = Array.isArray(result?.items) ? result.items : [];
-  for (const item of items) {
-    if (item?.status !== 'failed' && item?.status !== 'mapping_failed') continue;
-    const code = String(item?.error || '').trim();
-    return code.startsWith('github_') ? code : 'github_sync_item_failed';
+function resultFailureCode(result: Awaited<ReturnType<GithubSyncOrchestrator['sync']>>): string {
+  for (const item of result.items) {
+    if (item.status !== 'failed' && item.status !== 'mapping_failed') continue;
+    return item.error.startsWith('github_') ? item.error : 'github_sync_item_failed';
   }
-
-  const transportStatus = String(result?.transport?.status || '').trim();
-  if (transportStatus === 'invalid_resolution') return 'github_transport_resolution_incomplete';
-  if (transportStatus === 'failed') return 'github_transport_failed';
-  return '';
-}
-
-function normalizePositiveIds(value: unknown): number[] {
-  if (!Array.isArray(value)) return [];
-  return [
-    ...new Set(
-      value
-        .map((candidate) => Number(candidate))
-        .filter((candidate): candidate is number => Number.isSafeInteger(candidate) && candidate > 0),
-    ),
-  ];
+  return result.transportStatus === 'failed' ? 'github_transport_failed' : '';
 }
 
 export type GithubAutoSyncScheduler = AutoSyncScheduler & {
@@ -112,18 +94,15 @@ export function createGithubAutoSyncScheduler(
   const scheduleCleanup = async (when = infra.now()) => {
     if (!(await cleanupEnabled())) return;
     if (!infra.alarms.isAvailable()) return;
-    const candidate = Number(when);
     const now = infra.now();
-    const dueAt = Number.isFinite(candidate) && candidate > now ? Math.floor(candidate) : now;
+    const dueAt = when > now ? Math.floor(when) : now;
     infra.alarms.create(GITHUB_AUTO_SYNC_CLEANUP_ALARM_NAME, { when: dueAt });
   };
 
   const scheduleCleanupFailure = async (error: unknown) => {
     const code = String((error as any)?.code || '').trim();
     const delay =
-      code === 'sync_already_running'
-        ? GITHUB_CLEANUP_BUSY_RETRY_MS
-        : getGithubAutoSyncFailureRetryDelayMs(error) || GITHUB_CLEANUP_UNKNOWN_FAILURE_RETRY_MS;
+      code === 'sync_already_running' ? GITHUB_CLEANUP_BUSY_RETRY_MS : getGithubAutoSyncFailureRetryDelayMs(error);
     await scheduleCleanup(infra.now() + delay);
   };
 
@@ -131,27 +110,26 @@ export function createGithubAutoSyncScheduler(
   const flushCleanupOnce = async () => {
     if (!(await cleanupEnabled())) return;
     try {
-      const result: any = await deps.githubSyncOrchestrator.sync({
+      const result = await deps.githubSyncOrchestrator.sync({
         conversationIds: [],
         mode: 'incremental',
         instanceId: deps.getInstanceId(),
       });
-      if (result?.transport?.status === 'failed' || result?.transport?.status === 'invalid_resolution') {
+      if (result.transportStatus === 'failed') {
         throw Object.assign(new Error('github_cleanup_transport_failed'), { code: 'github_cleanup_transport_failed' });
       }
 
-      const replacementIds = normalizePositiveIds(result?.deferredReplacementConversationIds);
+      const replacementIds = result.deferredReplacementConversationIds;
       for (const conversationId of replacementIds) {
         await normalScheduler.enqueue(conversationId, 'github_cleanup_replacement');
       }
 
-      if (result?.cleanupHasMoreDue === true) {
+      if (result.cleanupHasMoreDue) {
         await scheduleCleanup(infra.now() + GITHUB_CLEANUP_BATCH_CONTINUE_DELAY_MS);
         return;
       }
-      const nextCleanupDueAt = Number(result?.nextCleanupDueAt);
-      if (Number.isFinite(nextCleanupDueAt) && nextCleanupDueAt > 0) {
-        await scheduleCleanup(nextCleanupDueAt);
+      if (result.nextCleanupDueAt != null) {
+        await scheduleCleanup(result.nextCleanupDueAt);
         return;
       }
       if (infra.alarms.isAvailable()) await infra.alarms.clear(GITHUB_AUTO_SYNC_CLEANUP_ALARM_NAME);

--- a/src/services/sync/background-handlers.ts
+++ b/src/services/sync/background-handlers.ts
@@ -48,7 +48,7 @@ type Deps = {
   };
   githubSyncOrchestrator: {
     sync: (input: {
-      conversationIds?: readonly unknown[];
+      conversationIds?: readonly number[];
       mode?: 'incremental' | 'reconcile';
       instanceId?: string;
     }) => Promise<unknown>;

--- a/src/services/sync/github/github-git-transport.ts
+++ b/src/services/sync/github/github-git-transport.ts
@@ -10,39 +10,22 @@ import {
 const GIT_SHA_RE = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
 const GITHUB_SYNC_COMMIT_MESSAGE = 'SyncNos GitHub sync';
 
-export type GithubStagedWriteOperation = {
-  type: 'write';
-  path: string;
-  content: string | Uint8Array;
-};
-
-export type GithubStagedReuseOperation = {
-  type: 'reuse';
-  path: string;
-  sha: string;
-};
-
-export type GithubStagedDeleteOperation = {
-  type: 'delete';
-  path: string;
-};
-
 export type GithubStagedOperation =
-  | GithubStagedWriteOperation
-  | GithubStagedReuseOperation
-  | GithubStagedDeleteOperation;
+  | { type: 'write'; path: string; content: string | Uint8Array }
+  | { type: 'reuse'; path: string; sha: string }
+  | { type: 'delete'; path: string };
 
-export type GithubDeleteResolution =
-  | { path: string; status: 'present'; sha: string }
+type GithubDeleteResolution =
+  | { path: string; status: 'present' }
   | { path: string; status: 'absent' }
   | { path: string; status: 'failure' };
 
-export type GithubOwnedDeleteResolution = {
+type GithubOwnedDeleteResolution = {
   operations: GithubStagedOperation[];
   deletes: GithubDeleteResolution[];
 };
 
-export type GithubGitTransportErrorCode =
+type GithubGitTransportErrorCode =
   | 'github_git_path_invalid'
   | 'github_git_branch_invalid'
   | 'github_git_sha_invalid'
@@ -51,7 +34,7 @@ export type GithubGitTransportErrorCode =
   | 'github_git_branch_race'
   | 'github_git_branch_race_exhausted';
 
-export class GithubGitTransportError extends Error {
+class GithubGitTransportError extends Error {
   constructor(readonly code: GithubGitTransportErrorCode) {
     super(code);
     this.name = 'GithubGitTransportError';
@@ -68,14 +51,11 @@ type GithubGitApi = GithubApiReader & {
 };
 
 type GitTreeEntry = {
-  path: string;
   type: 'blob' | 'tree' | 'other';
   sha: string;
 };
 
-type ParsedTree = {
-  entries: Map<string, GitTreeEntry>;
-};
+type ParsedTree = Map<string, GitTreeEntry>;
 
 function requireGitSha(value: unknown): string {
   if (typeof value !== 'string' || value !== value.trim() || !GIT_SHA_RE.test(value)) {
@@ -110,19 +90,11 @@ export function validateGithubGitPath(value: unknown): string {
 }
 
 export function validateGithubStagedOperations(operations: readonly GithubStagedOperation[]): GithubStagedOperation[] {
-  if (!Array.isArray(operations)) throw new GithubGitTransportError('github_git_path_invalid');
   return operations.map((operation) => {
-    if (!operation || typeof operation !== 'object') throw new GithubGitTransportError('github_git_path_invalid');
     const path = validateGithubGitPath(operation.path);
-    if (operation.type === 'write') {
-      if (typeof operation.content !== 'string' && !(operation.content instanceof Uint8Array)) {
-        throw new GithubGitTransportError('github_git_path_invalid');
-      }
-      return { ...operation, path };
-    }
-    if (operation.type === 'reuse') return { ...operation, path, sha: requireGitSha(operation.sha) };
-    if (operation.type === 'delete') return { ...operation, path };
-    throw new GithubGitTransportError('github_git_path_invalid');
+    return operation.type === 'reuse'
+      ? { ...operation, path, sha: requireGitSha(operation.sha) }
+      : { ...operation, path };
   });
 }
 
@@ -136,9 +108,9 @@ function parseTree(value: unknown): ParsedTree | null {
     if (typeof item.sha !== 'string' || !GIT_SHA_RE.test(item.sha)) return null;
     if (entries.has(item.path)) return null;
     const type = item.type === 'blob' || item.type === 'tree' ? item.type : 'other';
-    entries.set(item.path, { path: item.path, type, sha: item.sha.toLowerCase() });
+    entries.set(item.path, { type, sha: item.sha.toLowerCase() });
   }
-  return { entries };
+  return entries;
 }
 
 export async function resolveOwnedGithubDeletes(
@@ -149,7 +121,7 @@ export async function resolveOwnedGithubDeletes(
   if (!repository) throw new GithubGitTransportError('github_git_path_invalid');
   const encodedRepository = encodeGithubRepositoryPath(repository);
   const rootTreeSha = requireGitSha(input.treeSha);
-  const operations = validateGithubStagedOperations(input.operations);
+  const operations = input.operations;
   const treeCache = new Map<string, ParsedTree | null>();
 
   async function getTree(sha: string): Promise<ParsedTree | null> {
@@ -171,12 +143,12 @@ export async function resolveOwnedGithubDeletes(
     for (let index = 0; index < segments.length; index += 1) {
       const tree = await getTree(currentTreeSha);
       if (!tree) return { path, status: 'failure' };
-      const entry = tree.entries.get(segments[index]);
+      const entry = tree.get(segments[index]);
       if (!entry) return { path, status: 'absent' };
       const final = index === segments.length - 1;
       if (final) {
         if (entry.type !== 'blob') return { path, status: 'failure' };
-        return { path, status: 'present', sha: entry.sha };
+        return { path, status: 'present' };
       }
       if (entry.type === 'blob') return { path, status: 'absent' };
       if (entry.type !== 'tree') return { path, status: 'failure' };
@@ -204,18 +176,10 @@ export type GithubFinalFileResolution =
   | { path: string; status: 'written' | 'reused'; sha: string }
   | { path: string; status: 'deleted' | 'absent' };
 
-export type GithubGitTransactionResult =
-  | {
-      status: 'no_changes';
-      treeSha: string;
-      files: GithubFinalFileResolution[];
-    }
-  | {
-      status: 'committed';
-      treeSha: string;
-      commitSha: string;
-      files: GithubFinalFileResolution[];
-    };
+export type GithubGitTransactionResult = {
+  status: 'no_changes' | 'committed';
+  files: GithubFinalFileResolution[];
+};
 
 function bytesToBase64(bytes: Uint8Array): string {
   let binary = '';
@@ -271,7 +235,7 @@ export async function commitGithubStagedOperationsOnce(
   const encodedBranch = encodeGithubBranchPath(branch);
   const headSha = requireGitSha(input.headSha);
   const baseTreeSha = requireGitSha(input.treeSha);
-  const operations = validateGithubStagedOperations(input.operations);
+  const operations = input.operations;
 
   const deleteResolution = await resolveOwnedGithubDeletes({ repository, treeSha: baseTreeSha, operations }, api);
   if (deleteResolution.deletes.some((item) => item.status === 'failure')) {
@@ -308,7 +272,7 @@ export async function commitGithubStagedOperationsOnce(
       return { path: operation.path, status: resolved.status === 'absent' ? 'absent' : 'deleted' };
     });
 
-  if (treeEntries.length === 0) return { status: 'no_changes', treeSha: baseTreeSha, files: files() };
+  if (treeEntries.length === 0) return { status: 'no_changes', files: files() };
 
   const treeResponse = await api.post<any>(`/repos/${encodedRepository}/git/trees`, {
     base_tree: baseTreeSha,
@@ -319,7 +283,7 @@ export async function commitGithubStagedOperationsOnce(
     if (deleteResolution.deletes.some((item) => item.status === 'present')) {
       throw new GithubGitTransportError('github_git_response_invalid');
     }
-    return { status: 'no_changes', treeSha, files: files() };
+    return { status: 'no_changes', files: files() };
   }
 
   const commitResponse = await api.post<any>(`/repos/${encodedRepository}/git/commits`, {
@@ -341,10 +305,10 @@ export async function commitGithubStagedOperationsOnce(
   const updatedSha = requireResponseGitSha(refResponse?.object?.sha);
   if (updatedSha !== commitSha) throw new GithubGitTransportError('github_git_response_invalid');
 
-  return { status: 'committed', treeSha, commitSha, files: files() };
+  return { status: 'committed', files: files() };
 }
 
-export const GITHUB_BRANCH_RACE_MAX_ATTEMPTS = 3;
+const GITHUB_BRANCH_RACE_MAX_ATTEMPTS = 3;
 
 async function resolveGithubBranchState(
   repository: string,

--- a/src/services/sync/github/github-git-transport.ts
+++ b/src/services/sync/github/github-git-transport.ts
@@ -8,6 +8,7 @@ import {
 } from '@services/sync/github/settings-store';
 
 const GIT_SHA_RE = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
+const GITHUB_SYNC_COMMIT_MESSAGE = 'SyncNos GitHub sync';
 
 export type GithubStagedWriteOperation = {
   type: 'write';
@@ -44,7 +45,6 @@ export type GithubOwnedDeleteResolution = {
 export type GithubGitTransportErrorCode =
   | 'github_git_path_invalid'
   | 'github_git_branch_invalid'
-  | 'github_git_message_invalid'
   | 'github_git_sha_invalid'
   | 'github_git_delete_resolution_failed'
   | 'github_git_response_invalid'
@@ -89,15 +89,6 @@ function requireResponseGitSha(value: unknown): string {
     throw new GithubGitTransportError('github_git_response_invalid');
   }
   return value.toLowerCase();
-}
-
-function normalizeGithubCommitMessage(value: unknown, fallback: string): string {
-  if (value == null) return fallback;
-  if (typeof value !== 'string' || value !== value.trim() || !value || value.length > 160) {
-    throw new GithubGitTransportError('github_git_message_invalid');
-  }
-  if (hasAsciiControlCharacter(value)) throw new GithubGitTransportError('github_git_message_invalid');
-  return value;
 }
 
 export function validateGithubGitPath(value: unknown): string {
@@ -269,7 +260,6 @@ export async function commitGithubStagedOperationsOnce(
     headSha: string;
     treeSha: string;
     operations: readonly GithubStagedOperation[];
-    message?: string;
   },
   api: GithubGitApi = githubApiClient,
 ): Promise<GithubGitTransactionResult> {
@@ -282,7 +272,6 @@ export async function commitGithubStagedOperationsOnce(
   const headSha = requireGitSha(input.headSha);
   const baseTreeSha = requireGitSha(input.treeSha);
   const operations = validateGithubStagedOperations(input.operations);
-  const customMessage = input.message == null ? null : normalizeGithubCommitMessage(input.message, '');
 
   const deleteResolution = await resolveOwnedGithubDeletes({ repository, treeSha: baseTreeSha, operations }, api);
   if (deleteResolution.deletes.some((item) => item.status === 'failure')) {
@@ -334,7 +323,7 @@ export async function commitGithubStagedOperationsOnce(
   }
 
   const commitResponse = await api.post<any>(`/repos/${encodedRepository}/git/commits`, {
-    message: customMessage ?? `SyncNos: sync ${treeEntries.length} file${treeEntries.length === 1 ? '' : 's'}`,
+    message: GITHUB_SYNC_COMMIT_MESSAGE,
     tree: treeSha,
     parents: [headSha],
   });
@@ -373,7 +362,7 @@ async function resolveGithubBranchState(
 }
 
 export async function commitGithubStagedOperations(
-  input: { repository: string; branch: string; operations: readonly GithubStagedOperation[]; message?: string },
+  input: { repository: string; branch: string; operations: readonly GithubStagedOperation[] },
   api: GithubGitApi = githubApiClient,
 ): Promise<GithubGitTransactionResult> {
   const repository = normalizeGithubRepository(input.repository);
@@ -385,10 +374,7 @@ export async function commitGithubStagedOperations(
   for (let attempt = 1; attempt <= GITHUB_BRANCH_RACE_MAX_ATTEMPTS; attempt += 1) {
     const state = await resolveGithubBranchState(repository, branch, api);
     try {
-      return await commitGithubStagedOperationsOnce(
-        { repository, branch, ...state, operations, message: input.message },
-        api,
-      );
+      return await commitGithubStagedOperationsOnce({ repository, branch, ...state, operations }, api);
     } catch (error) {
       if (!(error instanceof GithubGitTransportError) || error.code !== 'github_git_branch_race') throw error;
       if (attempt >= GITHUB_BRANCH_RACE_MAX_ATTEMPTS) {

--- a/src/services/sync/github/github-managed-path-ownership.ts
+++ b/src/services/sync/github/github-managed-path-ownership.ts
@@ -5,7 +5,7 @@ import { GITHUB_OUTPUT_FOLDERS } from '@services/sync/github/settings-store';
 
 const GITHUB_MANAGED_ASSET_FILE_RE = /^[0-9a-f]{64}\.[a-z0-9]{1,10}$/;
 
-function outputFolderForConversation(conversation: any): string {
+export function githubOutputFolderForConversation(conversation: any): string {
   const sourceType = String(conversation?.sourceType || '').trim();
   if (sourceType === 'article') return GITHUB_OUTPUT_FOLDERS.article;
   if (sourceType === 'video') return GITHUB_OUTPUT_FOLDERS.video;
@@ -30,7 +30,7 @@ export function isGithubManagedPathOwnedByConversation(
   conversation: any,
 ): boolean {
   if (!isSafeGithubCleanupPath(path)) return false;
-  const folder = outputFolderForConversation(conversation);
+  const folder = githubOutputFolderForConversation(conversation);
   const segments = path.split('/');
 
   if (kind === 'markdown') {

--- a/src/services/sync/github/github-markdown-projection.ts
+++ b/src/services/sync/github/github-markdown-projection.ts
@@ -2,8 +2,10 @@ import type { ArticleCommentDto } from '@services/comments/domain/comment-dto';
 import { buildConversationBasename } from '@services/conversations/domain/file-naming';
 import { getImageCacheAssetsByIds, type ImageCacheAsset } from '@services/conversations/data/image-cache-read';
 import { sha256Hex } from '@services/sync/github/github-content-hash';
-import { isGithubManagedPathOwnedByConversation } from '@services/sync/github/github-managed-path-ownership';
-import { GITHUB_OUTPUT_FOLDERS } from '@services/sync/github/settings-store';
+import {
+  githubOutputFolderForConversation,
+  isGithubManagedPathOwnedByConversation,
+} from '@services/sync/github/github-managed-path-ownership';
 import {
   collectOrderedSyncnosAssetIds,
   replaceSyncnosAssetImageReferences,
@@ -22,19 +24,19 @@ export type GithubProjectionManagedFile = {
   sha: string;
 };
 
-export type GithubProjectionContinuity = {
+type GithubProjectionContinuity = {
   githubRemoteKey?: string;
   githubManagedFiles?: Record<string, GithubProjectionManagedFile>;
 };
 
-export type GithubProjectionAttachment = {
+type GithubProjectionAttachment = {
   path: string;
   relativeTarget: string;
   contentHash: string;
   sha: string;
 };
 
-export type GithubProjectionWarning = {
+type GithubProjectionWarning = {
   code: 'image_missing' | 'image_upload_failed';
   assetId: number;
 };
@@ -48,18 +50,11 @@ export type GithubMarkdownProjection = {
   warnings: GithubProjectionWarning[];
 };
 
-export type GithubImageBatchLoader = (input: {
+type GithubImageBatchLoader = (input: {
   ids: readonly number[];
   conversationId: number;
 }) => Promise<Map<number, ImageCacheAsset>>;
-export type GithubBlobUploader = (input: { content: Uint8Array }) => Promise<{ sha: string }>;
-
-function folderForConversation(conversation: any): string {
-  const sourceType = String(conversation?.sourceType || '').trim();
-  if (sourceType === 'article') return GITHUB_OUTPUT_FOLDERS.article;
-  if (sourceType === 'video') return GITHUB_OUTPUT_FOLDERS.video;
-  return GITHUB_OUTPUT_FOLDERS.chat;
-}
+type GithubBlobUploader = (input: { content: Uint8Array }) => Promise<{ sha: string }>;
 
 function normalizeImageExt(asset: Pick<ImageCacheAsset, 'contentType' | 'url'>): string {
   const contentType = String(asset.contentType || '')
@@ -168,7 +163,7 @@ export async function buildGithubMarkdownProjection(input: {
   blobUploader?: GithubBlobUploader;
 }): Promise<GithubMarkdownProjection> {
   const conversation = input.conversation || {};
-  const folder = folderForConversation(conversation);
+  const folder = githubOutputFolderForConversation(conversation);
   const markdownPath = `${folder}/${buildConversationBasename(conversation)}.md`;
   const rawMarkdown = buildFullNoteMarkdown({
     conversation,

--- a/src/services/sync/github/github-orchestrator-services.ts
+++ b/src/services/sync/github/github-orchestrator-services.ts
@@ -20,7 +20,7 @@ import {
 import { createSyncJobStore } from '@services/sync/sync-job-store';
 import { getGithubSettings, type GithubSettings } from '@services/sync/github/settings-store';
 
-export type GithubOrchestratorStorage = {
+type GithubOrchestratorStorage = {
   getSyncMappingByConversation: (conversationId: number) => Promise<{ conversation: any; mapping: any | null } | null>;
   getMessagesByConversationId: (conversationId: number) => Promise<any[]>;
   getArticleCommentsByConversationId: (conversationId: number) => Promise<any[]>;
@@ -30,8 +30,7 @@ export type GithubOrchestratorStorage = {
 
 const githubSyncJobStore = createSyncJobStore('github');
 
-export const GITHUB_REPLACEMENT_DEFER_SAFETY_MS = 5_000;
-export const DEFAULT_GITHUB_REPLACEMENT_DEFER_MS = GITHUB_AUTO_SYNC_DEBOUNCE_MS + GITHUB_REPLACEMENT_DEFER_SAFETY_MS;
+const DEFAULT_GITHUB_REPLACEMENT_DEFER_MS = GITHUB_AUTO_SYNC_DEBOUNCE_MS + 5_000;
 
 export type GithubOrchestratorServices = {
   getSettings: () => Promise<GithubSettings>;
@@ -55,11 +54,11 @@ export type GithubOrchestratorServices = {
 
 export const defaultGithubOrchestratorServices: GithubOrchestratorServices = {
   getSettings: getGithubSettings,
-  preflight: (input) => preflightGithubRepository(input),
+  preflight: preflightGithubRepository,
   storage: backgroundStorage,
   loadImages: getImageCacheAssetsByIds,
   createBlob: createGithubBlob,
-  commit: ({ repository, branch, operations }) => commitGithubStagedOperations({ repository, branch, operations }),
+  commit: commitGithubStagedOperations,
   listDueCleanupRows: listDueGithubCleanupRows,
   getNextCleanupDueAt: getNextGithubCleanupDueAt,
   deferCleanupRows: deferGithubCleanupRows,

--- a/src/services/sync/github/github-orchestrator-services.ts
+++ b/src/services/sync/github/github-orchestrator-services.ts
@@ -43,7 +43,6 @@ export type GithubOrchestratorServices = {
     repository: string;
     branch: string;
     operations: readonly GithubStagedOperation[];
-    message: string;
   }) => Promise<GithubGitTransactionResult>;
   listDueCleanupRows: typeof listDueGithubCleanupRows;
   getNextCleanupDueAt: typeof getNextGithubCleanupDueAt;
@@ -60,8 +59,7 @@ export const defaultGithubOrchestratorServices: GithubOrchestratorServices = {
   storage: backgroundStorage,
   loadImages: getImageCacheAssetsByIds,
   createBlob: createGithubBlob,
-  commit: ({ repository, branch, operations, message }) =>
-    commitGithubStagedOperations({ repository, branch, operations, message }),
+  commit: ({ repository, branch, operations }) => commitGithubStagedOperations({ repository, branch, operations }),
   listDueCleanupRows: listDueGithubCleanupRows,
   getNextCleanupDueAt: getNextGithubCleanupDueAt,
   deferCleanupRows: deferGithubCleanupRows,

--- a/src/services/sync/github/github-sync-orchestrator.ts
+++ b/src/services/sync/github/github-sync-orchestrator.ts
@@ -18,14 +18,9 @@ import {
   type GithubSyncContinuityDraft,
   type GithubSyncPlannerMode,
 } from '@services/sync/github/github-sync-planner';
-import type { GithubSettings } from '@services/sync/github/settings-store';
 import { createSyncJobLifecycle, type SyncJobLifecycle } from '@services/sync/sync-job-lifecycle';
 import { createSyncRunOwnership } from '@services/sync/sync-run-ownership';
-import { normalizeSyncConversationIds } from '@services/sync/sync-conversation-ids';
 import type { SyncJobSnapshot, SyncPerConversationResult, SyncWarning } from '@services/sync/models';
-
-const GIT_SHA_RE = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
-const CONTENT_HASH_RE = /^[0-9a-f]{64}$/;
 
 type GithubSyncStagedItem = {
   conversationId: number;
@@ -47,7 +42,7 @@ type GithubSyncStagedRun = {
   items: GithubSyncStagedItem[];
 };
 
-export type GithubSyncRunItem = {
+type GithubSyncRunItem = {
   conversationId: number;
   conversationTitle: string;
   status: 'no_changes' | 'synced' | 'mapping_failed' | 'failed';
@@ -55,25 +50,12 @@ export type GithubSyncRunItem = {
   warnings: string[];
 };
 
-export type GithubSyncRunResult = {
-  target: GithubSyncStagedRun['target'];
-  transport: {
-    status: 'not_needed' | 'committed' | 'no_changes' | 'failed' | 'invalid_resolution';
-    commitSha?: string;
-  };
+type GithubSyncRunResult = {
+  transportStatus: 'not_needed' | 'committed' | 'no_changes' | 'failed';
   items: GithubSyncRunItem[];
-  summary: {
-    candidateCount: number;
-    noOpCount: number;
-    syncedCount: number;
-    mappingFailedCount: number;
-    failedCount: number;
-    warningCount: number;
-  };
   cleanupHasMoreDue: boolean;
   nextCleanupDueAt: number | null;
   deferredReplacementConversationIds: number[];
-  cleanupWarnings: string[];
 };
 
 function safeString(value: unknown): string {
@@ -131,20 +113,10 @@ function buildResolutionMap(
   operations: readonly GithubStagedOperation[],
   files: readonly GithubFinalFileResolution[],
 ): Map<string, GithubFinalFileResolution> | null {
-  if (!Array.isArray(files)) return null;
-  const expected = new Set(operations.map((operation) => operation.path));
-  const resolutions = new Map<string, GithubFinalFileResolution>();
-  for (const file of files) {
-    if (!file || typeof file.path !== 'string' || !expected.has(file.path) || resolutions.has(file.path)) return null;
-    if (file.status === 'written' || file.status === 'reused') {
-      if (typeof file.sha !== 'string' || !GIT_SHA_RE.test(file.sha)) return null;
-      resolutions.set(file.path, { ...file, sha: file.sha.toLowerCase() });
-      continue;
-    }
-    if (file.status !== 'deleted' && file.status !== 'absent') return null;
-    resolutions.set(file.path, file);
-  }
-  return resolutions.size === expected.size ? resolutions : null;
+  const resolutions = new Map(files.map((file) => [file.path, file]));
+  return files.length === operations.length && operations.every((operation) => resolutions.has(operation.path))
+    ? resolutions
+    : null;
 }
 
 function buildContinuityAck(
@@ -153,27 +125,12 @@ function buildContinuityAck(
   syncedAt: number,
 ): Record<string, unknown> | null {
   const draft = item.nextContinuity;
-  if (!draft || !Number.isFinite(syncedAt) || syncedAt < 0) return null;
-
-  for (const operation of item.operations) {
-    const resolved = resolutions.get(operation.path);
-    if (!resolved) return null;
-    if (operation.type === 'delete') {
-      if (resolved.status !== 'deleted' && resolved.status !== 'absent') return null;
-    } else if (resolved.status !== 'written' && resolved.status !== 'reused') {
-      return null;
-    }
-  }
+  if (!draft) return null;
 
   const managedFiles: Record<string, { kind: 'markdown' | 'asset'; contentHash: string; sha: string }> = {};
   for (const [path, file] of Object.entries(draft.githubManagedFiles)) {
-    if ((file.kind !== 'markdown' && file.kind !== 'asset') || !CONTENT_HASH_RE.test(file.contentHash)) return null;
     const resolved = resolutions.get(path);
-    let sha = typeof file.sha === 'string' && GIT_SHA_RE.test(file.sha) ? file.sha.toLowerCase() : '';
-    if (resolved) {
-      if (resolved.status !== 'written' && resolved.status !== 'reused') return null;
-      sha = resolved.sha.toLowerCase();
-    }
+    const sha = resolved && 'sha' in resolved ? resolved.sha : file.sha;
     if (!sha) return null;
     managedFiles[path] = { kind: file.kind, contentHash: file.contentHash, sha };
   }
@@ -196,25 +153,9 @@ function finalItem(item: GithubSyncStagedItem, status: GithubSyncRunItem['status
   };
 }
 
-function finalSummary(items: readonly GithubSyncRunItem[]) {
-  return {
-    candidateCount: items.length,
-    noOpCount: items.filter((item) => item.status === 'no_changes').length,
-    syncedCount: items.filter((item) => item.status === 'synced').length,
-    mappingFailedCount: items.filter((item) => item.status === 'mapping_failed').length,
-    failedCount: items.filter((item) => item.status === 'failed').length,
-    warningCount: items.reduce((count, item) => count + item.warnings.length, 0),
-  };
-}
-
 function transportFailureCode(error: unknown): string {
   const code = safeString((error as any)?.code);
   return code.startsWith('github_') ? code : 'github_transport_failed';
-}
-
-function positiveId(value: unknown): number | null {
-  const id = Number(value);
-  return Number.isSafeInteger(id) && id > 0 ? id : null;
 }
 
 function successfulSameTargetOwnedPaths(mapping: any, remoteKey: string, conversation: any): Set<string> | null {
@@ -348,29 +289,23 @@ export function createGithubSyncOrchestrator(services: GithubOrchestratorService
     });
   }
 
-  function runExclusiveMaintenance<T>(mutation: () => Promise<T>): Promise<T> {
-    return ownership.runExclusiveMutation(mutation);
-  }
-
   function reconcileStartupSyncJob() {
     return ownership.runExclusiveMutation(() => services.jobStore.abortRunningJob());
   }
 
   async function runSync(input: {
-    conversationIds?: readonly unknown[];
+    conversationIds?: readonly number[];
     mode?: GithubSyncPlannerMode;
     instanceId?: string;
   }): Promise<GithubSyncRunResult> {
-    const ids = normalizeSyncConversationIds(input.conversationIds);
+    const ids = input.conversationIds ?? [];
     const mode: GithubSyncPlannerMode = input.mode === 'reconcile' ? 'reconcile' : 'incremental';
     const instanceId = safeString(input.instanceId);
     const runNow = services.now();
-    const cleanupWarnings: string[] = [];
     const deferredReplacementIds = new Set<number>();
     let cleanupHasMoreDue = false;
     let dueRows: GithubCleanupOutboxRecord[] = [];
     let lifecycle: SyncJobLifecycle | null = null;
-    let jobPersistenceWarning = false;
 
     const claimJob = async (currentStage: string): Promise<SyncJobLifecycle> => {
       const startedAt = services.now();
@@ -394,31 +329,24 @@ export function createGithubSyncOrchestrator(services: GithubOrchestratorService
       return createSyncJobLifecycle({
         initialJob: candidate,
         configuredConversationIds: ids,
-        persist: async (job) => {
-          const persisted = await services.jobStore.setJob(job);
-          if (!persisted) jobPersistenceWarning = true;
-          return persisted;
-        },
+        persist: (job) => services.jobStore.setJob(job),
         now: services.now,
       });
     };
 
     try {
-      let settings: GithubSettings;
-      let preflight: GithubRepositoryPreflight;
-      let staged: GithubSyncStagedRun;
-
       if (ids.length) {
         lifecycle = await claimJob('preparing_queue');
         await lifecycle.setRunStage('preflight');
-        settings = await services.getSettings();
-        preflight = await services.preflight({ repository: settings.repository, branch: settings.branch });
-        await lifecycle.setRunStage('staging_projection');
-        staged = await stageResolved(ids, mode, preflight, lifecycle);
-        await lifecycle.setRunStage('cleaning_remote_files');
+      }
+      const settings = await services.getSettings();
+      const preflight = await services.preflight({ repository: settings.repository, branch: settings.branch });
+      let staged: GithubSyncStagedRun;
+      if (ids.length) {
+        await lifecycle!.setRunStage('staging_projection');
+        staged = await stageResolved(ids, mode, preflight, lifecycle!);
+        await lifecycle!.setRunStage('cleaning_remote_files');
       } else {
-        settings = await services.getSettings();
-        preflight = await services.preflight({ repository: settings.repository, branch: settings.branch });
         staged = {
           target: { repository: preflight.repository, branch: preflight.branch, remoteKey: preflight.remoteKey },
           operations: [],
@@ -426,16 +354,12 @@ export function createGithubSyncOrchestrator(services: GithubOrchestratorService
         };
       }
 
-      try {
-        const batch = await services.listDueCleanupRows(
-          staged.target.remoteKey,
-          runNow,
-          GITHUB_CLEANUP_OUTBOX_BATCH_LIMIT,
-        );
-        dueRows = batch.rows;
-        cleanupHasMoreDue = batch.hasMoreDue;
-      } catch (_error) {
-        cleanupWarnings.push('github_cleanup_list_failed');
+      const cleanupBatch = await services
+        .listDueCleanupRows(staged.target.remoteKey, runNow, GITHUB_CLEANUP_OUTBOX_BATCH_LIMIT)
+        .catch(() => null);
+      if (cleanupBatch) {
+        dueRows = cleanupBatch.rows;
+        cleanupHasMoreDue = cleanupBatch.hasMoreDue;
       }
 
       if (!ids.length && dueRows.length) lifecycle = await claimJob('cleaning_remote_files');
@@ -479,7 +403,6 @@ export function createGithubSyncOrchestrator(services: GithubOrchestratorService
           replacementChecks.set(conversationId, result);
           return result;
         } catch (_error) {
-          cleanupWarnings.push('github_cleanup_replacement_check_failed');
           const result = { safe: false, dependsOnCurrentTransport: false, protectedPaths: new Set<string>() };
           replacementChecks.set(conversationId, result);
           return result;
@@ -491,22 +414,16 @@ export function createGithubSyncOrchestrator(services: GithubOrchestratorService
       const ackSupersededIds: number[] = [];
       const deferIds: number[] = [];
       for (const row of dueRows) {
-        const rowId = positiveId(row.id);
-        if (!rowId) {
-          cleanupWarnings.push('github_cleanup_row_id_invalid');
-          continue;
-        }
+        const rowId = row.id;
+        if (!rowId) continue;
         if (row.reason === 'delete') {
           ackAfterTransportIds.push(rowId);
           row.paths.forEach((path) => cleanupDeletePaths.add(path));
           continue;
         }
 
-        const replacementConversationId = positiveId(row.replacementConversationId);
-        if (!replacementConversationId) {
-          cleanupWarnings.push('github_cleanup_replacement_id_invalid');
-          continue;
-        }
+        const replacementConversationId = row.replacementConversationId;
+        if (!replacementConversationId) continue;
         const replacement = await resolveReplacement(replacementConversationId);
         if (!replacement.safe) {
           deferIds.push(rowId);
@@ -520,52 +437,28 @@ export function createGithubSyncOrchestrator(services: GithubOrchestratorService
         else ackSupersededIds.push(rowId);
       }
 
-      const replacementDeferMs =
-        Number.isFinite(services.replacementDeferMs) && services.replacementDeferMs > 0
-          ? Math.floor(services.replacementDeferMs)
-          : 1;
+      const replacementDeferMs = services.replacementDeferMs;
       if (deferIds.length) {
-        try {
-          await services.deferCleanupRows(deferIds, runNow + replacementDeferMs);
-        } catch (_error) {
-          cleanupWarnings.push('github_cleanup_defer_failed');
-        }
+        await services.deferCleanupRows(deferIds, runNow + replacementDeferMs).catch(() => undefined);
       }
       if (ackSupersededIds.length) {
-        try {
-          await services.ackCleanupRows(ackSupersededIds);
-        } catch (_error) {
-          cleanupWarnings.push('github_cleanup_ack_failed');
-        }
+        await services.ackCleanupRows(ackSupersededIds).catch(() => undefined);
       }
 
-      type ResultWithoutCleanup = Omit<
-        GithubSyncRunResult,
-        'cleanupHasMoreDue' | 'nextCleanupDueAt' | 'deferredReplacementConversationIds' | 'cleanupWarnings'
-      >;
-      const finalizeCleanup = async (result: ResultWithoutCleanup): Promise<GithubSyncRunResult> => {
-        let nextCleanupDueAt: number | null = null;
-        try {
-          nextCleanupDueAt = await services.getNextCleanupDueAt(staged.target.remoteKey);
-        } catch (_error) {
-          cleanupWarnings.push('github_cleanup_next_due_failed');
-        }
+      const finalizeCleanup = async (
+        result: Pick<GithubSyncRunResult, 'transportStatus' | 'items'>,
+      ): Promise<GithubSyncRunResult> => {
+        const nextCleanupDueAt = await services.getNextCleanupDueAt(staged.target.remoteKey).catch(() => null);
 
         const finalResult: GithubSyncRunResult = {
           ...result,
           cleanupHasMoreDue,
           nextCleanupDueAt,
-          deferredReplacementConversationIds: [...deferredReplacementIds].slice(0, GITHUB_CLEANUP_OUTBOX_BATCH_LIMIT),
-          cleanupWarnings: [...new Set(cleanupWarnings)],
+          deferredReplacementConversationIds: [...deferredReplacementIds],
         };
         if (lifecycle) {
           const perConversation = toJobRows(finalResult.items, services.now());
           await lifecycle.finish(perConversation, { currentStage: 'done' });
-        }
-        if (jobPersistenceWarning) {
-          finalResult.cleanupWarnings = [
-            ...new Set([...finalResult.cleanupWarnings, 'github_sync_job_persist_failed']),
-          ];
         }
         return finalResult;
       };
@@ -575,12 +468,7 @@ export function createGithubSyncOrchestrator(services: GithubOrchestratorService
         const items = staged.items.map((item) =>
           item.status === 'no_changes' ? finalItem(item, 'no_changes') : finalItem(item, 'failed', item.error),
         );
-        return await finalizeCleanup({
-          target: staged.target,
-          transport: { status: 'not_needed' },
-          items,
-          summary: finalSummary(items),
-        });
+        return await finalizeCleanup({ transportStatus: 'not_needed', items });
       }
 
       let transport: GithubGitTransactionResult;
@@ -598,28 +486,7 @@ export function createGithubSyncOrchestrator(services: GithubOrchestratorService
           if (item.status === 'staged') return finalItem(item, 'failed', code);
           return finalItem(item, 'failed', item.error);
         });
-        return await finalizeCleanup({
-          target: staged.target,
-          transport: { status: 'failed' },
-          items,
-          summary: finalSummary(items),
-        });
-      }
-
-      if (transport.status !== 'committed' && transport.status !== 'no_changes') {
-        const items = staged.items.map((item) =>
-          item.status === 'staged'
-            ? finalItem(item, 'failed', 'github_transport_resolution_incomplete')
-            : item.status === 'no_changes'
-              ? finalItem(item, 'no_changes')
-              : finalItem(item, 'failed', item.error),
-        );
-        return await finalizeCleanup({
-          target: staged.target,
-          transport: { status: 'invalid_resolution' },
-          items,
-          summary: finalSummary(items),
-        });
+        return await finalizeCleanup({ transportStatus: 'failed', items });
       }
 
       const resolutions = buildResolutionMap(operations, transport.files);
@@ -631,15 +498,7 @@ export function createGithubSyncOrchestrator(services: GithubOrchestratorService
               ? finalItem(item, 'no_changes')
               : finalItem(item, 'failed', item.error),
         );
-        return await finalizeCleanup({
-          target: staged.target,
-          transport: {
-            status: 'invalid_resolution',
-            ...(transport.status === 'committed' ? { commitSha: transport.commitSha } : {}),
-          },
-          items,
-          summary: finalSummary(items),
-        });
+        return await finalizeCleanup({ transportStatus: transport.status, items });
       }
 
       await lifecycle?.setRunStage('updating_mappings');
@@ -670,22 +529,10 @@ export function createGithubSyncOrchestrator(services: GithubOrchestratorService
       }
 
       if (ackAfterTransportIds.length) {
-        try {
-          await services.ackCleanupRows(ackAfterTransportIds);
-        } catch (_error) {
-          cleanupWarnings.push('github_cleanup_ack_failed');
-        }
+        await services.ackCleanupRows(ackAfterTransportIds).catch(() => undefined);
       }
 
-      return await finalizeCleanup({
-        target: staged.target,
-        transport: {
-          status: transport.status,
-          ...(transport.status === 'committed' ? { commitSha: transport.commitSha } : {}),
-        },
-        items,
-        summary: finalSummary(items),
-      });
+      return await finalizeCleanup({ transportStatus: transport.status, items });
     } catch (error) {
       await lifecycle?.failPending(error, { currentStage: 'done' });
       throw error;
@@ -693,7 +540,7 @@ export function createGithubSyncOrchestrator(services: GithubOrchestratorService
   }
 
   function sync(input: {
-    conversationIds?: readonly unknown[];
+    conversationIds?: readonly number[];
     mode?: GithubSyncPlannerMode;
     instanceId?: string;
   }): Promise<GithubSyncRunResult> {
@@ -704,8 +551,8 @@ export function createGithubSyncOrchestrator(services: GithubOrchestratorService
     sync,
     getSyncStatus,
     clearSyncStatus,
-    isRunActive: () => ownership.isRunActive(),
-    runExclusiveMaintenance,
+    isRunActive: ownership.isRunActive,
+    runExclusiveMaintenance: ownership.runExclusiveMutation,
     reconcileStartupSyncJob,
   };
 }

--- a/src/services/sync/github/github-sync-orchestrator.ts
+++ b/src/services/sync/github/github-sync-orchestrator.ts
@@ -571,7 +571,6 @@ export function createGithubSyncOrchestrator(services: GithubOrchestratorService
       };
 
       const operations = mergeCleanupDeletes(staged.operations, cleanupDeletePaths);
-      const changed = staged.items.filter((item) => item.status === 'staged');
       if (!operations.length) {
         const items = staged.items.map((item) =>
           item.status === 'no_changes' ? finalItem(item, 'no_changes') : finalItem(item, 'failed', item.error),
@@ -591,7 +590,6 @@ export function createGithubSyncOrchestrator(services: GithubOrchestratorService
           repository: staged.target.repository,
           branch: staged.target.branch,
           operations,
-          message: `SyncNos GitHub sync (${changed.length} items)`,
         });
       } catch (error) {
         const code = transportFailureCode(error);

--- a/src/services/sync/github/github-sync-planner.ts
+++ b/src/services/sync/github/github-sync-planner.ts
@@ -2,7 +2,7 @@ import type {
   GithubMarkdownProjection,
   GithubProjectionManagedFile,
 } from '@services/sync/github/github-markdown-projection';
-import { validateGithubGitPath, type GithubStagedOperation } from '@services/sync/github/github-git-transport';
+import type { GithubStagedOperation } from '@services/sync/github/github-git-transport';
 import { isGithubManagedPathOwnedByConversation } from '@services/sync/github/github-managed-path-ownership';
 
 const GIT_SHA_RE = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
@@ -10,29 +10,20 @@ const CONTENT_HASH_RE = /^[0-9a-f]{64}$/;
 
 export type GithubSyncPlannerMode = 'incremental' | 'reconcile';
 
-export type GithubSyncPlannerMapping = {
+type GithubSyncPlannerMapping = {
   githubRemoteKey?: string;
   githubProjectionFingerprint?: string;
   githubManagedFiles?: Record<string, GithubProjectionManagedFile>;
 };
 
-export type GithubSyncContinuityDraftFile = {
-  kind: 'markdown' | 'asset';
-  contentHash: string;
-  sha?: string;
-};
+type GithubSyncContinuityDraftFile =
+  | { kind: 'markdown'; contentHash: string; sha?: string }
+  | { kind: 'asset'; contentHash: string; sha: string };
 
 export type GithubSyncContinuityDraft = {
   githubRemoteKey: string;
   githubProjectionFingerprint: string;
   githubManagedFiles: Record<string, GithubSyncContinuityDraftFile>;
-};
-
-export type GithubSyncPlan = {
-  status: 'no_changes' | 'changed';
-  operations: GithubStagedOperation[];
-  nextContinuity: GithubSyncContinuityDraft;
-  warnings: string[];
 };
 
 function safeManagedFiles(value: unknown): Record<string, GithubProjectionManagedFile> {
@@ -47,15 +38,6 @@ function safeManagedFiles(value: unknown): Record<string, GithubProjectionManage
     output[path] = { kind: row.kind, contentHash: row.contentHash, sha: row.sha.toLowerCase() };
   }
   return output;
-}
-
-function isSafeGitPath(path: string): boolean {
-  try {
-    validateGithubGitPath(path);
-    return true;
-  } catch (_error) {
-    return false;
-  }
 }
 
 function currentFiles(projection: GithubMarkdownProjection): Record<string, GithubSyncContinuityDraftFile> {
@@ -87,7 +69,7 @@ export function planGithubConversationSync(input: {
   projection: GithubMarkdownProjection;
   mapping?: GithubSyncPlannerMapping | null;
   mode: GithubSyncPlannerMode;
-}): GithubSyncPlan {
+}) {
   const remoteKey = String(input.remoteKey || '');
   if (!remoteKey) throw new Error('github_remote_key_required');
   const projection = input.projection;
@@ -117,7 +99,6 @@ export function planGithubConversationSync(input: {
 
   const operations: GithubStagedOperation[] = [];
   for (const [path, row] of Object.entries(current)) {
-    if (!isSafeGitPath(path)) throw new Error('github_projection_path_invalid');
     const old = sameTarget ? previous[path] : undefined;
     const sameContent = !!old && old.kind === row.kind && old.contentHash === row.contentHash;
 
@@ -144,7 +125,6 @@ export function planGithubConversationSync(input: {
       continue;
     }
 
-    if (!row.sha || !GIT_SHA_RE.test(row.sha)) throw new Error('github_projection_asset_sha_invalid');
     if (sameContent && input.mode === 'incremental') continue;
     operations.push({ type: 'reuse', path, sha: row.sha });
   }

--- a/tests/integration/github-markdown-sync.test.ts
+++ b/tests/integration/github-markdown-sync.test.ts
@@ -748,7 +748,7 @@ describe('GitHub Markdown production-chain integration', () => {
       instanceId: 'github-integration-instance',
     });
     expect(unchanged.items.map((item) => item.status)).toEqual(['synced', 'synced']);
-    expect(unchanged.transport.status).toBe('no_changes');
+    expect(unchanged.transportStatus).toBe('no_changes');
     expect(fakeGithub.syncRefUpdates).toBe(commitsBeforeNoOp);
 
     const localMessagesBeforeDrift = await backgroundStorage.getMessagesByConversationId(Number(chat.id));
@@ -903,7 +903,7 @@ describe('GitHub Markdown production-chain integration', () => {
       mode: 'reconcile',
       instanceId: 'github-integration-instance',
     });
-    expect(finalRun.summary.failedCount).toBe(0);
+    expect(finalRun.items.map((item) => item.status)).toEqual(['synced', 'synced']);
     expect(fakeGithub.hasPath('README.md')).toBe(true);
     assertSecretFree(finalRun);
 
@@ -933,7 +933,7 @@ describe('GitHub Markdown production-chain integration', () => {
       conversationIds: [],
       instanceId: 'github-integration-instance',
     });
-    expect(cleanupRecovered.transport.status).toMatch(/^(committed|no_changes)$/);
+    expect(cleanupRecovered.transportStatus).toMatch(/^(committed|no_changes)$/);
     expect((await listDueGithubCleanupRows(REMOTE_KEY, Date.now(), 100)).rows).toEqual([]);
     expect(deletedRemotePaths.every((path) => !fakeGithub.hasPath(path))).toBe(true);
     expect(fakeGithub.hasPath('README.md')).toBe(true);

--- a/tests/smoke/github-auto-sync-scheduler.test.ts
+++ b/tests/smoke/github-auto-sync-scheduler.test.ts
@@ -46,7 +46,7 @@ beforeEach(() => {
 describe('github-auto-sync-scheduler', () => {
   it('runs queued conversations through incremental GitHub sync', async () => {
     storageState[GITHUB_AUTO_SYNC_ENABLED_STORAGE_KEY] = true;
-    const sync = vi.fn().mockResolvedValue({ transport: { status: 'not_needed' }, items: [] });
+    const sync = vi.fn().mockResolvedValue({ transportStatus: 'not_needed', items: [] });
     const scheduler = createGithubAutoSyncScheduler(
       { getInstanceId: () => 'github-auto-instance', githubSyncOrchestrator: { sync } as any },
       { now: () => 10_000 },
@@ -105,7 +105,7 @@ describe('github-auto-sync-scheduler', () => {
     storageState[GITHUB_AUTO_SYNC_ENABLED_STORAGE_KEY] = true;
     storageState[GITHUB_AUTO_SYNC_QUEUE_STORAGE_KEY] = { '8': 9_999 };
     const sync = vi.fn().mockResolvedValue({
-      transport: { status: 'failed' },
+      transportStatus: 'failed',
       items: [{ conversationId: 8, status: 'failed', error: 'github_network_error' }],
     });
     const scheduler = createGithubAutoSyncScheduler(
@@ -124,7 +124,7 @@ describe('github-auto-sync-scheduler', () => {
     storageState[GITHUB_AUTO_SYNC_ENABLED_STORAGE_KEY] = true;
     storageState[GITHUB_AUTO_SYNC_QUEUE_STORAGE_KEY] = { '9': 9_999 };
     const sync = vi.fn().mockResolvedValue({
-      transport: { status: 'not_needed' },
+      transportStatus: 'not_needed',
       items: [{ conversationId: 9, status: 'failed', error: 'github_network_error' }],
     });
     const scheduler = createGithubAutoSyncScheduler(
@@ -143,7 +143,7 @@ describe('github-auto-sync-scheduler', () => {
     storageState[GITHUB_AUTO_SYNC_ENABLED_STORAGE_KEY] = true;
     storageState[GITHUB_AUTO_SYNC_QUEUE_STORAGE_KEY] = { '12': 9_999 };
     const sync = vi.fn().mockResolvedValue({
-      transport: { status: 'not_needed' },
+      transportStatus: 'not_needed',
       items: [{ conversationId: 12, status: 'failed', error: 'conversation not found' }],
     });
     const scheduler = createGithubAutoSyncScheduler(
@@ -158,11 +158,11 @@ describe('github-auto-sync-scheduler', () => {
     });
   });
 
-  it('retains dirty ids when the orchestrator returns an invalid transport resolution', async () => {
+  it('retains dirty ids when transport resolution cannot be acknowledged', async () => {
     storageState[GITHUB_AUTO_SYNC_ENABLED_STORAGE_KEY] = true;
     storageState[GITHUB_AUTO_SYNC_QUEUE_STORAGE_KEY] = { '10': 9_999 };
     const sync = vi.fn().mockResolvedValue({
-      transport: { status: 'invalid_resolution' },
+      transportStatus: 'committed',
       items: [{ conversationId: 10, status: 'failed', error: 'github_transport_resolution_incomplete' }],
     });
     const scheduler = createGithubAutoSyncScheduler(
@@ -181,7 +181,7 @@ describe('github-auto-sync-scheduler', () => {
     storageState[GITHUB_AUTO_SYNC_ENABLED_STORAGE_KEY] = true;
     storageState[GITHUB_AUTO_SYNC_QUEUE_STORAGE_KEY] = { '11': 9_999 };
     const sync = vi.fn().mockResolvedValue({
-      transport: { status: 'committed' },
+      transportStatus: 'committed',
       items: [{ conversationId: 11, status: 'mapping_failed', error: 'github_mapping_patch_failed' }],
     });
     const scheduler = createGithubAutoSyncScheduler(
@@ -223,7 +223,7 @@ describe('github-auto-sync-scheduler', () => {
   it('drains cleanup-only work, re-dirties replacements, and schedules a future batch without recursion', async () => {
     storageState[GITHUB_AUTO_SYNC_ENABLED_STORAGE_KEY] = true;
     const sync = vi.fn().mockResolvedValue({
-      transport: { status: 'committed' },
+      transportStatus: 'committed',
       deferredReplacementConversationIds: [7, 7, '8', 0],
       cleanupHasMoreDue: true,
       nextCleanupDueAt: null,
@@ -250,7 +250,7 @@ describe('github-auto-sync-scheduler', () => {
   it('uses the orchestrator nextCleanupDueAt exactly when no cleanup batch remains due', async () => {
     storageState[GITHUB_AUTO_SYNC_ENABLED_STORAGE_KEY] = true;
     const sync = vi.fn().mockResolvedValue({
-      transport: { status: 'not_needed' },
+      transportStatus: 'not_needed',
       deferredReplacementConversationIds: [],
       cleanupHasMoreDue: false,
       nextCleanupDueAt: 45_678,
@@ -338,14 +338,14 @@ describe('github-auto-sync-scheduler', () => {
     const sync = vi
       .fn()
       .mockResolvedValueOnce({
-        transport: { status: 'not_needed' },
+        transportStatus: 'not_needed',
         deferredReplacementConversationIds: [7],
         cleanupHasMoreDue: false,
         nextCleanupDueAt: 75_000,
       })
-      .mockResolvedValueOnce({ transport: { status: 'committed' }, items: [{ conversationId: 7, status: 'synced' }] })
+      .mockResolvedValueOnce({ transportStatus: 'committed', items: [{ conversationId: 7, status: 'synced' }] })
       .mockResolvedValueOnce({
-        transport: { status: 'committed' },
+        transportStatus: 'committed',
         deferredReplacementConversationIds: [],
         cleanupHasMoreDue: false,
         nextCleanupDueAt: null,

--- a/tests/smoke/github-sync-orchestrator.test.ts
+++ b/tests/smoke/github-sync-orchestrator.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { GithubCleanupOutboxRecord } from '@platform/idb/github-cleanup-outbox-record';
 import { buildConversationBasename } from '@services/conversations/domain/file-naming';
 import { GithubApiError } from '@services/sync/github/github-api-client';
-import { commitGithubStagedOperations, GithubGitTransportError } from '@services/sync/github/github-git-transport';
+import { commitGithubStagedOperations } from '@services/sync/github/github-git-transport';
 import { buildGithubMarkdownProjection } from '@services/sync/github/github-markdown-projection';
 import type { GithubOrchestratorServices } from '@services/sync/github/github-orchestrator-services';
 import { createGithubSyncOrchestrator } from '@services/sync/github/github-sync-orchestrator';
@@ -24,7 +24,6 @@ const preflight = {
   remoteKey: 'github.com/owner/repo@main',
   installationId: 1,
   headSha: 'a'.repeat(40),
-  treeSha: 'b'.repeat(40),
 };
 
 function chat(id: number, overrides: Record<string, unknown> = {}) {
@@ -62,7 +61,6 @@ function fakeServices(input: {
 }) {
   const defaultCommit: GithubOrchestratorServices['commit'] = async () => ({
     status: 'no_changes',
-    treeSha: 'b'.repeat(40),
     files: [],
   });
   const commit = vi.fn(input.commitImpl ?? defaultCommit);
@@ -195,18 +193,16 @@ function successfulChatGithubMapping(conversation: any, syncedAt = 100) {
 }
 
 describe('github sync orchestrator staging through production sync', () => {
-  it('dedupes candidate ids and resolves the target exactly once', async () => {
+  it('resolves one target for a normalized conversation batch', async () => {
     const { services } = fakeServices({
       rows: { 1: { conversation: chat(1) }, 2: { conversation: chat(2) } },
       commitImpl: async ({ operations }) => ({
         status: 'committed',
-        treeSha: 'f'.repeat(40),
-        commitSha: '1'.repeat(40),
         files: resolvedFiles(operations),
       }),
     });
     const result = await createGithubSyncOrchestrator(services).sync({
-      conversationIds: [1, 1, 2, 0, 'bad'],
+      conversationIds: [1, 2],
       instanceId: 'staging-dedupe',
     });
 
@@ -214,8 +210,7 @@ describe('github sync orchestrator staging through production sync', () => {
     expect(services.preflight).toHaveBeenCalledWith({ repository: settings.repository, branch: settings.branch });
     expect(services.getSettings).toHaveBeenCalledTimes(1);
     expect(services.storage.getSyncMappingByConversation).toHaveBeenCalledTimes(2);
-    expect(result.summary.candidateCount).toBe(2);
-    expect(result.summary.syncedCount).toBe(2);
+    expect(result.items.map((item) => item.status)).toEqual(['synced', 'synced']);
   });
 
   it('reattaches article orphans before reading comments by conversation id only', async () => {
@@ -250,8 +245,6 @@ describe('github sync orchestrator staging through production sync', () => {
         stagedOperations = operations;
         return {
           status: 'committed',
-          treeSha: 'f'.repeat(40),
-          commitSha: '1'.repeat(40),
           files: resolvedFiles(operations),
         };
       },
@@ -278,8 +271,6 @@ describe('github sync orchestrator staging through production sync', () => {
         stagedOperations = operations;
         return {
           status: 'committed',
-          treeSha: 'f'.repeat(40),
-          commitSha: '1'.repeat(40),
           files: resolvedFiles(operations),
         };
       },
@@ -356,8 +347,6 @@ describe('github sync orchestrator staging through production sync', () => {
         stagedOperations = operations;
         return {
           status: 'committed',
-          treeSha: 'f'.repeat(40),
-          commitSha: '1'.repeat(40),
           files: resolvedFiles(operations),
         };
       },
@@ -390,7 +379,7 @@ describe('github sync orchestrator staging through production sync', () => {
       instanceId: 'collision',
     });
 
-    expect(result.transport.status).toBe('not_needed');
+    expect(result.transportStatus).toBe('not_needed');
     expect(commit).not.toHaveBeenCalled();
     expect(result.items.map((item) => [item.conversationId, item.status, item.error])).toEqual([
       [1, 'failed', 'github_staged_path_collision'],
@@ -415,7 +404,7 @@ describe('github sync orchestrator staging through production sync', () => {
       instanceId: 'local-no-op',
     });
 
-    expect(result.transport.status).toBe('not_needed');
+    expect(result.transportStatus).toBe('not_needed');
     expect(result.items[0]?.status).toBe('no_changes');
     expect(commit).not.toHaveBeenCalled();
   });
@@ -446,8 +435,6 @@ describe('github sync orchestrator job lifecycle', () => {
       rows: { 1: { conversation: chat(1) } },
       commitImpl: async ({ operations }) => ({
         status: 'committed',
-        treeSha: 'f'.repeat(40),
-        commitSha: '1'.repeat(40),
         files: resolvedFiles(operations),
       }),
     });
@@ -507,7 +494,7 @@ describe('github sync orchestrator job lifecycle', () => {
 
     const result = await createGithubSyncOrchestrator(services).sync({ conversationIds: [], instanceId: 'instance-a' });
 
-    expect(result.transport.status).toBe('not_needed');
+    expect(result.transportStatus).toBe('not_needed');
     expect(jobStore.setJob).not.toHaveBeenCalled();
   });
 
@@ -517,8 +504,6 @@ describe('github sync orchestrator job lifecycle', () => {
       cleanupRows: [cleanupRow(40)],
       commitImpl: async ({ operations }) => ({
         status: 'committed',
-        treeSha: 'f'.repeat(40),
-        commitSha: '1'.repeat(40),
         files: resolvedFiles(operations),
       }),
     });
@@ -559,8 +544,6 @@ describe('github sync orchestrator job lifecycle', () => {
       initialJob: residue,
       commitImpl: async ({ operations }) => ({
         status: 'committed',
-        treeSha: 'f'.repeat(40),
-        commitSha: '1'.repeat(40),
         files: resolvedFiles(operations),
       }),
     });
@@ -589,8 +572,6 @@ describe('github sync orchestrator job lifecycle', () => {
       initialJob: residue,
       commitImpl: async ({ operations }) => ({
         status: 'committed',
-        treeSha: 'f'.repeat(40),
-        commitSha: '1'.repeat(40),
         files: resolvedFiles(operations),
       }),
     });
@@ -620,8 +601,6 @@ describe('github sync orchestrator job lifecycle', () => {
       failJobWritesAfterInitial: true,
       commitImpl: async ({ operations }) => ({
         status: 'committed',
-        treeSha: 'f'.repeat(40),
-        commitSha: '1'.repeat(40),
         files: resolvedFiles(operations),
       }),
     });
@@ -633,9 +612,8 @@ describe('github sync orchestrator job lifecycle', () => {
 
     expect(commit).toHaveBeenCalledTimes(1);
     expect(services.storage.patchSyncMapping).toHaveBeenCalledTimes(1);
-    expect(result.transport.status).toBe('committed');
+    expect(result.transportStatus).toBe('committed');
     expect(result.items[0]?.status).toBe('synced');
-    expect(result.cleanupWarnings).toContain('github_sync_job_persist_failed');
     expect(getPersistedJob()).toMatchObject({ status: 'running', currentStage: 'preparing_queue' });
   });
 
@@ -775,8 +753,6 @@ describe('github sync orchestrator cleanup outbox', () => {
         committedOperations = operations;
         return {
           status: 'committed',
-          treeSha: 'f'.repeat(40),
-          commitSha: '1'.repeat(40),
           files: resolvedFiles(operations),
         };
       },
@@ -788,7 +764,7 @@ describe('github sync orchestrator cleanup outbox', () => {
     expect(committedOperations).toEqual([{ type: 'delete', path: 'Old/owned-1.md' }]);
     expect(services.ackCleanupRows).toHaveBeenCalledWith([1]);
     expect(getCleanupRows()).toEqual([]);
-    expect(result.transport.status).toBe('committed');
+    expect(result.transportStatus).toBe('committed');
     expect(result.cleanupHasMoreDue).toBe(false);
     expect(result.nextCleanupDueAt).toBeNull();
     expect(result.deferredReplacementConversationIds).toEqual([]);
@@ -811,8 +787,6 @@ describe('github sync orchestrator cleanup outbox', () => {
         committedOperations = operations;
         return {
           status: 'committed',
-          treeSha: 'f'.repeat(40),
-          commitSha: '1'.repeat(40),
           files: resolvedFiles(operations),
         };
       },
@@ -857,8 +831,6 @@ describe('github sync orchestrator cleanup outbox', () => {
         await commitRelease;
         return {
           status: 'committed',
-          treeSha: 'f'.repeat(40),
-          commitSha: '1'.repeat(40),
           files: resolvedFiles(operations),
         };
       },
@@ -901,7 +873,7 @@ describe('github sync orchestrator cleanup outbox', () => {
     expect(services.deferCleanupRows).toHaveBeenCalledWith([7], 9_000);
     expect(services.ackCleanupRows).not.toHaveBeenCalled();
     expect(getCleanupRows()[0]?.nextAttemptAt).toBe(9_000);
-    expect(result.transport.status).toBe('not_needed');
+    expect(result.transportStatus).toBe('not_needed');
     expect(result.deferredReplacementConversationIds).toEqual([2]);
     expect(result.nextCleanupDueAt).toBe(9_000);
   });
@@ -1037,7 +1009,6 @@ describe('github sync orchestrator cleanup outbox', () => {
         committedOperations = operations;
         return {
           status: 'no_changes',
-          treeSha: 'f'.repeat(40),
           files: resolvedFiles(operations),
         };
       },
@@ -1051,7 +1022,7 @@ describe('github sync orchestrator cleanup outbox', () => {
     ]);
     expect(services.ackCleanupRows).toHaveBeenCalledWith([8, 9]);
     expect(getCleanupRows()).toEqual([]);
-    expect(result.transport.status).toBe('no_changes');
+    expect(result.transportStatus).toBe('no_changes');
   });
 
   it('keeps eligible cleanup pending when the shared transport fails', async () => {
@@ -1066,7 +1037,7 @@ describe('github sync orchestrator cleanup outbox', () => {
 
     const result = await createGithubSyncOrchestrator(services).sync({ conversationIds: [] });
 
-    expect(result.transport.status).toBe('failed');
+    expect(result.transportStatus).toBe('failed');
     expect(services.ackCleanupRows).not.toHaveBeenCalled();
     expect(getCleanupRows()).toHaveLength(1);
     expect(result.nextCleanupDueAt).toBe(1);
@@ -1098,14 +1069,11 @@ describe('github sync orchestrator cleanup outbox', () => {
           remotePresent = false;
           return {
             status: 'committed',
-            treeSha: 'f'.repeat(40),
-            commitSha: '1'.repeat(40),
             files: resolvedFiles(operations),
           };
         }
         return {
           status: 'no_changes',
-          treeSha: 'f'.repeat(40),
           files: operations.map((operation) =>
             operation.type === 'delete'
               ? { path: operation.path, status: 'absent' as const }
@@ -1123,8 +1091,7 @@ describe('github sync orchestrator cleanup outbox', () => {
 
     const first = await orchestrator.sync({ conversationIds: [] });
 
-    expect(first.transport).toEqual({ status: 'committed', commitSha: '1'.repeat(40) });
-    expect(first.cleanupWarnings).toContain('github_cleanup_ack_failed');
+    expect(first.transportStatus).toBe('committed');
     expect(getCleanupRows()).toHaveLength(1);
     expect(first.nextCleanupDueAt).toBe(1);
 
@@ -1132,7 +1099,7 @@ describe('github sync orchestrator cleanup outbox', () => {
     const second = await orchestrator.sync({ conversationIds: [] });
 
     expect(commit).toHaveBeenCalledTimes(2);
-    expect(second.transport.status).toBe('no_changes');
+    expect(second.transportStatus).toBe('no_changes');
     expect(services.ackCleanupRows).toHaveBeenLastCalledWith([12]);
     expect(getCleanupRows()).toEqual([]);
   });
@@ -1152,7 +1119,6 @@ describe('github sync orchestrator cleanup outbox', () => {
 
     expect(commit).not.toHaveBeenCalled();
     expect(services.ackCleanupRows).not.toHaveBeenCalled();
-    expect(result.cleanupWarnings).toContain('github_cleanup_defer_failed');
     expect(result.deferredReplacementConversationIds).toEqual([6]);
     expect(getCleanupRows()[0]?.nextAttemptAt).toBe(1);
     expect(result.nextCleanupDueAt).toBe(1);
@@ -1190,7 +1156,6 @@ describe('github sync orchestrator cleanup crash recovery', () => {
         expect(remotePresent).toBe(false);
         return {
           status: 'no_changes',
-          treeSha: 'f'.repeat(40),
           files: operations.map((operation) =>
             operation.type === 'delete'
               ? { path: operation.path, status: 'absent' as const }
@@ -1202,12 +1167,12 @@ describe('github sync orchestrator cleanup crash recovery', () => {
     const orchestrator = createGithubSyncOrchestrator(services);
 
     const first = await orchestrator.sync({ conversationIds: [] });
-    expect(first.transport.status).toBe('failed');
+    expect(first.transportStatus).toBe('failed');
     expect(services.ackCleanupRows).not.toHaveBeenCalled();
     expect(getCleanupRows()).toHaveLength(1);
 
     const second = await orchestrator.sync({ conversationIds: [] });
-    expect(second.transport.status).toBe('no_changes');
+    expect(second.transportStatus).toBe('no_changes');
     expect(getCleanupRows()).toEqual([]);
     expect(services.ackCleanupRows).toHaveBeenCalledWith([20]);
   });
@@ -1218,11 +1183,12 @@ describe('github sync orchestrator cleanup crash recovery', () => {
       rows: {},
       cleanupRows: [cleanupRow(21)],
       commitImpl: async ({ operations }) => {
-        if (failRace) throw new GithubGitTransportError('github_git_branch_race_exhausted');
+        if (failRace)
+          throw Object.assign(new Error('github_git_branch_race_exhausted'), {
+            code: 'github_git_branch_race_exhausted',
+          });
         return {
           status: 'committed',
-          treeSha: 'f'.repeat(40),
-          commitSha: '1'.repeat(40),
           files: resolvedFiles(operations),
         };
       },
@@ -1230,12 +1196,12 @@ describe('github sync orchestrator cleanup crash recovery', () => {
     const orchestrator = createGithubSyncOrchestrator(services);
 
     const first = await orchestrator.sync({ conversationIds: [] });
-    expect(first.transport.status).toBe('failed');
+    expect(first.transportStatus).toBe('failed');
     expect(getCleanupRows()).toHaveLength(1);
 
     failRace = false;
     const second = await orchestrator.sync({ conversationIds: [] });
-    expect(second.transport.status).toBe('committed');
+    expect(second.transportStatus).toBe('committed');
     expect(getCleanupRows()).toEqual([]);
   });
 
@@ -1282,7 +1248,6 @@ describe('github sync orchestrator cleanup crash recovery', () => {
         committedOperations = operations;
         return {
           status: 'no_changes',
-          treeSha: 'f'.repeat(40),
           files: resolvedFiles(operations),
         };
       },
@@ -1334,13 +1299,11 @@ describe('github sync orchestrator transport acknowledgement', () => {
 
     resolveCommit({
       status: 'committed',
-      treeSha: 'f'.repeat(40),
-      commitSha: '1'.repeat(40),
       files: resolvedFiles(captured.operations),
     });
     const result = await syncPromise;
 
-    expect(result.transport).toEqual({ status: 'committed', commitSha: '1'.repeat(40) });
+    expect(result.transportStatus).toBe('committed');
     expect(result.items.map((item) => item.status)).toEqual(['synced', 'synced']);
     expect(services.storage.patchSyncMapping).toHaveBeenCalledTimes(2);
     for (const [, patch] of (services.storage.patchSyncMapping as any).mock.calls) {
@@ -1369,13 +1332,12 @@ describe('github sync orchestrator transport acknowledgement', () => {
       messages: { 1: messages },
       commitImpl: async ({ operations }) => ({
         status: 'no_changes',
-        treeSha: 'f'.repeat(40),
         files: resolvedFiles(operations, '9'.repeat(40)),
       }),
     });
 
     const result = await createGithubSyncOrchestrator(services).sync({ conversationIds: [1] });
-    expect(result.transport.status).toBe('no_changes');
+    expect(result.transportStatus).toBe('no_changes');
     expect(result.items[0]?.status).toBe('synced');
     expect(services.storage.patchSyncMapping).toHaveBeenCalledTimes(1);
     const patch = (services.storage.patchSyncMapping as any).mock.calls[0][1];
@@ -1418,7 +1380,7 @@ describe('github sync orchestrator transport acknowledgement', () => {
 
     const result = await createGithubSyncOrchestrator(services).sync({ conversationIds: [1, 2] });
     expect(services.storage.patchSyncMapping).not.toHaveBeenCalled();
-    expect(result.transport.status).toBe('failed');
+    expect(result.transportStatus).toBe('failed');
     expect(result.items.map((item) => [item.conversationId, item.status, item.error])).toEqual([
       [1, 'failed', 'github_outcome_unknown'],
       [2, 'no_changes', ''],
@@ -1431,14 +1393,12 @@ describe('github sync orchestrator transport acknowledgement', () => {
       patchFailures: new Set([2]),
       commitImpl: async ({ operations }) => ({
         status: 'committed',
-        treeSha: 'f'.repeat(40),
-        commitSha: '1'.repeat(40),
         files: resolvedFiles(operations),
       }),
     });
 
     const result = await createGithubSyncOrchestrator(services).sync({ conversationIds: [1, 2] });
-    expect(result.transport).toEqual({ status: 'committed', commitSha: '1'.repeat(40) });
+    expect(result.transportStatus).toBe('committed');
     expect(result.items.map((item) => item.status)).toEqual(['synced', 'mapping_failed']);
     expect(result.items[1]?.warnings).toContain('github_mapping_patch_failed');
     expect(services.storage.patchSyncMapping).toHaveBeenCalledTimes(2);
@@ -1449,14 +1409,12 @@ describe('github sync orchestrator transport acknowledgement', () => {
       rows: { 1: { conversation: chat(1) } },
       commitImpl: async () => ({
         status: 'committed',
-        treeSha: 'f'.repeat(40),
-        commitSha: '1'.repeat(40),
         files: [],
       }),
     });
 
     const result = await createGithubSyncOrchestrator(services).sync({ conversationIds: [1] });
-    expect(result.transport.status).toBe('invalid_resolution');
+    expect(result.transportStatus).toBe('committed');
     expect(result.items[0]).toMatchObject({ status: 'failed', error: 'github_transport_resolution_incomplete' });
     expect(services.storage.patchSyncMapping).not.toHaveBeenCalled();
   });
@@ -1545,7 +1503,7 @@ describe('github sync orchestrator atomic cross-layer contracts', () => {
     });
 
     const result = await createGithubSyncOrchestrator(services).sync({ conversationIds: [1] });
-    expect(result.transport.status).toBe('not_needed');
+    expect(result.transportStatus).toBe('not_needed');
     expect(result.items[0]?.status).toBe('no_changes');
     expect(commit).not.toHaveBeenCalled();
   });
@@ -1572,7 +1530,7 @@ describe('github sync orchestrator atomic cross-layer contracts', () => {
       conversationIds: [1],
       mode: 'reconcile',
     });
-    expect(driftedResult.transport.status).toBe('committed');
+    expect(driftedResult.transportStatus).toBe('committed');
     expect(drifted.calls.find((call) => call.path.endsWith('/git/trees'))?.body.tree).toEqual([
       { path: p.markdownPath, mode: '100644', type: 'blob', sha: 'd'.repeat(40) },
     ]);
@@ -1588,7 +1546,7 @@ describe('github sync orchestrator atomic cross-layer contracts', () => {
       conversationIds: [1],
       mode: 'reconcile',
     });
-    expect(currentResult.transport.status).toBe('no_changes');
+    expect(currentResult.transportStatus).toBe('no_changes');
     expect(currentResult.items[0]?.status).toBe('synced');
     expect(currentRemote.calls.filter((call) => call.path.endsWith('/git/commits'))).toHaveLength(0);
     expect(currentRemote.calls.filter((call) => call.method === 'PATCH')).toHaveLength(0);
@@ -1622,8 +1580,6 @@ describe('github sync orchestrator atomic cross-layer contracts', () => {
         renameOps = operations;
         return {
           status: 'committed',
-          treeSha: 'f'.repeat(40),
-          commitSha: '1'.repeat(40),
           files: resolvedFiles(operations),
         };
       },
@@ -1642,8 +1598,6 @@ describe('github sync orchestrator atomic cross-layer contracts', () => {
         switchOps = operations;
         return {
           status: 'committed',
-          treeSha: 'f'.repeat(40),
-          commitSha: '1'.repeat(40),
           files: resolvedFiles(operations),
         };
       },
@@ -1679,8 +1633,6 @@ describe('github sync orchestrator atomic cross-layer contracts', () => {
         committedMarkdown = write?.type === 'write' ? String(write.content) : '';
         return {
           status: 'committed',
-          treeSha: 'f'.repeat(40),
-          commitSha: '1'.repeat(40),
           files: resolvedFiles(operations),
         };
       },
@@ -1743,14 +1695,14 @@ describe('github sync orchestrator atomic cross-layer contracts', () => {
     const orchestrator = createGithubSyncOrchestrator(services);
 
     const first = await orchestrator.sync({ conversationIds: [1] });
-    expect(first.transport.status).toBe('failed');
+    expect(first.transportStatus).toBe('failed');
     expect(first.items[0]).toMatchObject({ status: 'failed', error: 'github_outcome_unknown' });
     expect(services.storage.patchSyncMapping).not.toHaveBeenCalled();
     expect(commitCreates).toBe(1);
     expect(refPatches).toBe(1);
 
     const second = await orchestrator.sync({ conversationIds: [1] });
-    expect(second.transport.status).toBe('no_changes');
+    expect(second.transportStatus).toBe('no_changes');
     expect(second.items[0]?.status).toBe('synced');
     expect(services.storage.patchSyncMapping).toHaveBeenCalledTimes(1);
     expect(commitCreates).toBe(1);

--- a/tests/smoke/github-sync-orchestrator.test.ts
+++ b/tests/smoke/github-sync-orchestrator.test.ts
@@ -1330,8 +1330,7 @@ describe('github sync orchestrator transport acknowledgement', () => {
     await started;
     expect(commit).toHaveBeenCalledTimes(1);
     expect(services.storage.patchSyncMapping).not.toHaveBeenCalled();
-    expect(captured.message).toBe('SyncNos GitHub sync (2 items)');
-    expect(captured.message).not.toMatch(/Title|body-/);
+    expect(captured).not.toHaveProperty('message');
 
     resolveCommit({
       status: 'committed',
@@ -1512,9 +1511,7 @@ describe('github sync orchestrator atomic cross-layer contracts', () => {
     expect(result.items.map((item) => item.status)).toEqual(['synced', 'synced']);
     expect(remote.calls.filter((call) => call.path.endsWith('/git/commits'))).toHaveLength(1);
     expect(remote.calls.filter((call) => call.method === 'PATCH')).toHaveLength(1);
-    expect(remote.calls.find((call) => call.path.endsWith('/git/commits'))?.body.message).toBe(
-      'SyncNos GitHub sync (2 items)',
-    );
+    expect(remote.calls.find((call) => call.path.endsWith('/git/commits'))?.body.message).toBe('SyncNos GitHub sync');
   });
 
   it('still commits the safe row when another conversation fails local projection', async () => {

--- a/tests/unit/github-git-transport.test.ts
+++ b/tests/unit/github-git-transport.test.ts
@@ -296,7 +296,7 @@ describe('github git transport staged path/delete resolver', () => {
     });
     const commit = calls.find((call) => call.path.endsWith('/git/commits'));
     expect(commit?.body).toEqual({
-      message: 'SyncNos: sync 3 files',
+      message: 'SyncNos GitHub sync',
       tree: NEW_TREE,
       parents: ['f'.repeat(40)],
     });
@@ -306,71 +306,6 @@ describe('github git transport staged path/delete resolver', () => {
       path: '/repos/owner/repo/git/refs/heads/feature/foo',
       body: { sha: COMMIT, force: false },
     });
-  });
-
-  it('uses an explicit safe commit message and rejects unsafe messages before mutations', async () => {
-    const NEW_TREE = '1'.repeat(40);
-    const COMMIT = '2'.repeat(40);
-    const calls: Array<{ method: string; path: string; body?: any }> = [];
-    const api = {
-      async get<T>(): Promise<T> {
-        throw new Error('no deletes');
-      },
-      async post<T>(path: string, body?: unknown): Promise<T> {
-        calls.push({ method: 'POST', path, body });
-        if (path.endsWith('/git/trees')) return { sha: NEW_TREE } as T;
-        if (path.endsWith('/git/commits')) return { sha: COMMIT } as T;
-        throw new Error(`unexpected:${path}`);
-      },
-      async patch<T>(path: string, body?: unknown): Promise<T> {
-        calls.push({ method: 'PATCH', path, body });
-        return { object: { sha: COMMIT } } as T;
-      },
-    };
-
-    await commitGithubStagedOperationsOnce(
-      {
-        repository: 'owner/repo',
-        branch: 'main',
-        headSha: 'f'.repeat(40),
-        treeSha: ROOT,
-        operations: [{ type: 'reuse', path: 'asset.png', sha: BLOB_2 }],
-        message: 'SyncNos GitHub sync (2 items)',
-      },
-      api,
-    );
-    expect(calls.find((call) => call.path.endsWith('/git/commits'))?.body).toMatchObject({
-      message: 'SyncNos GitHub sync (2 items)',
-    });
-
-    let mutations = 0;
-    const noMutationApi = {
-      async get<T>(): Promise<T> {
-        throw new Error('must-not-read');
-      },
-      async post<T>(): Promise<T> {
-        mutations += 1;
-        throw new Error('must-not-post');
-      },
-      async patch<T>(): Promise<T> {
-        mutations += 1;
-        throw new Error('must-not-patch');
-      },
-    };
-    await expect(
-      commitGithubStagedOperationsOnce(
-        {
-          repository: 'owner/repo',
-          branch: 'main',
-          headSha: 'f'.repeat(40),
-          treeSha: ROOT,
-          operations: [{ type: 'reuse', path: 'asset.png', sha: BLOB_2 }],
-          message: 'SyncNos\nbody',
-        },
-        noMutationApi,
-      ),
-    ).rejects.toMatchObject({ code: 'github_git_message_invalid' });
-    expect(mutations).toBe(0);
   });
 
   it('returns no_changes for absent deletes without creating tree/commit/ref', async () => {
@@ -571,17 +506,13 @@ describe('github git transport staged path/delete resolver', () => {
         repository: 'owner/repo',
         branch: 'main',
         operations: [{ type: 'reuse', path: 'asset.png', sha: BLOB_2 }],
-        message: 'SyncNos GitHub sync (1 items)',
       },
       api,
     );
     expect(result).toMatchObject({ status: 'committed', treeSha: NEW_2, commitSha: COMMIT_2 });
     expect(refReads).toBe(2);
     expect(treeBodies.map((body) => body.base_tree)).toEqual([BASE_1, BASE_2]);
-    expect(commitBodies.map((body) => body.message)).toEqual([
-      'SyncNos GitHub sync (1 items)',
-      'SyncNos GitHub sync (1 items)',
-    ]);
+    expect(commitBodies.map((body) => body.message)).toEqual(['SyncNos GitHub sync', 'SyncNos GitHub sync']);
     expect(patchBodies).toEqual([
       { sha: COMMIT_1, force: false },
       { sha: COMMIT_2, force: false },

--- a/tests/unit/github-git-transport.test.ts
+++ b/tests/unit/github-git-transport.test.ts
@@ -2,8 +2,6 @@ import { describe, expect, it } from 'vitest';
 
 import { GithubApiError } from '@services/sync/github/github-api-client';
 import {
-  GITHUB_BRANCH_RACE_MAX_ATTEMPTS,
-  GithubGitTransportError,
   commitGithubStagedOperations,
   commitGithubStagedOperationsOnce,
   createGithubBlob,
@@ -97,8 +95,8 @@ describe('github git transport staged path/delete resolver', () => {
     );
 
     expect(result.deletes).toEqual([
-      { path: 'folder/nested/one.md', status: 'present', sha: BLOB_1 },
-      { path: 'folder/nested/two.md', status: 'present', sha: BLOB_2 },
+      { path: 'folder/nested/one.md', status: 'present' },
+      { path: 'folder/nested/two.md', status: 'present' },
     ]);
     expect(result.operations).toEqual([
       { type: 'delete', path: 'folder/nested/one.md' },
@@ -277,8 +275,6 @@ describe('github git transport staged path/delete resolver', () => {
 
     expect(result).toEqual({
       status: 'committed',
-      treeSha: NEW_TREE,
-      commitSha: COMMIT,
       files: [
         { path: 'new.md', status: 'written', sha: BLOB_1 },
         { path: 'asset.png', status: 'reused', sha: BLOB_2 },
@@ -336,7 +332,6 @@ describe('github git transport staged path/delete resolver', () => {
     );
     expect(result).toEqual({
       status: 'no_changes',
-      treeSha: ROOT,
       files: [{ path: 'missing.md', status: 'absent' }],
     });
     expect(calls.some((call) => call.startsWith('POST') || call.startsWith('PATCH'))).toBe(false);
@@ -410,7 +405,6 @@ describe('github git transport staged path/delete resolver', () => {
     );
     expect(result).toEqual({
       status: 'no_changes',
-      treeSha: ROOT,
       files: [
         { path: 'same.md', status: 'written', sha: BLOB_1 },
         { path: 'same-asset.png', status: 'reused', sha: BLOB_2 },
@@ -509,7 +503,7 @@ describe('github git transport staged path/delete resolver', () => {
       },
       api,
     );
-    expect(result).toMatchObject({ status: 'committed', treeSha: NEW_2, commitSha: COMMIT_2 });
+    expect(result.status).toBe('committed');
     expect(refReads).toBe(2);
     expect(treeBodies.map((body) => body.base_tree)).toEqual([BASE_1, BASE_2]);
     expect(commitBodies.map((body) => body.message)).toEqual(['SyncNos GitHub sync', 'SyncNos GitHub sync']);
@@ -610,8 +604,8 @@ describe('github git transport staged path/delete resolver', () => {
         api,
       ),
     ).rejects.toMatchObject({ code: 'github_git_branch_race_exhausted' });
-    expect(refReads).toBe(GITHUB_BRANCH_RACE_MAX_ATTEMPTS);
-    expect(patches).toBe(GITHUB_BRANCH_RACE_MAX_ATTEMPTS);
+    expect(refReads).toBe(3);
+    expect(patches).toBe(3);
   });
 
   it('re-resolves deletes against the fresh tree and treats a concurrently removed path as satisfied', async () => {
@@ -658,7 +652,6 @@ describe('github git transport staged path/delete resolver', () => {
     );
     expect(result).toEqual({
       status: 'no_changes',
-      treeSha: BASE_2,
       files: [{ path: 'old.md', status: 'absent' }],
     });
     expect(treeReads).toEqual([BASE_1, BASE_2]);
@@ -680,7 +673,7 @@ describe('github git transport staged path/delete resolver', () => {
         { repository: 'owner/repo', treeSha: 'bad', operations: [{ type: 'delete', path: 'old.md' }] },
         api,
       ),
-    ).rejects.toBeInstanceOf(GithubGitTransportError);
+    ).rejects.toMatchObject({ code: 'github_git_sha_invalid' });
     expect(calls).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Related issue

N/A — 本次修复来自仓库内已确认的 GitHub commit bug 记录，未建立独立 GitHub Issue。

## Why

手动 GitHub 同步使用 `reconcile`，会重新声明内容未变化的受管文件。此前 commit message 把参与 reconcile 的 conversations 或 tree entries 数量当成实际变更数量，导致 GitHub 显示的 `N items/files` 与最终 diff 不一致。

同时，GitHub sync 链中保留了多套已经失去生产消费者的结果字段、重复校验和兼容状态，增加了维护成本，也让同步职责边界不够清晰。

## Scope

### In scope

- GitHub commit message 改为固定 `SyncNos GitHub sync`，不再报告无法可靠定义的数量。
- 收敛 GitHub planner / transport / orchestrator / auto-sync 的重复状态、校验和内部 API。
- 保持手动 `reconcile`、自动 `incremental`、cleanup retry 和 mapping ack 的原有语义。

### Non-goals

- 不改变 GitHub repository/branch 配置、认证、权限或 OAuth scope。
- 不改变 GitHub Markdown 输出内容和文件命名规则。
- 不引入新的迁移或兼容层。

## What changed

- 删除动态 commit item/file 数量以及对应 message 参数、校验和错误码。
- 删除 orchestrator 已无人消费的 `summary`、`target`、commit SHA、cleanup warning 等结果面，并将 transport 结果收敛为最小状态。
- 删除 planner、transport、auto-sync 和 orchestrator 内部重复的 ID / path / SHA / result 校验，只在真实信任边界保留校验。
- 收敛 GitHub 输出目录分类为单一 helper，避免 projection 与 ownership 规则漂移。
- 清理仅被测试引用的内部 export、纯转发 wrapper 和不可达 fallback。

## Architecture / invariants

- 手动 GitHub 同步仍以 `reconcile` 进入同一 GitHub orchestrator；自动同步仍以 `incremental` 进入同一 orchestrator。
- SyncJob 生命周期仍由 orchestrator 唯一维护，handler/scheduler 未引入第二套 progress/terminal 状态。
- 保留 path collision 防覆盖、conversation-owned delete、GitHub response SHA 校验、branch race retry、cleanup replacement defer，以及 transport resolution 完整后才写 mapping 的数据安全边界。
- `src/services/**` 依赖方向未引入 `@ui/*` / `@viewmodels/*`。

## Data, migration & recovery

无 schema 或数据迁移。

GitHub sync mapping 与 cleanup outbox 的持久化格式不变。远端提交失败时不会写入新的 mapping；cleanup acknowledgement 失败时仍保留 outbox 记录供后续重试；replacement cleanup 仍会 defer，避免删除新 identity 正在使用的远端文件。

## Permissions & privacy

N/A — manifest、host permissions、OAuth scope、secret 存储和网络目标均未改变。

## Compatibility

GitHub provider 支持范围不变。未增加旧结果 shape 的兼容别名；本次改动只收敛仓库内部 API，生产调用方已同步更新。

## Demo

N/A — no visual behavior changed.

## Drawbacks / risks

GitHub commit message 不再显示 item/file 数量。这是有意取舍：GitHub tree 最终 diff 数量无法由 reconcile 输入数量可靠推导，固定文案避免继续呈现误导信息。

## Tests & validation

### Automated

- `npm run gate:ci` — lint、Prettier、TypeScript compile、完整 Vitest 全部通过。
- 完整测试结果：284 test files / 2148 tests passed。
- GitHub 定向覆盖：10 files / 159 tests passed，覆盖 projection、planner、transport、orchestrator、manual handler、auto-sync scheduler、sync ownership、cleanup outbox 和 integration flow。
- `git diff --check` 通过。

### Manual

N/A — 未执行真实远端 GitHub 写入，避免为了验收制造外部仓库副作用；GitHub API 事务和完整同步流程由 transport / smoke / integration tests 覆盖。

## Documentation

仓库内本地 feature bug 记录已同步更新；该目录被 `.gitignore` 的 `features/` 规则忽略，因此不进入本 PR。没有 canonical 用户文档因本次内部同步契约收敛而失效。
