### PR TITLE
feat: 建立视频字幕、章节与元数据的 canonical capture 模型

### DIFF
--- a/src/collectors/video/video-bridge-store.ts
+++ b/src/collectors/video/video-bridge-store.ts
@@ -1,5 +1,8 @@
+import type { VideoPageMetaCandidates } from '@services/shared/video-capture';
+
 type StoreResponse = {
   url: string;
+  pageUrl: string;
   contentType?: string;
   bodyText: string;
   at: number;
@@ -7,23 +10,20 @@ type StoreResponse = {
 
 type VideoTranscriptBridgeStore = {
   responses: StoreResponse[];
-  metaByRequestId: Record<string, any>;
 };
 
 const STORE_KEY = '__SYNCNOS_VIDEO_TRANSCRIPT_BRIDGE__';
+const DEFAULT_META_TIMEOUT_MS = 1200;
 
 function getStore(): VideoTranscriptBridgeStore | null {
   const anyGlobal = globalThis as any;
   const store = anyGlobal?.[STORE_KEY] as VideoTranscriptBridgeStore | undefined;
-  if (!store) return null;
-  if (!Array.isArray(store.responses)) return null;
-  if (!store.metaByRequestId || typeof store.metaByRequestId !== 'object') return null;
+  if (!store || !Array.isArray(store.responses)) return null;
   return store;
 }
 
 export function listVideoInterceptedResponses(): StoreResponse[] {
-  const store = getStore();
-  const list = store?.responses;
+  const list = getStore()?.responses;
   if (!Array.isArray(list) || !list.length) return [];
   return list.slice();
 }
@@ -39,25 +39,47 @@ function randomId(): string {
   return `${Date.now()}_${Math.random().toString(16).slice(2)}`;
 }
 
-async function sleep(ms: number) {
-  await new Promise((resolve) => setTimeout(resolve, Math.max(0, Math.floor(ms))));
-}
-
-export async function requestVideoPageMeta(options?: { timeoutMs?: number }): Promise<any | null> {
+export function requestVideoPageMeta(options?: { timeoutMs?: number }): Promise<VideoPageMetaCandidates | null> {
+  const requestedTimeout = Number(options?.timeoutMs);
+  const timeoutMs =
+    Number.isFinite(requestedTimeout) && requestedTimeout >= 0 ? Math.floor(requestedTimeout) : DEFAULT_META_TIMEOUT_MS;
   const requestId = randomId();
-  try {
-    window.postMessage({ __syncnos: true, type: 'SYNCNOS_VIDEO_META_REQUEST', requestId }, '*');
-  } catch (_e) {
-    return null;
-  }
 
-  const timeoutMs = Math.max(120, Number(options?.timeoutMs) || 1200);
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const store = getStore();
-    const meta = store?.metaByRequestId?.[requestId];
-    if (meta !== undefined) return meta ?? null;
-    await sleep(50);
-  }
-  return null;
+  return new Promise((resolve) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const finish = (value: VideoPageMetaCandidates | null) => {
+      if (settled) return;
+      settled = true;
+      window.removeEventListener('message', onMessage);
+      if (timer != null) clearTimeout(timer);
+      resolve(value);
+    };
+
+    const onMessage = (event: MessageEvent) => {
+      if (event.source !== window) return;
+      const data: any = event.data;
+      if (!data || data.__syncnos !== true || data.type !== 'SYNCNOS_VIDEO_META_RESPONSE') return;
+      if (String(data.requestId || '') !== requestId) return;
+      const meta = data.meta;
+      if (!meta || typeof meta !== 'object') {
+        finish(null);
+        return;
+      }
+      finish({
+        state: meta.state && typeof meta.state === 'object' ? meta.state : null,
+        dom: meta.dom && typeof meta.dom === 'object' ? meta.dom : null,
+      });
+    };
+
+    window.addEventListener('message', onMessage);
+    timer = setTimeout(() => finish(null), timeoutMs);
+
+    try {
+      window.postMessage({ __syncnos: true, type: 'SYNCNOS_VIDEO_META_REQUEST', requestId }, '*');
+    } catch (_error) {
+      finish(null);
+    }
+  });
 }

--- a/src/collectors/video/video-transcript-extract.ts
+++ b/src/collectors/video/video-transcript-extract.ts
@@ -119,9 +119,11 @@ function extractBilibiliCuesFromIntercept(currentUrl: string): TranscriptCue[] {
 }
 
 function extractBilibiliChaptersFromIntercept(currentUrl: string): VideoChapter[] | null {
-  const picked = listCurrentResponses(currentUrl, 'bilibili-chapters')[0];
-  if (!picked) return null;
-  return parseBilibiliViewPointsJson(String(picked.bodyText || ''));
+  for (const item of listCurrentResponses(currentUrl, 'bilibili-chapters')) {
+    const chapters = parseBilibiliViewPointsJson(String(item.bodyText || ''));
+    if (chapters !== null) return chapters;
+  }
+  return null;
 }
 
 export async function extractVideoTranscriptFromCurrentPage(): Promise<VideoTranscriptExtraction> {

--- a/src/collectors/video/video-transcript-extract.ts
+++ b/src/collectors/video/video-transcript-extract.ts
@@ -1,20 +1,28 @@
-import { canonicalizeVideoUrl } from '@services/url-cleaning/video-url';
 import { listVideoInterceptedResponses, requestVideoPageMeta } from '@collectors/video/video-bridge-store';
 import {
   parseBilibiliSubtitleJson,
+  parseBilibiliViewPointsJson,
   parseWebVtt,
   parseYoutubeJson3,
   parseYoutubeTimedtextXml,
   type TranscriptCue,
 } from '@collectors/video/video-transcript-parse';
-
-export type VideoTranscriptSource = 'A' | 'B' | 'C';
+import { canonicalizeVideoUrl } from '@services/url-cleaning/video-url';
+import {
+  classifyVideoResponseUrl,
+  type VideoChapter,
+  type VideoPageMetaCandidate,
+  type VideoPageMetaCandidates,
+  type VideoPlatform,
+  type VideoResponseKind,
+} from '@services/shared/video-capture';
 
 export type VideoTranscriptMeta = {
-  platform: 'youtube' | 'bilibili' | 'unknown';
+  platform: VideoPlatform | 'unknown';
   url: string;
   title: string;
   author: string;
+  description: string;
   durationSeconds: number | null;
   thumbnailUrl: string;
 };
@@ -22,184 +30,118 @@ export type VideoTranscriptMeta = {
 export type VideoTranscriptExtraction = {
   meta: VideoTranscriptMeta;
   cues: TranscriptCue[];
-  source: VideoTranscriptSource;
-  hasTimestamps: boolean;
+  chapters: VideoChapter[] | null;
 };
 
+type InterceptedResponse = ReturnType<typeof listVideoInterceptedResponses>[number];
+
 function normalizeText(value: unknown): string {
-  return String(value || '')
+  return String(value ?? '')
     .replace(/\r\n/g, '\n')
     .trim();
 }
 
-function isYoutubeHost(hostname: string): boolean {
-  const h = String(hostname || '').toLowerCase();
-  return h === 'www.youtube.com' || h.endsWith('.youtube.com') || h === 'youtu.be';
-}
-
-function isBilibiliHost(hostname: string): boolean {
-  const h = String(hostname || '').toLowerCase();
-  return h === 'www.bilibili.com' || h.endsWith('.bilibili.com') || h === 'bilibili.com';
-}
-
 function inferPlatform(): VideoTranscriptMeta['platform'] {
   const host = String(location.hostname || '').toLowerCase();
-  if (isYoutubeHost(host)) return 'youtube';
-  if (isBilibiliHost(host)) return 'bilibili';
+  if (host === 'www.youtube.com' || host === 'youtube.com' || host === 'youtu.be') return 'youtube';
+  if (host === 'www.bilibili.com' || host === 'bilibili.com') return 'bilibili';
   return 'unknown';
 }
 
-function fallbackTitle(): string {
-  const fromDoc = normalizeText(document.title || '');
-  if (fromDoc) return fromDoc;
-  const og = normalizeText(document.querySelector('meta[property="og:title"]')?.getAttribute('content') || '');
-  return og;
+function normalizeDuration(value: unknown): number | null {
+  if (value == null || (typeof value === 'string' && !value.trim())) return null;
+  const duration = Number(value);
+  return Number.isFinite(duration) && duration >= 0 ? duration : null;
 }
 
-function fallbackThumbnail(): string {
-  const og = normalizeText(document.querySelector('meta[property="og:image"]')?.getAttribute('content') || '');
-  return og;
-}
-
-function fallbackAuthor(): string {
-  const author = normalizeText(document.querySelector('meta[name="author"]')?.getAttribute('content') || '');
-  return author;
+function selectMetaCandidate(
+  candidates: VideoPageMetaCandidates | null,
+  currentUrl: string,
+  platform: VideoTranscriptMeta['platform'],
+): VideoPageMetaCandidate | null {
+  if (!candidates || platform === 'unknown') return null;
+  for (const candidate of [candidates.state, candidates.dom]) {
+    if (!candidate || candidate.platform !== platform) continue;
+    const identityUrl = canonicalizeVideoUrl(candidate.identityUrl);
+    if (identityUrl && identityUrl === currentUrl) return candidate;
+  }
+  return null;
 }
 
 async function collectMeta(): Promise<VideoTranscriptMeta> {
   const platform = inferPlatform();
   const href = String(location.href || '');
   const canonical = canonicalizeVideoUrl(href) || href;
-
-  const meta = await requestVideoPageMeta({ timeoutMs: 1400 });
-  const title = normalizeText(meta?.title) || fallbackTitle();
-  const author = normalizeText(meta?.author) || fallbackAuthor();
-  const durationSeconds =
-    meta?.durationSeconds != null && Number.isFinite(Number(meta.durationSeconds))
-      ? Math.max(0, Math.floor(Number(meta.durationSeconds)))
-      : null;
-  const thumbnailUrl = normalizeText(meta?.thumbnailUrl) || fallbackThumbnail();
+  const candidates = await requestVideoPageMeta();
+  const candidate = selectMetaCandidate(candidates, canonical, platform);
 
   return {
-    platform: meta?.platform === 'youtube' || meta?.platform === 'bilibili' ? meta.platform : platform,
+    platform,
     url: canonical,
-    title,
-    author,
-    durationSeconds,
-    thumbnailUrl,
+    title: normalizeText(candidate?.title),
+    author: normalizeText(candidate?.author),
+    description: normalizeText(candidate?.description),
+    durationSeconds: normalizeDuration(candidate?.durationSeconds),
+    thumbnailUrl: normalizeText(candidate?.thumbnailUrl),
   };
 }
 
-function pickLatestResponse(pred: (url: string, contentType: string, bodyText: string) => boolean) {
-  const list = listVideoInterceptedResponses();
-  const sorted = list
-    .slice()
-    .filter((r) => r && typeof r.url === 'string' && typeof r.bodyText === 'string')
-    .sort((a, b) => Number(b.at) - Number(a.at));
-  for (const item of sorted) {
-    const url = String(item.url || '');
-    const contentType = String(item.contentType || '');
-    const bodyText = String(item.bodyText || '');
-    if (pred(url, contentType, bodyText)) return item;
-  }
-  return null;
+function listCurrentResponses(currentUrl: string, kind: VideoResponseKind): InterceptedResponse[] {
+  return listVideoInterceptedResponses()
+    .filter((item) => {
+      if (!item || classifyVideoResponseUrl(item.url) !== kind) return false;
+      const pageUrl = canonicalizeVideoUrl(item.pageUrl);
+      return !!pageUrl && pageUrl === currentUrl;
+    })
+    .sort((left, right) => Number(right.at) - Number(left.at));
 }
 
-function extractYoutubeCuesFromIntercept(): TranscriptCue[] {
-  const picked = pickLatestResponse((url) => url.toLowerCase().includes('youtube.com/api/timedtext'));
-  if (!picked) return [];
-  const body = normalizeText(picked.bodyText);
+function parseYoutubeBody(bodyText: string): TranscriptCue[] {
+  const body = normalizeText(bodyText);
   if (!body) return [];
-
   if (body.startsWith('WEBVTT')) return parseWebVtt(body);
-  if (body.trim().startsWith('{')) return parseYoutubeJson3(body);
+  if (body.startsWith('{')) return parseYoutubeJson3(body);
   if (body.includes('<transcript') || body.includes('<text')) return parseYoutubeTimedtextXml(body);
   return [];
 }
 
-function extractBilibiliCuesFromIntercept(): TranscriptCue[] {
-  const list = listVideoInterceptedResponses();
-  const sorted = list
-    .slice()
-    .filter((r) => r && typeof r.url === 'string' && typeof r.bodyText === 'string')
-    .sort((a, b) => Number(b.at) - Number(a.at));
+function extractYoutubeCuesFromIntercept(currentUrl: string): TranscriptCue[] {
+  const picked = listCurrentResponses(currentUrl, 'youtube-timedtext')[0];
+  return picked ? parseYoutubeBody(picked.bodyText) : [];
+}
 
-  for (const item of sorted) {
-    const urlLower = String(item.url || '').toLowerCase();
-    if (!urlLower) continue;
-    if (!urlLower.includes('/bfs/subtitle/') && !urlLower.includes('/bfs/ai_subtitle/')) continue;
+function extractBilibiliCuesFromIntercept(currentUrl: string): TranscriptCue[] {
+  for (const item of listCurrentResponses(currentUrl, 'bilibili-subtitle')) {
     const cues = parseBilibiliSubtitleJson(String(item.bodyText || ''));
     if (cues.length) return cues;
   }
-
   return [];
 }
 
-function parseTimeToSeconds(raw: string): number | null {
-  const text = String(raw || '').trim();
-  if (!text) return null;
-  const m = text.match(/^(\d{1,2}:)?(\d{1,2}):(\d{2})$/);
-  if (!m) return null;
-  const hours = m[1] ? Number(String(m[1]).replace(':', '')) : 0;
-  const minutes = Number(m[2]);
-  const seconds = Number(m[3]);
-  if (![hours, minutes, seconds].every((x) => Number.isFinite(x))) return null;
-  return hours * 3600 + minutes * 60 + seconds;
-}
-
-function extractYoutubeCuesFromDom(): TranscriptCue[] {
-  const nodes = Array.from(document.querySelectorAll('ytd-transcript-segment-renderer')) as HTMLElement[];
-  if (!nodes.length) return [];
-
-  const cues: TranscriptCue[] = [];
-  for (const node of nodes) {
-    const ts =
-      normalizeText((node.querySelector('.segment-timestamp') as any)?.innerText || '') ||
-      normalizeText((node.querySelector('div') as any)?.innerText || '');
-    const text =
-      normalizeText((node.querySelector('.segment-text') as any)?.innerText || '') ||
-      normalizeText((node as any)?.innerText || '');
-    const start = parseTimeToSeconds(ts);
-    if (start == null) continue;
-    if (!text) continue;
-    cues.push({ start, text });
-  }
-  return cues;
-}
-
-function extractBilibiliCuesFromDom(): TranscriptCue[] {
-  const panel = document.querySelector('.bpx-player-subtitle-panel-text') as HTMLElement | null;
-  if (!panel) return [];
-  const lines = Array.from(panel.querySelectorAll('*'))
-    .map((el) => normalizeText((el as any)?.innerText || ''))
-    .filter(Boolean);
-  const unique = Array.from(new Set(lines));
-  return unique.map((text, idx) => ({ start: idx, text }));
+function extractBilibiliChaptersFromIntercept(currentUrl: string): VideoChapter[] | null {
+  const picked = listCurrentResponses(currentUrl, 'bilibili-chapters')[0];
+  if (!picked) return null;
+  return parseBilibiliViewPointsJson(String(picked.bodyText || ''));
 }
 
 export async function extractVideoTranscriptFromCurrentPage(): Promise<VideoTranscriptExtraction> {
   const meta = await collectMeta();
 
-  if (meta.platform !== 'youtube' && meta.platform !== 'bilibili') {
+  if (meta.platform === 'youtube') {
     return {
       meta,
-      cues: [],
-      source: 'C',
-      hasTimestamps: false,
+      cues: extractYoutubeCuesFromIntercept(meta.url),
+      chapters: null,
     };
   }
 
-  if (meta.platform === 'youtube') {
-    const cues = extractYoutubeCuesFromIntercept();
-    if (cues.length) return { meta, cues, source: 'A', hasTimestamps: true };
-    const dom = extractYoutubeCuesFromDom();
-    if (dom.length) return { meta, cues: dom, source: 'B', hasTimestamps: true };
-    return { meta, cues: [], source: 'C', hasTimestamps: false };
+  if (meta.platform === 'bilibili') {
+    return {
+      meta,
+      cues: extractBilibiliCuesFromIntercept(meta.url),
+      chapters: extractBilibiliChaptersFromIntercept(meta.url),
+    };
   }
 
-  const cues = extractBilibiliCuesFromIntercept();
-  if (cues.length) return { meta, cues, source: 'A', hasTimestamps: true };
-  const dom = extractBilibiliCuesFromDom();
-  if (dom.length) return { meta, cues: dom, source: 'B', hasTimestamps: false };
-  return { meta, cues: [], source: 'C', hasTimestamps: false };
+  return { meta, cues: [], chapters: null };
 }

--- a/src/collectors/video/video-transcript-parse.ts
+++ b/src/collectors/video/video-transcript-parse.ts
@@ -1,3 +1,5 @@
+import type { VideoChapter } from '@services/shared/video-capture';
+
 export type TranscriptCue = {
   start: number;
   end?: number;
@@ -8,6 +10,14 @@ function normalizeText(value: unknown): string {
   return String(value || '')
     .replace(/\r\n/g, '\n')
     .trim();
+}
+
+function readNonNegativeNumber(value: unknown): number | null {
+  if (value == null) return null;
+  const text = typeof value === 'string' ? value.trim() : value;
+  if (text === '') return null;
+  const number = Number(text);
+  return Number.isFinite(number) && number >= 0 ? number : null;
 }
 
 function decodeHtmlEntities(input: string): string {
@@ -81,7 +91,7 @@ export function parseWebVtt(text: string): TranscriptCue[] {
 
     const joined = normalizeText(texts.join('\n').replace(/<[^>]+>/g, ''));
     if (!joined) continue;
-    cues.push({ start, ...(end != null ? { end } : null), text: joined });
+    cues.push({ start, ...(end != null && end >= start ? { end } : null), text: joined });
   }
 
   return cues;
@@ -91,16 +101,21 @@ export function parseYoutubeTimedtextXml(text: string): TranscriptCue[] {
   const src = normalizeText(text);
   if (!src) return [];
   const cues: TranscriptCue[] = [];
-  const re = /<text\b[^>]*\bstart="([^"]+)"[^>]*?(?:\bdur="([^"]+)")?[^>]*>([\s\S]*?)<\/text>/gim;
+  const re = /<text\b([^>]*)>([\s\S]*?)<\/text>/gim;
+  const readAttribute = (attributes: string, name: string) => {
+    const match = attributes.match(new RegExp(`\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`, 'i'));
+    return match ? (match[1] ?? match[2] ?? '') : null;
+  };
+
   for (;;) {
-    const m = re.exec(src);
-    if (!m) break;
-    const start = Number(m[1]);
-    const dur = m[2] != null ? Number(m[2]) : NaN;
-    if (!Number.isFinite(start)) continue;
-    const end = Number.isFinite(dur) ? start + dur : undefined;
+    const match = re.exec(src);
+    if (!match) break;
+    const start = readNonNegativeNumber(readAttribute(match[1] || '', 'start'));
+    if (start == null) continue;
+    const duration = readNonNegativeNumber(readAttribute(match[1] || '', 'dur'));
+    const end = duration == null ? undefined : start + duration;
     const raw = decodeHtmlEntities(
-      String(m[3] || '')
+      String(match[2] || '')
         .replace(/\s+/g, ' ')
         .trim(),
     );
@@ -119,11 +134,11 @@ export function parseYoutubeJson3(text: string): TranscriptCue[] {
     const events = Array.isArray(json?.events) ? json.events : [];
     const out: TranscriptCue[] = [];
     for (const ev of events) {
-      const tStartMs = Number(ev?.tStartMs);
-      const dDurationMs = Number(ev?.dDurationMs);
-      if (!Number.isFinite(tStartMs)) continue;
+      const tStartMs = readNonNegativeNumber(ev?.tStartMs);
+      const dDurationMs = readNonNegativeNumber(ev?.dDurationMs);
+      if (tStartMs == null) continue;
       const start = tStartMs / 1000;
-      const end = Number.isFinite(dDurationMs) ? start + dDurationMs / 1000 : undefined;
+      const end = dDurationMs == null ? undefined : start + dDurationMs / 1000;
       const segs = Array.isArray(ev?.segs) ? ev.segs : [];
       const text = normalizeText(
         segs
@@ -145,22 +160,42 @@ export function parseBilibiliSubtitleJson(text: string): TranscriptCue[] {
   if (!src) return [];
   try {
     const json: any = JSON.parse(src);
-    const body =
-      (Array.isArray(json?.body) ? json.body : null) ??
-      (Array.isArray(json?.data?.body) ? json.data.body : null) ??
-      (Array.isArray(json?.result?.body) ? json.result.body : null) ??
-      (Array.isArray(json?.subtitle?.body) ? json.subtitle.body : null) ??
-      [];
+    const body = Array.isArray(json?.body) ? json.body : [];
     const out: TranscriptCue[] = [];
     for (const item of body) {
-      const start = Number(item?.from);
-      const end = Number(item?.to);
-      const content = normalizeText(String(item?.content || ''));
-      if (!Number.isFinite(start) || !content) continue;
-      out.push({ start, ...(Number.isFinite(end) ? { end } : null), text: content });
+      const start = readNonNegativeNumber(item?.from);
+      const end = readNonNegativeNumber(item?.to);
+      const content = normalizeText(item?.content);
+      if (start == null || !content) continue;
+      out.push({ start, ...(end != null && end >= start ? { end } : null), text: content });
     }
     return out;
   } catch (_e) {
     return [];
+  }
+}
+
+export function parseBilibiliViewPointsJson(text: string): VideoChapter[] | null {
+  const src = normalizeText(text);
+  if (!src) return null;
+  try {
+    const json: any = JSON.parse(src);
+    if (Number(json?.code) !== 0 || !Array.isArray(json?.data?.view_points)) return null;
+
+    const chapters: VideoChapter[] = [];
+    for (const item of json.data.view_points) {
+      const title = normalizeText(item?.content).replace(/\s+/g, ' ');
+      const startSeconds = readNonNegativeNumber(item?.from);
+      const end = readNonNegativeNumber(item?.to);
+      if (!title || startSeconds == null) continue;
+      chapters.push({
+        title,
+        startSeconds,
+        endSeconds: end != null && end >= startSeconds ? end : null,
+      });
+    }
+    return chapters;
+  } catch (_error) {
+    return null;
   }
 }

--- a/src/collectors/video/video-transcript-parse.ts
+++ b/src/collectors/video/video-transcript-parse.ts
@@ -180,7 +180,7 @@ export function parseBilibiliViewPointsJson(text: string): VideoChapter[] | null
   if (!src) return null;
   try {
     const json: any = JSON.parse(src);
-    if (Number(json?.code) !== 0 || !Array.isArray(json?.data?.view_points)) return null;
+    if (typeof json?.code !== 'number' || json.code !== 0 || !Array.isArray(json?.data?.view_points)) return null;
 
     const chapters: VideoChapter[] = [];
     for (const item of json.data.view_points) {

--- a/src/entrypoints/video-transcript-bridge.content.ts
+++ b/src/entrypoints/video-transcript-bridge.content.ts
@@ -1,15 +1,15 @@
+import { classifyVideoResponseUrl } from '@services/shared/video-capture';
+
 type StoreResponse = {
   url: string;
+  pageUrl: string;
   contentType?: string;
   bodyText: string;
   at: number;
 };
 
-type StoreMetaByRequestId = Record<string, any>;
-
 type VideoTranscriptBridgeStore = {
   responses: StoreResponse[];
-  metaByRequestId: StoreMetaByRequestId;
 };
 
 const STORE_KEY = '__SYNCNOS_VIDEO_TRANSCRIPT_BRIDGE__';
@@ -19,72 +19,47 @@ const MAX_BODY_CHARS = 2_000_000;
 function getStore(): VideoTranscriptBridgeStore {
   const anyGlobal = globalThis as any;
   const existing = anyGlobal[STORE_KEY] as VideoTranscriptBridgeStore | undefined;
-  if (
-    existing &&
-    Array.isArray(existing.responses) &&
-    existing.metaByRequestId &&
-    typeof existing.metaByRequestId === 'object'
-  ) {
-    return existing;
-  }
-  const created: VideoTranscriptBridgeStore = { responses: [], metaByRequestId: {} };
+  if (existing && Array.isArray(existing.responses)) return existing;
+  const created: VideoTranscriptBridgeStore = { responses: [] };
   anyGlobal[STORE_KEY] = created;
   return created;
 }
 
-function safeSliceBody(text: string): string {
-  const value = String(text || '');
-  if (value.length <= MAX_BODY_CHARS) return value;
-  return value.slice(0, MAX_BODY_CHARS);
-}
-
 function pushResponse(store: VideoTranscriptBridgeStore, next: StoreResponse) {
   const url = String(next?.url || '').trim();
+  const pageUrl = String(next?.pageUrl || '').trim();
   const bodyText = String(next?.bodyText || '');
-  if (!url || !bodyText) return;
-  const item: StoreResponse = {
+  if (!classifyVideoResponseUrl(url) || !pageUrl || !bodyText || bodyText.length > MAX_BODY_CHARS) return;
+
+  store.responses.push({
     url,
+    pageUrl,
     contentType: next?.contentType ? String(next.contentType) : undefined,
-    bodyText: safeSliceBody(bodyText),
+    bodyText,
     at: Number(next?.at) || Date.now(),
-  };
-  store.responses.push(item);
+  });
   if (store.responses.length > MAX_RESPONSES) {
     store.responses.splice(0, store.responses.length - MAX_RESPONSES);
   }
 }
 
 export default defineContentScript({
-  matches: [
-    'https://www.youtube.com/watch*',
-    'https://youtu.be/*',
-    'https://www.bilibili.com/video/*',
-    'https://bilibili.com/video/*',
-  ],
+  matches: ['https://www.youtube.com/*', 'https://youtu.be/*', 'https://www.bilibili.com/*', 'https://bilibili.com/*'],
   runAt: 'document_start',
   main() {
     const store = getStore();
 
     window.addEventListener('message', (event: MessageEvent) => {
       if (event.source !== window) return;
-      const data: any = (event as any)?.data;
-      if (!data || data.__syncnos !== true) return;
-
-      if (data.type === 'SYNCNOS_VIDEO_INTERCEPTED') {
-        pushResponse(store, {
-          url: String(data.url || ''),
-          contentType: data.contentType ? String(data.contentType) : undefined,
-          bodyText: String(data.bodyText || ''),
-          at: Number(data.at) || Date.now(),
-        });
-        return;
-      }
-
-      if (data.type === 'SYNCNOS_VIDEO_META_RESPONSE') {
-        const requestId = String(data.requestId || '').trim();
-        if (!requestId) return;
-        store.metaByRequestId[requestId] = data.meta ?? null;
-      }
+      const data: any = event.data;
+      if (!data || data.__syncnos !== true || data.type !== 'SYNCNOS_VIDEO_INTERCEPTED') return;
+      pushResponse(store, {
+        url: String(data.url || ''),
+        pageUrl: String(data.pageUrl || ''),
+        contentType: data.contentType ? String(data.contentType) : undefined,
+        bodyText: String(data.bodyText || ''),
+        at: Number(data.at) || Date.now(),
+      });
     });
   },
 });

--- a/src/entrypoints/video-transcript-interceptor.content.ts
+++ b/src/entrypoints/video-transcript-interceptor.content.ts
@@ -1,7 +1,15 @@
+import { canonicalizeVideoUrl } from '@services/url-cleaning/video-url';
+import {
+  classifyVideoResponseUrl,
+  type VideoPageMetaCandidate,
+  type VideoPageMetaCandidates,
+} from '@services/shared/video-capture';
+
 type InterceptedResponsePayload = {
   __syncnos: true;
   type: 'SYNCNOS_VIDEO_INTERCEPTED';
   url: string;
+  pageUrl: string;
   contentType?: string;
   bodyText: string;
   at: number;
@@ -17,40 +25,34 @@ type MetaResponsePayload = {
   __syncnos: true;
   type: 'SYNCNOS_VIDEO_META_RESPONSE';
   requestId: string;
-  meta: any;
+  meta: VideoPageMetaCandidates;
 };
 
-const MAX_BODY_CHARS = 2_000_000;
-
-function normalizeUrl(raw: unknown): string {
-  return String(raw || '').trim();
+function normalizeText(value: unknown): string {
+  return String(value ?? '')
+    .replace(/\r\n/g, '\n')
+    .trim();
 }
 
-function isYoutubeHost(hostname: string): boolean {
-  const h = String(hostname || '').toLowerCase();
-  return h === 'www.youtube.com' || h.endsWith('.youtube.com') || h === 'youtu.be';
+function normalizeDuration(value: unknown): number | null {
+  if (value == null || (typeof value === 'string' && !value.trim())) return null;
+  const duration = Number(value);
+  return Number.isFinite(duration) && duration >= 0 ? duration : null;
 }
 
-function isBilibiliHost(hostname: string): boolean {
-  const h = String(hostname || '').toLowerCase();
-  return h === 'www.bilibili.com' || h.endsWith('.bilibili.com') || h === 'bilibili.com';
+function parseContentType(value: unknown): string {
+  return String(value || '').trim();
 }
 
-function shouldInterceptUrl(raw: string): boolean {
-  const url = normalizeUrl(raw);
-  if (!url) return false;
-  const lower = url.toLowerCase();
-  if (lower.includes('youtube.com/api/timedtext')) return true;
-  if (lower.includes('/bfs/ai_subtitle/')) return true;
-  if (lower.includes('hdslb.com/bfs/subtitle/') && lower.includes('.json')) return true;
-  if (lower.includes('api.bilibili.com/x/player/wbi/v2')) return true;
-  return false;
-}
-
-function safeSliceBody(text: string): string {
-  const value = String(text || '');
-  if (value.length <= MAX_BODY_CHARS) return value;
-  return value.slice(0, MAX_BODY_CHARS);
+function resolveAbsoluteUrl(raw: unknown): string {
+  const source = typeof raw === 'object' && raw && 'url' in raw ? (raw as { url?: unknown }).url : raw;
+  const text = String(source ?? '').trim();
+  if (!text) return '';
+  try {
+    return new URL(text, document.baseURI || location.href).toString();
+  } catch (_error) {
+    return '';
+  }
 }
 
 function postIntercept(payload: Omit<InterceptedResponsePayload, '__syncnos' | 'type'>) {
@@ -68,63 +70,97 @@ function postIntercept(payload: Omit<InterceptedResponsePayload, '__syncnos' | '
   }
 }
 
-function parseContentType(value: unknown): string {
-  return String(value || '').trim();
-}
-
-function collectYoutubeMeta() {
+function collectYoutubeStateCandidate(): VideoPageMetaCandidate | null {
   try {
-    const pr: any = (window as any).ytInitialPlayerResponse;
-    const details = pr?.videoDetails || null;
-    const title = String(details?.title || '').trim();
-    const author = String(details?.author || '').trim();
-    const lengthSeconds = Number(details?.lengthSeconds);
-    const durationSeconds = Number.isFinite(lengthSeconds) ? Math.max(0, Math.floor(lengthSeconds)) : null;
+    const details: any = (window as any).ytInitialPlayerResponse?.videoDetails || null;
+    const videoId = normalizeText(details?.videoId);
+    if (!videoId) return null;
+    const identityUrl = canonicalizeVideoUrl(`https://www.youtube.com/watch?v=${encodeURIComponent(videoId)}`);
+    if (!identityUrl) return null;
 
     const thumbs = Array.isArray(details?.thumbnail?.thumbnails) ? details.thumbnail.thumbnails : [];
     const bestThumb = thumbs.length ? thumbs[thumbs.length - 1] : null;
-    const thumbnailUrl = bestThumb?.url ? String(bestThumb.url) : '';
-
     return {
       platform: 'youtube',
-      title,
-      author,
-      durationSeconds,
-      thumbnailUrl,
+      identityUrl,
+      title: normalizeText(details?.title),
+      author: normalizeText(details?.author),
+      description: normalizeText(details?.shortDescription),
+      durationSeconds: normalizeDuration(details?.lengthSeconds),
+      thumbnailUrl: normalizeText(bestThumb?.url),
     };
-  } catch (_e) {
+  } catch (_error) {
     return null;
   }
 }
 
-function collectBilibiliMeta() {
+function bilibiliIdentityFromState(bvid: string): string {
   try {
-    const state: any = (window as any).__INITIAL_STATE__;
-    const videoData = state?.videoData || null;
-    const title = String(videoData?.title || '').trim();
-    const author = String(videoData?.owner?.name || '').trim();
-    const durationSeconds = Number.isFinite(Number(videoData?.duration))
-      ? Math.max(0, Math.floor(Number(videoData.duration)))
-      : null;
-    const thumbnailUrl = String(videoData?.pic || '').trim();
+    const candidate = new URL(`https://www.bilibili.com/video/${bvid}/`);
+    const current = new URL(location.href);
+    const p = String(current.searchParams.get('p') || '').trim();
+    if (p) candidate.searchParams.set('p', p);
+    return canonicalizeVideoUrl(candidate.toString());
+  } catch (_error) {
+    return '';
+  }
+}
+
+function collectBilibiliStateCandidate(): VideoPageMetaCandidate | null {
+  try {
+    const videoData: any = (window as any).__INITIAL_STATE__?.videoData || null;
+    const bvid = normalizeText(videoData?.bvid);
+    if (!bvid) return null;
+    const identityUrl = bilibiliIdentityFromState(bvid);
+    if (!identityUrl) return null;
+
+    const desc = normalizeText(videoData?.desc);
+    const descV2 = Array.isArray(videoData?.desc_v2)
+      ? videoData.desc_v2
+          .map((item: any) => normalizeText(item?.raw_text))
+          .filter(Boolean)
+          .join('\n')
+      : '';
 
     return {
       platform: 'bilibili',
-      title,
-      author,
-      durationSeconds,
-      thumbnailUrl,
+      identityUrl,
+      title: normalizeText(videoData?.title),
+      author: normalizeText(videoData?.owner?.name),
+      description: desc || descV2,
+      durationSeconds: normalizeDuration(videoData?.duration),
+      thumbnailUrl: normalizeText(videoData?.pic),
     };
-  } catch (_e) {
+  } catch (_error) {
     return null;
   }
 }
 
-function collectMetaForPage() {
+function collectBilibiliDomCandidate(): VideoPageMetaCandidate | null {
+  try {
+    const identityUrl = canonicalizeVideoUrl(document.querySelector('link[rel="canonical"]')?.getAttribute('href'));
+    if (!identityUrl) return null;
+    return {
+      platform: 'bilibili',
+      identityUrl,
+      title: normalizeText((document.querySelector('h1.video-title') as HTMLElement | null)?.innerText),
+      author: normalizeText((document.querySelector('a.up-name') as HTMLElement | null)?.innerText),
+      description: normalizeText((document.querySelector('.desc-info-text') as HTMLElement | null)?.innerText),
+    };
+  } catch (_error) {
+    return null;
+  }
+}
+
+function collectMetaForPage(): VideoPageMetaCandidates {
   const host = String(location.hostname || '').toLowerCase();
-  if (isYoutubeHost(host)) return collectYoutubeMeta();
-  if (isBilibiliHost(host)) return collectBilibiliMeta();
-  return null;
+  if (host === 'www.youtube.com' || host === 'youtube.com' || host === 'youtu.be') {
+    return { state: collectYoutubeStateCandidate(), dom: null };
+  }
+  if (host === 'www.bilibili.com' || host === 'bilibili.com') {
+    return { state: collectBilibiliStateCandidate(), dom: collectBilibiliDomCandidate() };
+  }
+  return { state: null, dom: null };
 }
 
 function wrapFetch() {
@@ -132,26 +168,53 @@ function wrapFetch() {
   if (typeof original !== 'function') return;
 
   (globalThis as any).fetch = async function (...args: any[]) {
-    const res = await original.apply(this, args);
+    const pageUrl = String(location.href || '');
+    const response = await original.apply(this, args);
     try {
-      const url = normalizeUrl(res?.url || args?.[0]);
-      if (!shouldInterceptUrl(url)) return res;
-
-      const cloned = res?.clone?.();
-      if (!cloned || typeof cloned.text !== 'function') return res;
-      const contentType = parseContentType(cloned?.headers?.get?.('content-type') || '');
-      const bodyText = safeSliceBody(await cloned.text());
-      postIntercept({ url, contentType, bodyText, at: Date.now() });
-    } catch (_e) {
+      const url = resolveAbsoluteUrl(response?.url || args?.[0]);
+      if (!classifyVideoResponseUrl(url)) return response;
+      const cloned = response?.clone?.();
+      if (!cloned || typeof cloned.text !== 'function') return response;
+      const bodyText = String(await cloned.text());
+      if (!bodyText) return response;
+      postIntercept({
+        url,
+        pageUrl,
+        contentType: parseContentType(cloned?.headers?.get?.('content-type')),
+        bodyText,
+        at: Date.now(),
+      });
+    } catch (_error) {
       // ignore
     }
-    return res;
+    return response;
   };
+}
+
+function readXhrBody(xhr: any): string {
+  const responseType = String(xhr?.responseType || '');
+  if (!responseType || responseType === 'text') return String(xhr?.responseText || '');
+  if (responseType === 'json') {
+    if (xhr?.response == null) return '';
+    try {
+      return JSON.stringify(xhr.response);
+    } catch (_error) {
+      return '';
+    }
+  }
+  if (responseType === 'arraybuffer' && xhr?.response && typeof xhr.response.byteLength === 'number') {
+    try {
+      return typeof TextDecoder === 'function' ? new TextDecoder('utf-8').decode(xhr.response) : '';
+    } catch (_error) {
+      return '';
+    }
+  }
+  return '';
 }
 
 function wrapXhr() {
   const Xhr = (globalThis as any).XMLHttpRequest;
-  if (!Xhr || !Xhr.prototype) return;
+  if (!Xhr?.prototype) return;
 
   const originalOpen = Xhr.prototype.open;
   const originalSend = Xhr.prototype.send;
@@ -159,8 +222,8 @@ function wrapXhr() {
 
   Xhr.prototype.open = function (...args: any[]) {
     try {
-      (this as any).__syncnos_url = String(args?.[1] || '');
-    } catch (_e) {
+      (this as any).__syncnos_url = resolveAbsoluteUrl(args?.[1]);
+    } catch (_error) {
       // ignore
     }
     return originalOpen.apply(this, args);
@@ -168,43 +231,30 @@ function wrapXhr() {
 
   Xhr.prototype.send = function (...args: any[]) {
     try {
-      const url = normalizeUrl((this as any).__syncnos_url || '');
-      if (shouldInterceptUrl(url)) {
+      const url = String((this as any).__syncnos_url || '');
+      if (classifyVideoResponseUrl(url)) {
+        const pageUrl = String(location.href || '');
         this.addEventListener(
           'load',
           () => {
             try {
-              const contentType = parseContentType((this as any).getResponseHeader?.('content-type') || '');
-              let bodyText = safeSliceBody(String((this as any).responseText || ''));
-              if (!bodyText) {
-                const responseType = String((this as any).responseType || '');
-                const response = (this as any).response;
-                if (responseType === 'json' && response != null) {
-                  try {
-                    bodyText = safeSliceBody(JSON.stringify(response));
-                  } catch (_e) {
-                    // ignore
-                  }
-                } else if (responseType === 'arraybuffer' && response && typeof response.byteLength === 'number') {
-                  try {
-                    if (typeof TextDecoder === 'function') {
-                      bodyText = safeSliceBody(new TextDecoder('utf-8').decode(response));
-                    }
-                  } catch (_e) {
-                    // ignore
-                  }
-                }
-              }
+              const bodyText = readXhrBody(this);
               if (!bodyText) return;
-              postIntercept({ url, contentType, bodyText, at: Date.now() });
-            } catch (_e) {
+              postIntercept({
+                url,
+                pageUrl,
+                contentType: parseContentType((this as any).getResponseHeader?.('content-type')),
+                bodyText,
+                at: Date.now(),
+              });
+            } catch (_error) {
               // ignore
             }
           },
           { once: true } as any,
         );
       }
-    } catch (_e) {
+    } catch (_error) {
       // ignore
     }
     return originalSend.apply(this, args);
@@ -212,12 +262,7 @@ function wrapXhr() {
 }
 
 export default defineContentScript({
-  matches: [
-    'https://www.youtube.com/watch*',
-    'https://youtu.be/*',
-    'https://www.bilibili.com/video/*',
-    'https://bilibili.com/video/*',
-  ],
+  matches: ['https://www.youtube.com/*', 'https://youtu.be/*', 'https://www.bilibili.com/*', 'https://bilibili.com/*'],
   runAt: 'document_start',
   world: 'MAIN',
   main() {
@@ -226,24 +271,22 @@ export default defineContentScript({
 
     window.addEventListener('message', (event: MessageEvent) => {
       if (event.source !== window) return;
-      const data: any = (event as any)?.data;
-      if (!data || data.__syncnos !== true) return;
-      if (data.type !== 'SYNCNOS_VIDEO_META_REQUEST') return;
+      const data: any = event.data;
+      if (!data || data.__syncnos !== true || data.type !== 'SYNCNOS_VIDEO_META_REQUEST') return;
       const requestId = String((data as MetaRequestPayload).requestId || '').trim();
       if (!requestId) return;
 
       try {
-        const meta = collectMetaForPage();
         window.postMessage(
           {
             __syncnos: true,
             type: 'SYNCNOS_VIDEO_META_RESPONSE',
             requestId,
-            meta: meta || null,
+            meta: collectMetaForPage(),
           } satisfies MetaResponsePayload,
           '*',
         );
-      } catch (_e) {
+      } catch (_error) {
         // ignore
       }
     });

--- a/src/services/bootstrap/video-transcript-capture.ts
+++ b/src/services/bootstrap/video-transcript-capture.ts
@@ -19,7 +19,7 @@ function toError(message: unknown) {
   return new Error(String(message || 'unknown error'));
 }
 
-function formatTranscriptMarkdown(cues: Array<{ start: number; text: string }>, hasTimestamps: boolean): string {
+function formatTranscriptMarkdown(cues: Array<{ start: number; text: string }>): string {
   const lines: string[] = [];
   const pad2 = (n: number) => String(Math.max(0, Math.floor(n))).padStart(2, '0');
   const fmt = (sec: number) => {
@@ -33,11 +33,8 @@ function formatTranscriptMarkdown(cues: Array<{ start: number; text: string }>, 
   for (const cue of cues || []) {
     const text = normalizeText((cue as any)?.text || '');
     if (!text) continue;
-    if (hasTimestamps && Number.isFinite(Number((cue as any)?.start))) {
-      lines.push(`${fmt(Number((cue as any).start))} ${text}`);
-    } else {
-      lines.push(text);
-    }
+    if (!Number.isFinite(Number((cue as any)?.start))) continue;
+    lines.push(`${fmt(Number((cue as any).start))} ${text}`);
   }
 
   return normalizeText(lines.join('\n'));
@@ -73,7 +70,7 @@ export function createVideoTranscriptCaptureService(deps: { runtime: RuntimeClie
     const thumbnailUrl = normalizeText(extracted?.meta?.thumbnailUrl || '');
 
     const cues = Array.isArray(extracted?.cues) ? extracted.cues : [];
-    const transcriptMarkdown = formatTranscriptMarkdown(cues, extracted?.hasTimestamps === true);
+    const transcriptMarkdown = formatTranscriptMarkdown(cues);
     const subtitleStatus: 'ok' | 'empty' = transcriptMarkdown ? 'ok' : 'empty';
 
     if (subtitleStatus === 'empty') {
@@ -99,8 +96,6 @@ export function createVideoTranscriptCaptureService(deps: { runtime: RuntimeClie
         platform,
         durationSeconds,
         thumbnailUrl,
-        transcriptSource: extracted?.source || 'C',
-        hasTimestamps: extracted?.hasTimestamps === true,
       },
     });
     if (!conversationRes?.ok) {

--- a/src/services/bootstrap/video-transcript-capture.ts
+++ b/src/services/bootstrap/video-transcript-capture.ts
@@ -1,13 +1,14 @@
 import { extractVideoTranscriptFromCurrentPage } from '@collectors/video/video-transcript-extract';
+import {
+  formatVideoTranscriptMarkdown,
+  normalizeCanonicalVideoChapters,
+  toCanonicalVideoTranscriptCues,
+} from '@services/conversations/domain/video-content';
+import { CORE_MESSAGE_TYPES } from '@platform/messaging/message-contracts';
 
 type RuntimeClient = {
   send?: (type: string, payload?: Record<string, unknown>) => Promise<any>;
 };
-
-const CORE_MESSAGE_TYPES = Object.freeze({
-  UPSERT_CONVERSATION: 'upsertConversation',
-  SYNC_CONVERSATION_MESSAGES: 'syncConversationMessages',
-});
 
 function normalizeText(text: unknown) {
   return String(text || '')
@@ -17,27 +18,6 @@ function normalizeText(text: unknown) {
 
 function toError(message: unknown) {
   return new Error(String(message || 'unknown error'));
-}
-
-function formatTranscriptMarkdown(cues: Array<{ start: number; text: string }>): string {
-  const lines: string[] = [];
-  const pad2 = (n: number) => String(Math.max(0, Math.floor(n))).padStart(2, '0');
-  const fmt = (sec: number) => {
-    const s = Math.max(0, Number(sec) || 0);
-    const h = Math.floor(s / 3600);
-    const m = Math.floor((s % 3600) / 60);
-    const r = Math.floor(s % 60);
-    return h > 0 ? `${pad2(h)}:${pad2(m)}:${pad2(r)}` : `${pad2(m)}:${pad2(r)}`;
-  };
-
-  for (const cue of cues || []) {
-    const text = normalizeText((cue as any)?.text || '');
-    if (!text) continue;
-    if (!Number.isFinite(Number((cue as any)?.start))) continue;
-    lines.push(`${fmt(Number((cue as any).start))} ${text}`);
-  }
-
-  return normalizeText(lines.join('\n'));
 }
 
 export function createVideoTranscriptCaptureService(deps: { runtime: RuntimeClient | null }) {
@@ -65,12 +45,13 @@ export function createVideoTranscriptCaptureService(deps: { runtime: RuntimeClie
     const platform = normalizeText(extracted?.meta?.platform || '');
     const durationSeconds =
       extracted?.meta?.durationSeconds != null && Number.isFinite(Number(extracted.meta.durationSeconds))
-        ? Math.max(0, Math.floor(Number(extracted.meta.durationSeconds)))
+        ? Math.max(0, Number(extracted.meta.durationSeconds))
         : null;
     const thumbnailUrl = normalizeText(extracted?.meta?.thumbnailUrl || '');
+    const videoDescription = normalizeText(extracted?.meta?.description || '');
 
-    const cues = Array.isArray(extracted?.cues) ? extracted.cues : [];
-    const transcriptMarkdown = formatTranscriptMarkdown(cues);
+    const transcriptCues = toCanonicalVideoTranscriptCues(Array.isArray(extracted?.cues) ? extracted.cues : []);
+    const transcriptMarkdown = formatVideoTranscriptMarkdown(transcriptCues);
     const subtitleStatus: 'ok' | 'empty' = transcriptMarkdown ? 'ok' : 'empty';
 
     if (subtitleStatus === 'empty') {
@@ -90,12 +71,11 @@ export function createVideoTranscriptCaptureService(deps: { runtime: RuntimeClie
         title,
         url,
         author,
-        publishedAt: '',
-        warningFlags: [],
         lastActivityAt: 0,
         platform,
         durationSeconds,
         thumbnailUrl,
+        videoDescription,
       },
     });
     if (!conversationRes?.ok) {
@@ -105,15 +85,18 @@ export function createVideoTranscriptCaptureService(deps: { runtime: RuntimeClie
     const conversationId = Number((conversation as any)?.id);
     if (!Number.isFinite(conversationId) || conversationId <= 0) throw toError('invalid conversation id');
 
-    const messages = [
-      {
-        messageKey: 'video_transcript',
-        role: 'transcript',
-        contentMarkdown: transcriptMarkdown,
-        sequence: 1,
-        updatedAt: activityAt,
-      },
-    ];
+    const message: Record<string, unknown> = {
+      messageKey: 'video_transcript',
+      role: 'transcript',
+      contentMarkdown: transcriptMarkdown,
+      transcriptCues,
+      sequence: 1,
+      updatedAt: activityAt,
+    };
+    if (extracted?.chapters !== null) {
+      message.videoChapters = normalizeCanonicalVideoChapters(extracted?.chapters);
+    }
+    const messages = [message];
 
     const messagesRes = await send(CORE_MESSAGE_TYPES.SYNC_CONVERSATION_MESSAGES, {
       conversationId: conversation.id,

--- a/src/services/conversations/data/storage-idb.ts
+++ b/src/services/conversations/data/storage-idb.ts
@@ -1,5 +1,9 @@
 import type { Conversation, ConversationMessage } from '@services/conversations/domain/models';
 import {
+  normalizeCanonicalVideoChapters,
+  normalizeCanonicalVideoTranscriptCues,
+} from '@services/conversations/domain/video-content';
+import {
   hasReusableImageCachePayload,
   reusableImageCacheByteSize,
 } from '@services/conversations/data/image-cache-record';
@@ -155,6 +159,41 @@ function messageRecordsEquivalent(left: unknown, right: unknown): boolean {
   delete leftRecord.id;
   delete rightRecord.id;
   return storedValueEqual(leftRecord, rightRecord);
+}
+
+function buildConversationMessageRecord(input: {
+  conversationId: number;
+  message: any;
+  existing?: any;
+  contentMarkdown: string;
+  authorName: string;
+  sequence: number;
+  timestamp: ResolvedMessageTimestamp;
+}) {
+  const { conversationId, message, existing, contentMarkdown, authorName, sequence, timestamp } = input;
+  const messageKey = String(message?.messageKey || '');
+  const baseRecord: Record<string, unknown> = {
+    conversationId,
+    messageKey,
+    role: message?.role || 'assistant',
+    authorName: authorName || (existing ? existing.authorName || '' : ''),
+    contentMarkdown,
+    sequence,
+    ...(timestamp.present ? { updatedAt: timestamp.value } : null),
+  };
+
+  if (messageKey === 'video_transcript') {
+    if (Object.prototype.hasOwnProperty.call(message, 'transcriptCues') && message.transcriptCues !== undefined) {
+      baseRecord.transcriptCues = normalizeCanonicalVideoTranscriptCues(message.transcriptCues);
+    }
+    if (Object.prototype.hasOwnProperty.call(message, 'videoChapters') && message.videoChapters !== undefined) {
+      baseRecord.videoChapters = normalizeCanonicalVideoChapters(message.videoChapters);
+    } else if (existing && Object.prototype.hasOwnProperty.call(existing, 'videoChapters')) {
+      baseRecord.videoChapters = normalizeCanonicalVideoChapters(existing.videoChapters);
+    }
+  }
+
+  return withOptionalId(existing && existing.id, baseRecord);
 }
 
 function normalizeListKey(value: unknown, fallback: string): string {
@@ -484,7 +523,7 @@ export async function upsertConversation(payload: any): Promise<Conversation & {
         : requestedActivityAt;
       const existingBase = existing && typeof existing === 'object' ? { ...existing } : {};
       delete existingBase.id;
-      const baseRecord = normalizeConversationListRecord({
+      const baseRecord: any = normalizeConversationListRecord({
         ...existingBase,
         sourceType: nextSourceType,
         source: nextSource,
@@ -502,6 +541,44 @@ export async function upsertConversation(payload: any): Promise<Conversation & {
         feishuDocId: payload.feishuDocId || (existing ? existing.feishuDocId || '' : ''),
         lastActivityAt: nextLastActivityAt,
       });
+
+      delete baseRecord.transcriptSource;
+      delete baseRecord.hasTimestamps;
+      if (safeString(nextSourceType).toLowerCase() === 'video') {
+        const incomingPlatform = safeString(payload.platform).toLowerCase();
+        const existingPlatform = safeString(existing?.platform).toLowerCase();
+        const platform =
+          incomingPlatform === 'youtube' || incomingPlatform === 'bilibili'
+            ? incomingPlatform
+            : existingPlatform === 'youtube' || existingPlatform === 'bilibili'
+              ? existingPlatform
+              : '';
+        if (platform) baseRecord.platform = platform;
+        else delete baseRecord.platform;
+
+        const incomingDuration = Number(payload.durationSeconds);
+        const existingDuration = Number(existing?.durationSeconds);
+        const durationSeconds =
+          payload.durationSeconds != null && Number.isFinite(incomingDuration) && incomingDuration >= 0
+            ? incomingDuration
+            : existing?.durationSeconds != null && Number.isFinite(existingDuration) && existingDuration >= 0
+              ? existingDuration
+              : null;
+        baseRecord.durationSeconds = durationSeconds;
+
+        const incomingThumbnail = safeString(payload.thumbnailUrl);
+        const existingThumbnail = safeString(existing?.thumbnailUrl);
+        baseRecord.thumbnailUrl = incomingThumbnail || existingThumbnail;
+
+        const incomingDescription = safeString(payload.videoDescription);
+        const existingDescription = safeString(existing?.videoDescription);
+        baseRecord.videoDescription = incomingDescription || existingDescription;
+      } else {
+        delete baseRecord.platform;
+        delete baseRecord.durationSeconds;
+        delete baseRecord.thumbnailUrl;
+        delete baseRecord.videoDescription;
+      }
 
       const record: any = withOptionalId(existing && existing.id, baseRecord);
 
@@ -1031,16 +1108,15 @@ export async function syncConversationMessages(
             (mergePolicy === 'preserve-existing-content' || mergePolicy === 'preserve-existing-markdown') &&
             !!existingMarkdown.trim();
           const timestamp = resolveMessageTimestamp(existing, m.updatedAt, preserveExistingContent);
-          const baseRecord: Record<string, unknown> = {
+          const record: any = buildConversationMessageRecord({
             conversationId,
-            messageKey: key,
-            role: m.role || 'assistant',
-            authorName: incomingAuthorName || (existing ? existing.authorName || '' : ''),
+            message: { ...m, messageKey: key },
+            existing,
             contentMarkdown: preserveExistingMarkdown ? existingMarkdown : incomingMarkdown,
+            authorName: incomingAuthorName,
             sequence,
-            ...(timestamp.present ? { updatedAt: timestamp.value } : null),
-          };
-          const record: any = withOptionalId(existing && existing.id, baseRecord);
+            timestamp,
+          });
           if (existing) {
             if (!messageRecordsEquivalent(existing, record)) {
               await reqToPromise(stores.messages.put(record));
@@ -1089,16 +1165,15 @@ export async function syncConversationMessages(
         const incomingMarkdown = String(m.contentMarkdown ?? '');
         const incomingAuthorName = m.authorName && String(m.authorName).trim() ? String(m.authorName).trim() : '';
         const timestamp = resolveMessageTimestamp(existing, m.updatedAt, false);
-        const baseRecord: Record<string, unknown> = {
+        const record: any = buildConversationMessageRecord({
           conversationId,
-          messageKey: m.messageKey,
-          role: m.role || 'assistant',
-          authorName: incomingAuthorName || (existing ? existing.authorName || '' : ''),
+          message: m,
+          existing,
           contentMarkdown: incomingMarkdown,
+          authorName: incomingAuthorName,
           sequence: Number.isFinite(m.sequence) ? m.sequence : 0,
-          ...(timestamp.present ? { updatedAt: timestamp.value } : null),
-        };
-        const record: any = withOptionalId(existing && existing.id, baseRecord);
+          timestamp,
+        });
         if (existing) {
           if (!messageRecordsEquivalent(existing, record)) {
             await reqToPromise(stores.messages.put(record));

--- a/src/services/conversations/domain/models.ts
+++ b/src/services/conversations/domain/models.ts
@@ -1,3 +1,6 @@
+import type { VideoChapter, VideoPlatform } from '@services/shared/video-capture';
+import type { VideoTranscriptCue } from '@services/conversations/domain/video-content';
+
 export type Conversation = {
   id: number;
   sourceType?: string;
@@ -16,6 +19,10 @@ export type Conversation = {
   feishuDocId?: string;
   lastActivityAt: number;
   commentThreadCount?: number;
+  platform?: VideoPlatform;
+  durationSeconds?: number | null;
+  thumbnailUrl?: string;
+  videoDescription?: string;
 };
 
 export type ConversationMessage = {
@@ -27,6 +34,8 @@ export type ConversationMessage = {
   contentMarkdown?: string;
   sequence?: number;
   updatedAt?: number;
+  transcriptCues?: VideoTranscriptCue[];
+  videoChapters?: VideoChapter[];
 };
 
 export type ConversationDetail = {

--- a/src/services/conversations/domain/video-content.ts
+++ b/src/services/conversations/domain/video-content.ts
@@ -1,0 +1,115 @@
+import type { VideoChapter, VideoPlatform } from '@services/shared/video-capture';
+
+export type VideoTranscriptCue = {
+  startSeconds: number;
+  endSeconds: number | null;
+  text: string;
+};
+
+export type { VideoChapter, VideoPlatform };
+
+function normalizeText(value: unknown): string {
+  return String(value ?? '')
+    .replace(/\r\n/g, '\n')
+    .trim();
+}
+
+function normalizeSingleLine(value: unknown): string {
+  return normalizeText(value).replace(/\s+/g, ' ');
+}
+
+function readNonNegativeNumber(value: unknown): number | null {
+  if (value == null) return null;
+  const text = typeof value === 'string' ? value.trim() : value;
+  if (text === '') return null;
+  const number = Number(text);
+  return Number.isFinite(number) && number >= 0 ? number : null;
+}
+
+function normalizeEnd(value: unknown, startSeconds: number): number | null {
+  if (value === null) return null;
+  const endSeconds = readNonNegativeNumber(value);
+  return endSeconds != null && endSeconds >= startSeconds ? endSeconds : null;
+}
+
+export function toCanonicalVideoTranscriptCues(value: unknown): VideoTranscriptCue[] {
+  if (!Array.isArray(value)) return [];
+  const cues: VideoTranscriptCue[] = [];
+  for (const item of value) {
+    const startSeconds = readNonNegativeNumber((item as any)?.start);
+    const text = normalizeText((item as any)?.text);
+    if (startSeconds == null || !text) continue;
+    cues.push({
+      startSeconds,
+      endSeconds: normalizeEnd((item as any)?.end, startSeconds),
+      text,
+    });
+  }
+  return cues;
+}
+
+export function normalizeCanonicalVideoTranscriptCues(value: unknown): VideoTranscriptCue[] {
+  if (!Array.isArray(value)) return [];
+  const cues: VideoTranscriptCue[] = [];
+  for (const item of value) {
+    const startSeconds = readNonNegativeNumber((item as any)?.startSeconds);
+    const text = normalizeText((item as any)?.text);
+    if (startSeconds == null || !text) continue;
+    cues.push({
+      startSeconds,
+      endSeconds: normalizeEnd((item as any)?.endSeconds, startSeconds),
+      text,
+    });
+  }
+  return cues;
+}
+
+export function normalizeCanonicalVideoChapters(value: unknown): VideoChapter[] {
+  if (!Array.isArray(value)) return [];
+  const chapters: VideoChapter[] = [];
+  for (const item of value) {
+    const title = normalizeSingleLine((item as any)?.title);
+    const startSeconds = readNonNegativeNumber((item as any)?.startSeconds);
+    if (!title || startSeconds == null) continue;
+    chapters.push({
+      title,
+      startSeconds,
+      endSeconds: normalizeEnd((item as any)?.endSeconds, startSeconds),
+    });
+  }
+  return chapters;
+}
+
+export function formatVideoTimecode(seconds: number): string {
+  const safeSeconds = Number.isFinite(seconds) && seconds >= 0 ? seconds : 0;
+  const totalMilliseconds = Math.round(safeSeconds * 1000);
+  const hours = Math.floor(totalMilliseconds / 3_600_000);
+  const minutes = Math.floor((totalMilliseconds % 3_600_000) / 60_000);
+  const wholeSeconds = Math.floor((totalMilliseconds % 60_000) / 1000);
+  const milliseconds = totalMilliseconds % 1000;
+  const pad2 = (value: number) => String(value).padStart(2, '0');
+  const base =
+    hours > 0 ? `${pad2(hours)}:${pad2(minutes)}:${pad2(wholeSeconds)}` : `${pad2(minutes)}:${pad2(wholeSeconds)}`;
+  return milliseconds ? `${base}.${String(milliseconds).padStart(3, '0')}` : base;
+}
+
+export function formatVideoTranscriptMarkdown(cues: VideoTranscriptCue[]): string {
+  return cues
+    .map((cue) => {
+      const start = formatVideoTimecode(cue.startSeconds);
+      const range = cue.endSeconds == null ? start : `${start} → ${formatVideoTimecode(cue.endSeconds)}`;
+      return `[${range}] ${cue.text}`;
+    })
+    .join('\n')
+    .trim();
+}
+
+export function formatVideoChaptersMarkdown(chapters: VideoChapter[]): string {
+  if (!chapters.length) return '';
+  const lines = chapters.map((chapter) => {
+    const start = formatVideoTimecode(chapter.startSeconds);
+    const range = chapter.endSeconds == null ? start : `${start} → ${formatVideoTimecode(chapter.endSeconds)}`;
+    return `- [${range}] ${chapter.title}`;
+  });
+  return `## Chapters\n\n${lines.join('\n')}`;
+}

--- a/src/services/protocols/conversation-kinds.ts
+++ b/src/services/protocols/conversation-kinds.ts
@@ -76,14 +76,16 @@ function asNumber(value: unknown) {
   return { number: Number.isFinite(numeric) ? numeric : 0 };
 }
 
+function asNullableNonNegativeNumber(value: unknown) {
+  if (value == null || (typeof value === 'string' && !value.trim())) return { number: null };
+  const numeric = Number(value);
+  return { number: Number.isFinite(numeric) && numeric >= 0 ? numeric : null };
+}
+
 function asSelect(value: unknown) {
   const name = String(value || '').trim();
   if (!name) return { select: null };
   return { select: { name } };
-}
-
-function asCheckbox(value: unknown) {
-  return { checkbox: value === true };
 }
 
 function register(definition: ConversationKindDefinition): boolean {
@@ -246,8 +248,6 @@ const videoKind: ConversationKindDefinition = {
         Author: { rich_text: {} },
         Duration: { number: {} },
         Thumbnail: { url: {} },
-        'Transcript Source': { select: { options: [] } },
-        'Has Timestamps': { checkbox: {} },
       },
       ensureSchemaPatch: {
         'Last Activity': { date: {} },
@@ -255,8 +255,6 @@ const videoKind: ConversationKindDefinition = {
         Author: { rich_text: {} },
         Duration: { number: {} },
         Thumbnail: { url: {} },
-        'Transcript Source': { select: { options: [] } },
-        'Has Timestamps': { checkbox: {} },
       },
     },
     pageSpec: {
@@ -268,10 +266,8 @@ const videoKind: ConversationKindDefinition = {
           'Last Activity': asDate(data.lastActivityAt),
           Platform: asSelect((data as any).platform),
           Author: asRichText(data.author),
-          Duration: asNumber((data as any).durationSeconds),
+          Duration: asNullableNonNegativeNumber((data as any).durationSeconds),
           Thumbnail: asUrl((data as any).thumbnailUrl),
-          'Transcript Source': asSelect((data as any).transcriptSource),
-          'Has Timestamps': asCheckbox((data as any).hasTimestamps),
         };
       },
       buildUpdateProperties(conversation) {
@@ -282,10 +278,8 @@ const videoKind: ConversationKindDefinition = {
           'Last Activity': asDate(data.lastActivityAt),
           Platform: asSelect((data as any).platform),
           Author: asRichText(data.author),
-          Duration: asNumber((data as any).durationSeconds),
+          Duration: asNullableNonNegativeNumber((data as any).durationSeconds),
           Thumbnail: asUrl((data as any).thumbnailUrl),
-          'Transcript Source': asSelect((data as any).transcriptSource),
-          'Has Timestamps': asCheckbox((data as any).hasTimestamps),
         };
       },
     },

--- a/src/services/shared/video-capture.ts
+++ b/src/services/shared/video-capture.ts
@@ -1,0 +1,58 @@
+export type VideoPlatform = 'youtube' | 'bilibili';
+
+export type VideoChapter = {
+  title: string;
+  startSeconds: number;
+  endSeconds: number | null;
+};
+
+export type VideoPageMetaCandidate = {
+  platform: VideoPlatform;
+  identityUrl: string;
+  title?: string;
+  author?: string;
+  description?: string;
+  durationSeconds?: number | null;
+  thumbnailUrl?: string;
+};
+
+export type VideoPageMetaCandidates = {
+  state: VideoPageMetaCandidate | null;
+  dom: VideoPageMetaCandidate | null;
+};
+
+export type VideoResponseKind = 'youtube-timedtext' | 'bilibili-subtitle' | 'bilibili-chapters';
+
+export function classifyVideoResponseUrl(raw: unknown): VideoResponseKind | null {
+  const text = String(raw ?? '').trim();
+  if (!text) return null;
+
+  let url: URL;
+  try {
+    url = new URL(text);
+  } catch (_error) {
+    return null;
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+
+  const host = url.hostname.toLowerCase();
+  const path = url.pathname.toLowerCase();
+
+  if ((host === 'youtube.com' || host === 'www.youtube.com') && path === '/api/timedtext') {
+    return 'youtube-timedtext';
+  }
+
+  if (
+    (host === 'hdslb.com' || host.endsWith('.hdslb.com')) &&
+    (path.startsWith('/bfs/subtitle/') || path.startsWith('/bfs/ai_subtitle/'))
+  ) {
+    return 'bilibili-subtitle';
+  }
+
+  if (host === 'api.bilibili.com' && path === '/x/player/wbi/v2') {
+    return 'bilibili-chapters';
+  }
+
+  return null;
+}

--- a/src/services/sync/backup/backup-utils.ts
+++ b/src/services/sync/backup/backup-utils.ts
@@ -1,6 +1,10 @@
 import { DATA_REVISION_WAKE_STORAGE_KEY } from '@services/data-revisions/wake';
 import { normalizeLegacyMessageRecord } from '@platform/idb/message-record';
 import {
+  normalizeCanonicalVideoChapters,
+  normalizeCanonicalVideoTranscriptCues,
+} from '@services/conversations/domain/video-content';
+import {
   canonicalizeInpageDisplayModeStorageRecord,
   INPAGE_DISPLAY_MODE_STORAGE_KEY,
 } from '@services/shared/inpage-display-mode';
@@ -120,6 +124,47 @@ export function mergeConversationRecord(
   next.publishedAt = pickStringPreferExisting(a.publishedAt, b.publishedAt);
   next.warningFlags = mergeWarningFlags(a.warningFlags, b.warningFlags);
 
+  if (
+    String(next.sourceType || '')
+      .trim()
+      .toLowerCase() === 'video'
+  ) {
+    const existingPlatform = String(a.platform || '')
+      .trim()
+      .toLowerCase();
+    const incomingPlatform = String(b.platform || '')
+      .trim()
+      .toLowerCase();
+    const platform =
+      existingPlatform === 'youtube' || existingPlatform === 'bilibili'
+        ? existingPlatform
+        : incomingPlatform === 'youtube' || incomingPlatform === 'bilibili'
+          ? incomingPlatform
+          : '';
+    if (platform) next.platform = platform;
+    else delete next.platform;
+
+    const validDuration = (value: unknown) => {
+      if (value == null || (typeof value === 'string' && !value.trim())) return null;
+      const numeric = Number(value);
+      return Number.isFinite(numeric) && numeric >= 0 ? numeric : null;
+    };
+    const durationSeconds = validDuration(a.durationSeconds) ?? validDuration(b.durationSeconds);
+    if (durationSeconds != null) next.durationSeconds = durationSeconds;
+    else delete next.durationSeconds;
+
+    const thumbnailUrl = pickStringPreferExisting(a.thumbnailUrl, b.thumbnailUrl);
+    if (thumbnailUrl) next.thumbnailUrl = thumbnailUrl;
+    else delete next.thumbnailUrl;
+    const videoDescription = pickStringPreferExisting(a.videoDescription, b.videoDescription);
+    if (videoDescription) next.videoDescription = videoDescription;
+    else delete next.videoDescription;
+
+    delete next.transcriptSource;
+    delete next.hasTimestamps;
+    delete next.description;
+  }
+
   // notionPageId: never overwrite a non-empty local mapping.
   const notionPageId = pickStringPreferExisting(a.notionPageId, b.notionPageId);
   const hasExplicitEmptyNotionPageId = [a, b].some(
@@ -152,6 +197,7 @@ export function mergeMessageRecord(existing: UnknownRecord, incoming: UnknownRec
   const b = normalizeLegacyMessageRecord(incoming);
 
   const preferIncoming = !hasExisting || shouldPreferIncomingMessage(a, b);
+  const winner = preferIncoming ? b : a;
   const next = preferIncoming ? { ...a, ...b } : { ...b, ...a };
   next.role = pickStringPreferExisting(next.role, 'assistant') || 'assistant';
 
@@ -166,6 +212,22 @@ export function mergeMessageRecord(existing: UnknownRecord, incoming: UnknownRec
   if (Number.isFinite(bSeq)) next.sequence = bSeq;
   else if (Number.isFinite(aSeq)) next.sequence = aSeq;
   else next.sequence = 0;
+
+  if (String(next.messageKey || '') === 'video_transcript') {
+    if (Object.prototype.hasOwnProperty.call(winner, 'transcriptCues')) {
+      next.transcriptCues = normalizeCanonicalVideoTranscriptCues(winner.transcriptCues);
+    } else {
+      delete next.transcriptCues;
+    }
+    if (Object.prototype.hasOwnProperty.call(winner, 'videoChapters')) {
+      next.videoChapters = normalizeCanonicalVideoChapters(winner.videoChapters);
+    } else {
+      delete next.videoChapters;
+    }
+  } else {
+    delete next.transcriptCues;
+    delete next.videoChapters;
+  }
 
   return next;
 }

--- a/tests/domains/backup-service.test.ts
+++ b/tests/domains/backup-service.test.ts
@@ -7,7 +7,12 @@ import { exportBackupZip } from '@services/sync/backup/export';
 import { importBackupZipMerge } from '@services/sync/backup/import';
 import { extractZipEntries } from '@services/sync/backup/zip-utils';
 import { closeDbForTests, openDb } from '../../src/platform/idb/schema';
-import { upsertConversation } from '@services/conversations/data/storage-idb';
+import {
+  getConversationById,
+  getMessagesByConversationId,
+  syncConversationMessages,
+  upsertConversation,
+} from '@services/conversations/data/storage-idb';
 import { buildBackupV2FixtureEntries } from '../helpers/backup-v2-fixture';
 
 function reqToPromise<T>(request: IDBRequest<T>): Promise<T> {
@@ -319,6 +324,101 @@ describe('backup service', () => {
       'display owner failed',
     );
     expect(chromeMock.__setPayloads.some((payload) => 'inpage_display_mode' in payload)).toBe(false);
+  });
+
+  it('round-trips canonical Video metadata, cues and chapters through the ZIP backup without duplication', async () => {
+    const chromeMock = mockChromeStorage();
+    // @ts-expect-error test global
+    globalThis.chrome = chromeMock;
+    // @ts-expect-error test global
+    globalThis.browser = undefined;
+
+    const conversation = await upsertConversation({
+      sourceType: 'video',
+      source: 'video',
+      conversationKey: 'video:https://www.bilibili.com/video/BV1BACKUP123/',
+      title: 'Backup Video',
+      url: 'https://www.bilibili.com/video/BV1BACKUP123/',
+      author: 'Author',
+      platform: 'bilibili',
+      durationSeconds: 123.5,
+      thumbnailUrl: 'https://example.com/thumb.jpg',
+      videoDescription: 'Full description',
+      lastActivityAt: 100,
+    });
+    const conversationId = Number(conversation.id);
+    await syncConversationMessages(conversationId, [
+      {
+        messageKey: 'video_transcript',
+        role: 'transcript',
+        contentMarkdown: '[00:01.234 → 00:03.456] hello',
+        transcriptCues: [{ startSeconds: 1.234, endSeconds: 3.456, text: 'hello' }],
+        videoChapters: [{ title: 'Intro', startSeconds: 0, endSeconds: 30 }],
+        sequence: 1,
+        updatedAt: 100,
+      },
+    ]);
+
+    const exported = await exportBackupZip();
+    const entries = await extractZipEntries(exported.blob);
+    const manifest = JSON.parse(new TextDecoder().decode(entries.get('manifest.json')!));
+    const videoGroup = manifest.sources.find((group: any) => group.source === 'video');
+    expect(videoGroup?.files).toHaveLength(1);
+    const bundle = JSON.parse(new TextDecoder().decode(entries.get(videoGroup.files[0])!));
+    expect(bundle.conversation).toMatchObject({
+      sourceType: 'video',
+      platform: 'bilibili',
+      durationSeconds: 123.5,
+      thumbnailUrl: 'https://example.com/thumb.jpg',
+      videoDescription: 'Full description',
+    });
+    expect(bundle.messages).toEqual([
+      expect.objectContaining({
+        messageKey: 'video_transcript',
+        contentMarkdown: '[00:01.234 → 00:03.456] hello',
+        transcriptCues: [{ startSeconds: 1.234, endSeconds: 3.456, text: 'hello' }],
+        videoChapters: [{ title: 'Intro', startSeconds: 0, endSeconds: 30 }],
+      }),
+    ]);
+
+    closeDbForTests();
+    await deleteDb('webclipper');
+
+    const first = await importBackupZipMerge(entries);
+    expect(first.conversationsAdded).toBe(1);
+    expect(first.messagesAdded).toBe(1);
+
+    const restoredDb = await openDb();
+    const tx = restoredDb.transaction(['conversations'], 'readonly');
+    const restoredRows = await reqToPromise<any[]>(tx.objectStore('conversations').getAll() as any);
+    await new Promise<void>((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      tx.onabort = () => reject(tx.error);
+    });
+    expect(restoredRows).toHaveLength(1);
+    const restoredId = Number(restoredRows[0].id);
+    expect(await getConversationById(restoredId)).toMatchObject({
+      platform: 'bilibili',
+      durationSeconds: 123.5,
+      thumbnailUrl: 'https://example.com/thumb.jpg',
+      videoDescription: 'Full description',
+    });
+    expect(await getMessagesByConversationId(restoredId)).toEqual([
+      expect.objectContaining({
+        messageKey: 'video_transcript',
+        contentMarkdown: '[00:01.234 → 00:03.456] hello',
+        transcriptCues: [{ startSeconds: 1.234, endSeconds: 3.456, text: 'hello' }],
+        videoChapters: [{ title: 'Intro', startSeconds: 0, endSeconds: 30 }],
+      }),
+    ]);
+
+    const repeated = await importBackupZipMerge(entries);
+    expect(repeated.conversationsAdded).toBe(0);
+    expect(repeated.messagesAdded).toBe(0);
+    expect(
+      (await getMessagesByConversationId(restoredId)).filter((row) => row.messageKey === 'video_transcript'),
+    ).toHaveLength(1);
   });
 
   it('exportBackupZip emits manifest + bundles and filters storage.local', async () => {

--- a/tests/domains/backup-utils.test.ts
+++ b/tests/domains/backup-utils.test.ts
@@ -284,4 +284,131 @@ describe('backup backup-utils', () => {
     expect(merged.contentMarkdown).toBe('hi');
     expect(merged.updatedAt).toBe(20);
   });
+
+  it('mergeConversationRecord preserves local canonical Video metadata, fills missing values, and drops retired fields', () => {
+    const merged = mergeConversationRecord(
+      {
+        id: 10,
+        sourceType: 'video',
+        source: 'video',
+        conversationKey: 'video:https://example.com/video',
+        title: 'Local',
+        url: 'https://example.com/video',
+        platform: 'bilibili',
+        durationSeconds: 120.5,
+        thumbnailUrl: 'https://example.com/local.jpg',
+        videoDescription: 'Local description',
+        transcriptSource: 'C',
+        hasTimestamps: false,
+        description: 'retired description',
+        lastActivityAt: 20,
+      },
+      {
+        sourceType: 'video',
+        source: 'video',
+        conversationKey: 'video:https://example.com/video',
+        title: 'Backup',
+        url: 'https://example.com/video',
+        platform: 'youtube',
+        durationSeconds: 999,
+        thumbnailUrl: 'https://example.com/backup.jpg',
+        videoDescription: 'Backup description',
+        transcriptSource: 'A',
+        hasTimestamps: true,
+        lastActivityAt: 30,
+      },
+    );
+
+    expect(merged).toMatchObject({
+      platform: 'bilibili',
+      durationSeconds: 120.5,
+      thumbnailUrl: 'https://example.com/local.jpg',
+      videoDescription: 'Local description',
+      lastActivityAt: 30,
+    });
+    expect(merged).not.toHaveProperty('transcriptSource');
+    expect(merged).not.toHaveProperty('hasTimestamps');
+    expect(merged).not.toHaveProperty('description');
+
+    const filled = mergeConversationRecord(
+      {
+        sourceType: 'video',
+        source: 'video',
+        conversationKey: 'video:https://example.com/missing',
+        title: 'Local',
+        url: 'https://example.com/missing',
+        platform: 'invalid',
+        durationSeconds: -1,
+        thumbnailUrl: '',
+        videoDescription: '',
+        lastActivityAt: 1,
+      },
+      {
+        sourceType: 'video',
+        source: 'video',
+        conversationKey: 'video:https://example.com/missing',
+        platform: 'youtube',
+        durationSeconds: 42.25,
+        thumbnailUrl: 'https://example.com/backup.jpg',
+        videoDescription: 'Backup description',
+        lastActivityAt: 2,
+      },
+    );
+    expect(filled).toMatchObject({
+      platform: 'youtube',
+      durationSeconds: 42.25,
+      thumbnailUrl: 'https://example.com/backup.jpg',
+      videoDescription: 'Backup description',
+    });
+  });
+
+  it('mergeMessageRecord keeps structured Video content only from the winning transcript row', () => {
+    const older = {
+      conversationId: 1,
+      messageKey: 'video_transcript',
+      role: 'transcript',
+      contentMarkdown: 'older',
+      updatedAt: 10,
+      transcriptCues: [{ startSeconds: 1, endSeconds: 2, text: 'older', raw: true }],
+      videoChapters: [{ title: 'Old', startSeconds: 0, endSeconds: 10, imgUrl: 'raw' }],
+    };
+    const newerWithoutStructuredFields = {
+      conversationId: 1,
+      messageKey: 'video_transcript',
+      role: 'transcript',
+      contentMarkdown: 'newer',
+      updatedAt: 20,
+    };
+
+    const merged = mergeMessageRecord(older, newerWithoutStructuredFields);
+    expect(merged.contentMarkdown).toBe('newer');
+    expect(merged).not.toHaveProperty('transcriptCues');
+    expect(merged).not.toHaveProperty('videoChapters');
+
+    const canonicalWinner = mergeMessageRecord(newerWithoutStructuredFields, {
+      ...older,
+      updatedAt: 30,
+      transcriptCues: [{ startSeconds: 1.234, endSeconds: 3.456, text: 'winner', raw: true }],
+      videoChapters: [{ title: ' Winner\nchapter ', startSeconds: 0, endSeconds: 30, imgUrl: 'raw' }],
+    });
+    expect(canonicalWinner.transcriptCues).toEqual([{ startSeconds: 1.234, endSeconds: 3.456, text: 'winner' }]);
+    expect(canonicalWinner.videoChapters).toEqual([{ title: 'Winner chapter', startSeconds: 0, endSeconds: 30 }]);
+  });
+
+  it('mergeMessageRecord removes stray Video structured fields from non-transcript messages', () => {
+    const merged = mergeMessageRecord(
+      {},
+      {
+        conversationId: 1,
+        messageKey: 'ordinary',
+        role: 'assistant',
+        contentMarkdown: 'ordinary',
+        updatedAt: 10,
+        transcriptCues: [{ startSeconds: 1, endSeconds: null, text: 'stray' }],
+        videoChapters: [{ title: 'stray', startSeconds: 0, endSeconds: null }],
+      },
+    );
+    expect(merged).not.toHaveProperty('transcriptCues');
+    expect(merged).not.toHaveProperty('videoChapters');
+  });
 });

--- a/tests/smoke/video-kind.test.ts
+++ b/tests/smoke/video-kind.test.ts
@@ -2,11 +2,51 @@ import { describe, expect, it } from 'vitest';
 import { conversationKinds } from '@services/protocols/conversation-kinds.ts';
 
 describe('video kind', () => {
-  it('registers SyncNos-Videos notion db spec', () => {
-    const list = conversationKinds.list();
-    const video = list.find((k) => k && k.id === 'video') as any;
+  function getVideoKind() {
+    const video = conversationKinds.list().find((kind) => kind && kind.id === 'video') as any;
     expect(video).toBeTruthy();
-    expect(String(video?.notion?.dbSpec?.title || '')).toBe('SyncNos-Videos');
-    expect(String(video?.notion?.dbSpec?.storageKey || '')).toBe('notion_db_id_syncnos_videos');
+    return video;
+  }
+
+  it('registers the stable SyncNos-Videos identity without obsolete diagnostic properties', () => {
+    const video = getVideoKind();
+    expect(String(video.notion.dbSpec.title || '')).toBe('SyncNos-Videos');
+    expect(String(video.notion.dbSpec.storageKey || '')).toBe('notion_db_id_syncnos_videos');
+    expect(video.notion.dbSpec.properties).not.toHaveProperty('Transcript Source');
+    expect(video.notion.dbSpec.properties).not.toHaveProperty('Has Timestamps');
+    expect(video.notion.dbSpec.ensureSchemaPatch).not.toHaveProperty('Transcript Source');
+    expect(video.notion.dbSpec.ensureSchemaPatch).not.toHaveProperty('Has Timestamps');
+    expect(video.view).toMatchObject({ renderer: 'article', commentsSidebar: false });
+    expect(video.obsidian.folder).toBe('SyncNos-Videos');
+  });
+
+  it('projects a nullable non-negative Video duration without changing other metadata', () => {
+    const pageSpec = getVideoKind().notion.pageSpec;
+    const base = {
+      title: 'Video',
+      url: 'https://www.bilibili.com/video/BV1TEST12345/',
+      author: 'Author',
+      platform: 'bilibili',
+      thumbnailUrl: 'https://example.com/thumb.jpg',
+      lastActivityAt: 1_700_000_000_000,
+    };
+
+    expect(pageSpec.buildCreateProperties({ ...base, durationSeconds: 123.5 }).Duration).toEqual({ number: 123.5 });
+    expect(pageSpec.buildCreateProperties({ ...base, durationSeconds: null }).Duration).toEqual({ number: null });
+    expect(pageSpec.buildUpdateProperties({ ...base, durationSeconds: -1 }).Duration).toEqual({ number: null });
+    expect(pageSpec.buildUpdateProperties({ ...base, durationSeconds: 'bad' }).Duration).toEqual({ number: null });
+    expect(pageSpec.buildCreateProperties(base)).not.toHaveProperty('Transcript Source');
+    expect(pageSpec.buildCreateProperties(base)).not.toHaveProperty('Has Timestamps');
+  });
+
+  it('keeps Article Comment Threads number semantics unchanged', () => {
+    const article = conversationKinds.list().find((kind) => kind && kind.id === 'article') as any;
+    const properties = article.notion.pageSpec.buildCreateProperties({
+      title: 'Article',
+      url: 'https://example.com/article',
+      lastActivityAt: 1,
+      commentThreadCount: null,
+    });
+    expect(properties['Comment Threads']).toEqual({ number: 0 });
   });
 });

--- a/tests/smoke/video-transcript-bridge.test.ts
+++ b/tests/smoke/video-transcript-bridge.test.ts
@@ -1,0 +1,143 @@
+import { JSDOM } from 'jsdom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const STORE_KEY = '__SYNCNOS_VIDEO_TRANSCRIPT_BRIDGE__';
+
+let dom: JSDOM;
+
+async function loadBridge() {
+  let config: any = null;
+  vi.stubGlobal('defineContentScript', (value: any) => {
+    config = value;
+    return value;
+  });
+  await import('../../src/entrypoints/video-transcript-bridge.content.ts');
+  if (!config) throw new Error('bridge content script was not registered');
+  return config;
+}
+
+function dispatch(data: any) {
+  window.dispatchEvent(new (window as any).MessageEvent('message', { source: window, data }));
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.restoreAllMocks();
+  delete (globalThis as any)[STORE_KEY];
+  dom = new JSDOM('<!doctype html><html><body></body></html>', {
+    url: 'https://www.bilibili.com/video/BV1BBBBBBBBB/',
+  });
+  vi.stubGlobal('window', dom.window as unknown as Window & typeof globalThis);
+  vi.stubGlobal('document', dom.window.document);
+  vi.stubGlobal('location', dom.window.location);
+});
+
+afterEach(() => {
+  delete (globalThis as any)[STORE_KEY];
+  vi.unstubAllGlobals();
+  dom.window.close();
+});
+
+describe('video transcript isolated bridge', () => {
+  it('is injected on exact video-capable hosts rather than only video paths', async () => {
+    const config = await loadBridge();
+    expect(config.runAt).toBe('document_start');
+    expect(config.matches).toEqual([
+      'https://www.youtube.com/*',
+      'https://youtu.be/*',
+      'https://www.bilibili.com/*',
+      'https://bilibili.com/*',
+    ]);
+  });
+
+  it('stores only trusted video endpoints with request-page identity', async () => {
+    const config = await loadBridge();
+    config.main();
+
+    dispatch({
+      __syncnos: true,
+      type: 'SYNCNOS_VIDEO_INTERCEPTED',
+      url: 'https://aisubtitle.hdslb.com/bfs/ai_subtitle/current.json',
+      pageUrl: location.href,
+      contentType: 'application/json',
+      bodyText: '{"body":[]}',
+      at: 10,
+    });
+    dispatch({
+      __syncnos: true,
+      type: 'SYNCNOS_VIDEO_INTERCEPTED',
+      url: 'https://evil.example/?next=https://www.youtube.com/api/timedtext',
+      pageUrl: location.href,
+      bodyText: 'evil',
+      at: 11,
+    });
+    dispatch({
+      __syncnos: true,
+      type: 'SYNCNOS_VIDEO_INTERCEPTED',
+      url: 'https://aisubtitle.hdslb.com/bfs/ai_subtitle/no-page.json',
+      bodyText: '{"body":[]}',
+      at: 12,
+    });
+    dispatch({
+      __syncnos: true,
+      type: 'SYNCNOS_VIDEO_META_RESPONSE',
+      requestId: 'legacy-meta',
+      meta: { state: null, dom: null },
+    });
+
+    expect((globalThis as any)[STORE_KEY]).toEqual({
+      responses: [
+        {
+          url: 'https://aisubtitle.hdslb.com/bfs/ai_subtitle/current.json',
+          pageUrl: location.href,
+          contentType: 'application/json',
+          bodyText: '{"body":[]}',
+          at: 10,
+        },
+      ],
+    });
+  });
+
+  it('keeps one bounded response history without truncating oversized JSON', async () => {
+    const config = await loadBridge();
+    config.main();
+
+    const exactlyAtLimit = 'x'.repeat(2_000_000);
+    dispatch({
+      __syncnos: true,
+      type: 'SYNCNOS_VIDEO_INTERCEPTED',
+      url: 'https://api.bilibili.com/x/player/wbi/v2?limit=exact',
+      pageUrl: location.href,
+      bodyText: exactlyAtLimit,
+      at: 1,
+    });
+    expect((globalThis as any)[STORE_KEY].responses).toHaveLength(1);
+    expect((globalThis as any)[STORE_KEY].responses[0].bodyText).toHaveLength(2_000_000);
+
+    dispatch({
+      __syncnos: true,
+      type: 'SYNCNOS_VIDEO_INTERCEPTED',
+      url: 'https://api.bilibili.com/x/player/wbi/v2?limit=over',
+      pageUrl: location.href,
+      bodyText: `${exactlyAtLimit}x`,
+      at: 2,
+    });
+    expect((globalThis as any)[STORE_KEY].responses).toHaveLength(1);
+
+    for (let index = 0; index < 31; index += 1) {
+      dispatch({
+        __syncnos: true,
+        type: 'SYNCNOS_VIDEO_INTERCEPTED',
+        url: `https://api.bilibili.com/x/player/wbi/v2?index=${index}`,
+        pageUrl: location.href,
+        bodyText: `body-${index}`,
+        at: 100 + index,
+      });
+    }
+
+    const responses = (globalThis as any)[STORE_KEY].responses;
+    expect(responses).toHaveLength(30);
+    expect(responses[0].bodyText).toBe('body-1');
+    expect(responses[29].bodyText).toBe('body-30');
+  });
+});

--- a/tests/smoke/video-transcript-interceptor.test.ts
+++ b/tests/smoke/video-transcript-interceptor.test.ts
@@ -1,0 +1,297 @@
+import { JSDOM } from 'jsdom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let dom: JSDOM;
+
+function installDom(url: string, html = '<!doctype html><html><head></head><body></body></html>') {
+  dom = new JSDOM(html, { url });
+  vi.stubGlobal('window', dom.window as unknown as Window & typeof globalThis);
+  vi.stubGlobal('document', dom.window.document);
+  vi.stubGlobal('location', dom.window.location);
+}
+
+async function loadInterceptor() {
+  let config: any = null;
+  vi.stubGlobal('defineContentScript', (value: any) => {
+    config = value;
+    return value;
+  });
+  await import('../../src/entrypoints/video-transcript-interceptor.content.ts');
+  if (!config) throw new Error('interceptor content script was not registered');
+  return config;
+}
+
+function dispatchMetaRequest(requestId = 'meta-request') {
+  window.dispatchEvent(
+    new (window as any).MessageEvent('message', {
+      source: window,
+      data: { __syncnos: true, type: 'SYNCNOS_VIDEO_META_REQUEST', requestId },
+    }),
+  );
+}
+
+function findPosted(spy: ReturnType<typeof vi.spyOn>, type: string) {
+  return spy.mock.calls.map((call) => call[0] as any).filter((data) => data?.type === type);
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  dom?.window.close();
+});
+
+describe('video transcript main-world interceptor', () => {
+  it('is injected at document-start on exact video-capable hosts', async () => {
+    installDom('https://www.youtube.com/');
+    const config = await loadInterceptor();
+    expect(config.runAt).toBe('document_start');
+    expect(config.world).toBe('MAIN');
+    expect(config.matches).toEqual([
+      'https://www.youtube.com/*',
+      'https://youtu.be/*',
+      'https://www.bilibili.com/*',
+      'https://bilibili.com/*',
+    ]);
+  });
+
+  it('binds fetch responses to the page where the request started', async () => {
+    const pageA = 'https://www.youtube.com/watch?v=A';
+    const pageB = 'https://www.youtube.com/watch?v=B';
+    installDom(pageA);
+
+    let resolveFetch!: (value: any) => void;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        () =>
+          new Promise((resolve) => {
+            resolveFetch = resolve;
+          }),
+      ),
+    );
+    const postSpy = vi.spyOn(window, 'postMessage').mockImplementation(() => undefined);
+    const config = await loadInterceptor();
+    config.main();
+
+    const pending = (globalThis.fetch as any)('https://www.youtube.com/api/timedtext?v=A');
+    dom.reconfigure({ url: pageB });
+    resolveFetch({
+      url: 'https://www.youtube.com/api/timedtext?v=A',
+      clone: () => ({
+        headers: { get: () => 'text/xml' },
+        text: async () => '<transcript><text start="1" dur="1">A</text></transcript>',
+      }),
+    });
+    await pending;
+
+    const posted = findPosted(postSpy, 'SYNCNOS_VIDEO_INTERCEPTED');
+    expect(posted).toHaveLength(1);
+    expect(posted[0]).toMatchObject({
+      url: 'https://www.youtube.com/api/timedtext?v=A',
+      pageUrl: pageA,
+      bodyText: '<transcript><text start="1" dur="1">A</text></transcript>',
+    });
+  });
+
+  it('keeps XHR endpoint identity from open time and page identity from send time', async () => {
+    const pageA = 'https://www.youtube.com/watch?v=A';
+    const pageB = 'https://www.youtube.com/watch?v=B';
+    installDom(pageA);
+
+    class FakeXhr {
+      responseType = 'json';
+      response: any = { events: [{ tStartMs: 1000, dDurationMs: 500, segs: [{ utf8: 'B' }] }] };
+      private listeners = new Map<string, () => void>();
+
+      get responseText() {
+        throw new Error('responseText must not be read for responseType=json');
+      }
+
+      open() {}
+      send() {
+        this.listeners.get('load')?.();
+      }
+      addEventListener(type: string, listener: () => void) {
+        this.listeners.set(type, listener);
+      }
+      getResponseHeader() {
+        return 'application/json';
+      }
+    }
+
+    vi.stubGlobal('XMLHttpRequest', FakeXhr as any);
+    vi.stubGlobal('fetch', undefined);
+    const postSpy = vi.spyOn(window, 'postMessage').mockImplementation(() => undefined);
+    const config = await loadInterceptor();
+    config.main();
+
+    const xhr = new (globalThis as any).XMLHttpRequest();
+    xhr.open('GET', '/api/timedtext');
+    dom.reconfigure({ url: pageB });
+    xhr.send();
+
+    const posted = findPosted(postSpy, 'SYNCNOS_VIDEO_INTERCEPTED');
+    expect(posted).toHaveLength(1);
+    expect(posted[0]).toMatchObject({
+      url: 'https://www.youtube.com/api/timedtext',
+      pageUrl: pageB,
+      contentType: 'application/json',
+      bodyText: JSON.stringify(xhr.response),
+    });
+  });
+
+  it.each([
+    {
+      responseType: 'text',
+      responseText: '<transcript><text start="1">text</text></transcript>',
+      response: null,
+      expected: '<transcript><text start="1">text</text></transcript>',
+    },
+    {
+      responseType: 'arraybuffer',
+      responseText: '',
+      response: new TextEncoder().encode('{"body":[]}').buffer,
+      expected: '{"body":[]}',
+    },
+  ])('reads $responseType XHR bodies without crossing response APIs', async (fixture) => {
+    installDom('https://www.youtube.com/watch?v=current');
+
+    class FakeXhr {
+      responseType = fixture.responseType;
+      response = fixture.response;
+      responseText = fixture.responseText;
+      private listeners = new Map<string, () => void>();
+      open() {}
+      send() {
+        this.listeners.get('load')?.();
+      }
+      addEventListener(type: string, listener: () => void) {
+        this.listeners.set(type, listener);
+      }
+      getResponseHeader() {
+        return 'text/plain';
+      }
+    }
+
+    vi.stubGlobal('XMLHttpRequest', FakeXhr as any);
+    vi.stubGlobal('fetch', undefined);
+    const postSpy = vi.spyOn(window, 'postMessage').mockImplementation(() => undefined);
+    const config = await loadInterceptor();
+    config.main();
+
+    const xhr = new (globalThis as any).XMLHttpRequest();
+    xhr.open('GET', 'https://www.youtube.com/api/timedtext?v=current');
+    xhr.send();
+
+    expect(findPosted(postSpy, 'SYNCNOS_VIDEO_INTERCEPTED')[0]?.bodyText).toBe(fixture.expected);
+  });
+
+  it('does not intercept substring-spoofed response URLs', async () => {
+    installDom('https://www.youtube.com/watch?v=current');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        url: 'https://evil.example/?next=https://www.youtube.com/api/timedtext',
+        clone: () => ({ headers: { get: () => 'text/plain' }, text: async () => 'evil' }),
+      })),
+    );
+    const postSpy = vi.spyOn(window, 'postMessage').mockImplementation(() => undefined);
+    const config = await loadInterceptor();
+    config.main();
+
+    await (globalThis.fetch as any)('https://evil.example/?next=https://www.youtube.com/api/timedtext');
+    expect(findPosted(postSpy, 'SYNCNOS_VIDEO_INTERCEPTED')).toEqual([]);
+  });
+
+  it('returns identity-bound YouTube state metadata including the full description', async () => {
+    installDom('https://www.youtube.com/watch?v=abc');
+    (window as any).ytInitialPlayerResponse = {
+      videoDetails: {
+        videoId: 'abc',
+        title: 'Title',
+        author: 'Author',
+        shortDescription: 'line 1\nline 2',
+        lengthSeconds: '123',
+        thumbnail: { thumbnails: [{ url: 'small' }, { url: 'large' }] },
+      },
+    };
+    vi.stubGlobal('fetch', undefined);
+    vi.stubGlobal('XMLHttpRequest', undefined);
+    const postSpy = vi.spyOn(window, 'postMessage').mockImplementation(() => undefined);
+    const config = await loadInterceptor();
+    config.main();
+
+    dispatchMetaRequest('youtube-meta');
+    const response = findPosted(postSpy, 'SYNCNOS_VIDEO_META_RESPONSE')[0];
+    expect(response).toEqual({
+      __syncnos: true,
+      type: 'SYNCNOS_VIDEO_META_RESPONSE',
+      requestId: 'youtube-meta',
+      meta: {
+        state: {
+          platform: 'youtube',
+          identityUrl: 'https://www.youtube.com/watch?v=abc',
+          title: 'Title',
+          author: 'Author',
+          description: 'line 1\nline 2',
+          durationSeconds: 123,
+          thumbnailUrl: 'large',
+        },
+        dom: null,
+      },
+    });
+  });
+
+  it('returns separate Bilibili state and DOM metadata candidates without mixing them', async () => {
+    installDom(
+      'https://www.bilibili.com/video/BV1STATE1234/?p=2&utm_source=test',
+      '<!doctype html><html><head><link rel="canonical" href="https://www.bilibili.com/video/BV1DOM123456/?p=2"></head><body><h1 class="video-title"></h1><a class="up-name"></a><div class="desc-info-text"></div></body></html>',
+    );
+    (window as any).__INITIAL_STATE__ = {
+      videoData: {
+        bvid: 'BV1STATE1234',
+        title: 'State title',
+        owner: { name: 'State author' },
+        desc: '',
+        desc_v2: [{ raw_text: 'State line 1' }, { raw_text: 'State line 2' }],
+        duration: 456,
+        pic: 'https://example.com/state.jpg',
+      },
+    };
+    const title = document.querySelector('h1.video-title') as HTMLElement;
+    const author = document.querySelector('a.up-name') as HTMLElement;
+    const description = document.querySelector('.desc-info-text') as HTMLElement;
+    title.innerText = 'DOM title';
+    author.innerText = 'DOM author';
+    description.innerText = 'DOM full description';
+
+    vi.stubGlobal('fetch', undefined);
+    vi.stubGlobal('XMLHttpRequest', undefined);
+    const postSpy = vi.spyOn(window, 'postMessage').mockImplementation(() => undefined);
+    const config = await loadInterceptor();
+    config.main();
+
+    dispatchMetaRequest('bilibili-meta');
+    const response = findPosted(postSpy, 'SYNCNOS_VIDEO_META_RESPONSE')[0];
+    expect(response.meta.state).toEqual({
+      platform: 'bilibili',
+      identityUrl: 'https://www.bilibili.com/video/BV1STATE1234/?p=2',
+      title: 'State title',
+      author: 'State author',
+      description: 'State line 1\nState line 2',
+      durationSeconds: 456,
+      thumbnailUrl: 'https://example.com/state.jpg',
+    });
+    expect(response.meta.dom).toEqual({
+      platform: 'bilibili',
+      identityUrl: 'https://www.bilibili.com/video/BV1DOM123456/?p=2',
+      title: 'DOM title',
+      author: 'DOM author',
+      description: 'DOM full description',
+    });
+  });
+});

--- a/tests/storage/conversations-idb.test.ts
+++ b/tests/storage/conversations-idb.test.ts
@@ -3479,3 +3479,180 @@ describe('conversations storage-idb', () => {
     expect(merged?.listSiteKey).toBe('domain:example.com');
   });
 });
+
+describe('canonical video storage', () => {
+  it('persists Video metadata, preserves non-empty context, and clears obsolete diagnostics on recapture', async () => {
+    const payload = {
+      sourceType: 'video',
+      source: 'video',
+      conversationKey: 'video:https://www.bilibili.com/video/BV1TEST12345/',
+      title: 'Video',
+      url: 'https://www.bilibili.com/video/BV1TEST12345/',
+      author: 'Author',
+      platform: 'bilibili',
+      durationSeconds: 123.5,
+      thumbnailUrl: 'https://example.com/thumb.jpg',
+      videoDescription: 'Full description',
+      transcriptSource: 'A',
+      hasTimestamps: true,
+      lastActivityAt: 10,
+    };
+
+    const created = await upsertConversation(payload);
+    const id = Number(created.id);
+    expect(await getConversationById(id)).toMatchObject({
+      platform: 'bilibili',
+      durationSeconds: 123.5,
+      thumbnailUrl: 'https://example.com/thumb.jpg',
+      videoDescription: 'Full description',
+    });
+    expect(await getConversationById(id)).not.toHaveProperty('transcriptSource');
+    expect(await getConversationById(id)).not.toHaveProperty('hasTimestamps');
+
+    const stableRevision = await readDataRevision('conversations');
+    await upsertConversation({
+      ...payload,
+      platform: '',
+      durationSeconds: null,
+      thumbnailUrl: '',
+      videoDescription: '',
+      transcriptSource: undefined,
+      hasTimestamps: undefined,
+    });
+    expect(await readDataRevision('conversations')).toBe(stableRevision);
+    expect(await getConversationById(id)).toMatchObject({
+      platform: 'bilibili',
+      durationSeconds: 123.5,
+      thumbnailUrl: 'https://example.com/thumb.jpg',
+      videoDescription: 'Full description',
+    });
+
+    const db = await openDb();
+    const tx = db.transaction(['conversations'], 'readwrite');
+    const store = tx.objectStore('conversations');
+    const raw = await reqToPromise<any>(store.get(id));
+    await reqToPromise(store.put({ ...raw, transcriptSource: 'C', hasTimestamps: false }));
+    await txDone(tx);
+
+    await upsertConversation({ ...payload, transcriptSource: undefined, hasTimestamps: undefined });
+    const cleaned = await getConversationById(id);
+    expect(cleaned).not.toHaveProperty('transcriptSource');
+    expect(cleaned).not.toHaveProperty('hasTimestamps');
+    expect(await readDataRevision('conversations')).toBe(stableRevision + 1);
+
+    await upsertConversation({ ...payload, videoDescription: 'Updated description' });
+    expect((await getConversationById(id))?.videoDescription).toBe('Updated description');
+    expect(await readDataRevision('conversations')).toBe(stableRevision + 2);
+  });
+
+  it('persists canonical transcript cues and applies chapter unknown/replace/clear semantics in every write path', async () => {
+    const convo = await upsertConversation({
+      sourceType: 'video',
+      source: 'video',
+      conversationKey: 'video:https://www.youtube.com/watch?v=storage',
+      title: 'Video storage',
+      url: 'https://www.youtube.com/watch?v=storage',
+      platform: 'youtube',
+      lastActivityAt: 1,
+    });
+    const id = Number(convo.id);
+    const initial = {
+      messageKey: 'video_transcript',
+      role: 'transcript',
+      contentMarkdown: '[00:01] first',
+      sequence: 1,
+      updatedAt: 100,
+      transcriptCues: [{ startSeconds: 1, endSeconds: 2, text: 'first', raw: true }],
+      videoChapters: [{ title: 'Intro', startSeconds: 0, endSeconds: 10, imgUrl: 'raw' }],
+    };
+
+    await syncConversationMessages(id, [initial]);
+    expect(await getMessagesByConversationId(id)).toEqual([
+      expect.objectContaining({
+        messageKey: 'video_transcript',
+        transcriptCues: [{ startSeconds: 1, endSeconds: 2, text: 'first' }],
+        videoChapters: [{ title: 'Intro', startSeconds: 0, endSeconds: 10 }],
+      }),
+    ]);
+    const initialRevision = await readDataRevision('messages');
+
+    await syncConversationMessages(id, [initial]);
+    expect(await readDataRevision('messages')).toBe(initialRevision);
+
+    await syncConversationMessages(
+      id,
+      [
+        {
+          ...initial,
+          contentMarkdown: '[00:03] second',
+          updatedAt: 101,
+          transcriptCues: [{ startSeconds: 3, endSeconds: null, text: 'second' }],
+          videoChapters: undefined,
+        },
+      ],
+      { mode: 'incremental', diff: { added: [], updated: ['video_transcript'], removed: [] } },
+    );
+    let stored = (await getMessagesByConversationId(id))[0] as any;
+    expect(stored.transcriptCues).toEqual([{ startSeconds: 3, endSeconds: null, text: 'second' }]);
+    expect(stored.videoChapters).toEqual([{ title: 'Intro', startSeconds: 0, endSeconds: 10 }]);
+
+    await syncConversationMessages(id, [
+      {
+        messageKey: 'video_transcript',
+        role: 'transcript',
+        contentMarkdown: '[00:04] no structured cue',
+        sequence: 1,
+        updatedAt: 102,
+        videoChapters: [],
+      },
+    ]);
+    stored = (await getMessagesByConversationId(id))[0] as any;
+    expect(stored).not.toHaveProperty('transcriptCues');
+    expect(stored.videoChapters).toEqual([]);
+  });
+
+  it('does not allow transcript-only structured fields on ordinary messages and keeps Activity-only recapture revision-safe', async () => {
+    const convo = await upsertConversation({
+      sourceType: 'video',
+      source: 'video',
+      conversationKey: 'video:https://www.youtube.com/watch?v=activity',
+      title: 'Activity',
+      url: 'https://www.youtube.com/watch?v=activity',
+      platform: 'youtube',
+      lastActivityAt: 10,
+    });
+    const id = Number(convo.id);
+    const message = {
+      messageKey: 'video_transcript',
+      role: 'transcript',
+      contentMarkdown: '[00:01] same',
+      sequence: 1,
+      updatedAt: 100,
+      transcriptCues: [{ startSeconds: 1, endSeconds: null, text: 'same' }],
+    };
+    await syncConversationMessages(id, [message]);
+    const messageRevision = await readDataRevision('messages');
+    const conversationRevision = await readDataRevision('conversations');
+
+    await syncConversationMessages(id, [message], { activityAt: 20 });
+    expect(await readDataRevision('messages')).toBe(messageRevision);
+    expect(await readDataRevision('conversations')).toBe(conversationRevision + 1);
+    expect((await getConversationById(id))?.lastActivityAt).toBe(20);
+
+    await syncConversationMessages(id, [
+      {
+        messageKey: 'ordinary',
+        role: 'assistant',
+        contentMarkdown: 'ordinary',
+        sequence: 2,
+        updatedAt: 101,
+        transcriptCues: [{ startSeconds: 9, endSeconds: null, text: 'stray' }],
+        videoChapters: [{ title: 'stray', startSeconds: 0, endSeconds: null }],
+      },
+    ]);
+    const ordinary = (await getMessagesByConversationId(id))[0] as any;
+    expect(ordinary.messageKey).toBe('ordinary');
+    expect(ordinary).not.toHaveProperty('transcriptCues');
+    expect(ordinary).not.toHaveProperty('videoChapters');
+  });
+});

--- a/tests/unit/video-content-domain.test.ts
+++ b/tests/unit/video-content-domain.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatVideoChaptersMarkdown,
+  formatVideoTimecode,
+  formatVideoTranscriptMarkdown,
+  normalizeCanonicalVideoChapters,
+  normalizeCanonicalVideoTranscriptCues,
+  toCanonicalVideoTranscriptCues,
+} from '../../src/services/conversations/domain/video-content';
+
+describe('canonical video content domain', () => {
+  it('maps source cues to exact canonical timing without sorting or merging', () => {
+    expect(
+      toCanonicalVideoTranscriptCues([
+        { start: 1.234, end: 3.456, text: 'first', sid: 1 },
+        { start: 5, end: 4, text: 'bad end' },
+        { start: null, end: 8, text: 'bad start' },
+        { start: 9, end: 10, text: '' },
+      ]),
+    ).toEqual([
+      { startSeconds: 1.234, endSeconds: 3.456, text: 'first' },
+      { startSeconds: 5, endSeconds: null, text: 'bad end' },
+    ]);
+  });
+
+  it('accepts only canonical cue keys and strips extras', () => {
+    expect(
+      normalizeCanonicalVideoTranscriptCues([
+        { startSeconds: 1.234, endSeconds: 3.456, text: 'cue', rawExtra: true },
+        { start: 5, end: 6, text: 'legacy alias' },
+      ]),
+    ).toEqual([{ startSeconds: 1.234, endSeconds: 3.456, text: 'cue' }]);
+  });
+
+  it('accepts only canonical chapter keys, strips extras, and preserves order', () => {
+    expect(
+      normalizeCanonicalVideoChapters([
+        { title: ' First\nchapter ', startSeconds: 10, endSeconds: 20, imgUrl: 'raw' },
+        { title: 'Second', startSeconds: 0, endSeconds: null },
+        { content: 'raw alias', from: 30, to: 40 },
+      ]),
+    ).toEqual([
+      { title: 'First chapter', startSeconds: 10, endSeconds: 20 },
+      { title: 'Second', startSeconds: 0, endSeconds: null },
+    ]);
+  });
+
+  it('formats millisecond timecodes without losing precision', () => {
+    expect(formatVideoTimecode(1.234)).toBe('00:01.234');
+    expect(formatVideoTimecode(3.456)).toBe('00:03.456');
+    expect(formatVideoTimecode(62)).toBe('01:02');
+    expect(formatVideoTimecode(3661.007)).toBe('01:01:01.007');
+  });
+
+  it('formats transcript ranges from canonical cues only', () => {
+    expect(
+      formatVideoTranscriptMarkdown([
+        { startSeconds: 1.234, endSeconds: 3.456, text: 'hello' },
+        { startSeconds: 5, endSeconds: null, text: 'world' },
+      ]),
+    ).toBe('[00:01.234 → 00:03.456] hello\n[00:05] world');
+  });
+
+  it('formats canonical chapters as a dedicated markdown section', () => {
+    expect(
+      formatVideoChaptersMarkdown([
+        { title: 'Intro', startSeconds: 0, endSeconds: 30 },
+        { title: 'Main', startSeconds: 30.5, endSeconds: null },
+      ]),
+    ).toBe('## Chapters\n\n- [00:00 → 00:30] Intro\n- [00:30.500] Main');
+    expect(formatVideoChaptersMarkdown([])).toBe('');
+  });
+});

--- a/tests/unit/video-transcript-capture.test.ts
+++ b/tests/unit/video-transcript-capture.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  extractVideoTranscriptFromCurrentPage: vi.fn(),
+}));
+
+vi.mock('@collectors/video/video-transcript-extract', () => ({
+  extractVideoTranscriptFromCurrentPage: mocks.extractVideoTranscriptFromCurrentPage,
+}));
+
+import { createVideoTranscriptCaptureService } from '../../src/services/bootstrap/video-transcript-capture';
+import { CORE_MESSAGE_TYPES } from '../../src/platform/messaging/message-contracts';
+
+function successfulRuntime() {
+  const send = vi.fn(async (type: string) => {
+    if (type === CORE_MESSAGE_TYPES.UPSERT_CONVERSATION) {
+      return { ok: true, data: { id: 7, __isNew: true }, error: null };
+    }
+    if (type === CORE_MESSAGE_TYPES.SYNC_CONVERSATION_MESSAGES) {
+      return { ok: true, data: { upserted: 1, deleted: 0 }, error: null };
+    }
+    throw new Error(`unexpected type: ${type}`);
+  });
+  return { send };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('video transcript capture service', () => {
+  it('persists canonical metadata, cues, chapters and lossless Markdown with canonical message names', async () => {
+    mocks.extractVideoTranscriptFromCurrentPage.mockResolvedValue({
+      meta: {
+        platform: 'bilibili',
+        url: 'https://www.bilibili.com/video/BV1TEST12345/',
+        title: 'Video title',
+        author: 'Author',
+        description: 'Full description\nsecond line',
+        durationSeconds: 123.5,
+        thumbnailUrl: 'https://example.com/thumb.jpg',
+      },
+      cues: [
+        { start: 1.234, end: 3.456, text: 'hello', sid: 1 },
+        { start: 5, text: 'world' },
+      ],
+      chapters: [
+        { title: 'Intro', startSeconds: 0, endSeconds: 30, imgUrl: 'raw' },
+        { title: 'Main', startSeconds: 30, endSeconds: null },
+      ],
+    });
+    const runtime = successfulRuntime();
+    const service = createVideoTranscriptCaptureService({ runtime });
+
+    await expect(service.captureVideoTranscript()).resolves.toEqual({
+      conversationId: 7,
+      title: 'Video title',
+      url: 'https://www.bilibili.com/video/BV1TEST12345/',
+      isNew: true,
+      subtitleStatus: 'ok',
+    });
+
+    expect(runtime.send).toHaveBeenNthCalledWith(1, CORE_MESSAGE_TYPES.UPSERT_CONVERSATION, {
+      payload: {
+        sourceType: 'video',
+        source: 'video',
+        conversationKey: 'video:https://www.bilibili.com/video/BV1TEST12345/',
+        title: 'Video title',
+        url: 'https://www.bilibili.com/video/BV1TEST12345/',
+        author: 'Author',
+        lastActivityAt: 0,
+        platform: 'bilibili',
+        durationSeconds: 123.5,
+        thumbnailUrl: 'https://example.com/thumb.jpg',
+        videoDescription: 'Full description\nsecond line',
+      },
+    });
+    expect((runtime.send.mock.calls[0]?.[1] as any)?.payload).not.toHaveProperty('publishedAt');
+    expect((runtime.send.mock.calls[0]?.[1] as any)?.payload).not.toHaveProperty('warningFlags');
+    expect((runtime.send.mock.calls[0]?.[1] as any)?.payload).not.toHaveProperty('transcriptSource');
+    expect((runtime.send.mock.calls[0]?.[1] as any)?.payload).not.toHaveProperty('hasTimestamps');
+
+    expect(runtime.send).toHaveBeenNthCalledWith(
+      2,
+      CORE_MESSAGE_TYPES.SYNC_CONVERSATION_MESSAGES,
+      expect.objectContaining({
+        conversationId: 7,
+        mode: 'snapshot',
+        conversationSourceType: 'video',
+        conversationUrl: 'https://www.bilibili.com/video/BV1TEST12345/',
+        messages: [
+          {
+            messageKey: 'video_transcript',
+            role: 'transcript',
+            contentMarkdown: '[00:01.234 → 00:03.456] hello\n[00:05] world',
+            transcriptCues: [
+              { startSeconds: 1.234, endSeconds: 3.456, text: 'hello' },
+              { startSeconds: 5, endSeconds: null, text: 'world' },
+            ],
+            videoChapters: [
+              { title: 'Intro', startSeconds: 0, endSeconds: 30 },
+              { title: 'Main', startSeconds: 30, endSeconds: null },
+            ],
+            sequence: 1,
+            updatedAt: expect.any(Number),
+          },
+        ],
+      }),
+    );
+  });
+
+  it('omits chapters when this capture did not observe a trustworthy chapter response', async () => {
+    mocks.extractVideoTranscriptFromCurrentPage.mockResolvedValue({
+      meta: {
+        platform: 'youtube',
+        url: 'https://www.youtube.com/watch?v=test',
+        title: 'YouTube',
+        author: '',
+        description: '',
+        durationSeconds: null,
+        thumbnailUrl: '',
+      },
+      cues: [{ start: 1, end: 2, text: 'subtitle' }],
+      chapters: null,
+    });
+    const runtime = successfulRuntime();
+
+    await createVideoTranscriptCaptureService({ runtime }).captureVideoTranscript();
+    const message = ((runtime.send.mock.calls[1]?.[1] as any)?.messages || [])[0];
+    expect(message).not.toHaveProperty('videoChapters');
+    expect(message.transcriptCues).toEqual([{ startSeconds: 1, endSeconds: 2, text: 'subtitle' }]);
+  });
+
+  it('sends an explicit empty chapter array so storage can clear previous chapters', async () => {
+    mocks.extractVideoTranscriptFromCurrentPage.mockResolvedValue({
+      meta: {
+        platform: 'bilibili',
+        url: 'https://www.bilibili.com/video/BV1TEST12345/',
+        title: 'Video',
+        author: '',
+        description: '',
+        durationSeconds: null,
+        thumbnailUrl: '',
+      },
+      cues: [{ start: 1, text: 'subtitle' }],
+      chapters: [],
+    });
+    const runtime = successfulRuntime();
+
+    await createVideoTranscriptCaptureService({ runtime }).captureVideoTranscript();
+    const message = ((runtime.send.mock.calls[1]?.[1] as any)?.messages || [])[0];
+    expect(message.videoChapters).toEqual([]);
+  });
+
+  it('does not create an empty Video when no canonical cues remain', async () => {
+    mocks.extractVideoTranscriptFromCurrentPage.mockResolvedValue({
+      meta: {
+        platform: 'bilibili',
+        url: 'https://www.bilibili.com/video/BV1TEST12345/',
+        title: 'No subtitles',
+        author: '',
+        description: 'context',
+        durationSeconds: 10,
+        thumbnailUrl: '',
+      },
+      cues: [
+        { start: null, end: 2, text: 'invalid' },
+        { start: 1, text: '' },
+      ],
+      chapters: [{ title: 'Chapter', startSeconds: 0, endSeconds: 10 }],
+    });
+    const runtime = successfulRuntime();
+
+    await expect(createVideoTranscriptCaptureService({ runtime }).captureVideoTranscript()).resolves.toEqual({
+      conversationId: null,
+      title: 'No subtitles',
+      url: 'https://www.bilibili.com/video/BV1TEST12345/',
+      subtitleStatus: 'empty',
+    });
+    expect(runtime.send).not.toHaveBeenCalled();
+  });
+
+  it('propagates canonical runtime failures instead of reporting a saved Video', async () => {
+    mocks.extractVideoTranscriptFromCurrentPage.mockResolvedValue({
+      meta: {
+        platform: 'youtube',
+        url: 'https://www.youtube.com/watch?v=test',
+        title: 'Video',
+        author: '',
+        description: '',
+        durationSeconds: 10,
+        thumbnailUrl: '',
+      },
+      cues: [{ start: 1, text: 'subtitle' }],
+      chapters: null,
+    });
+
+    const upsertFailure = {
+      send: vi.fn(async () => ({ ok: false, data: null, error: { message: 'upsert failed' } })),
+    };
+    await expect(
+      createVideoTranscriptCaptureService({ runtime: upsertFailure }).captureVideoTranscript(),
+    ).rejects.toThrow('upsert failed');
+
+    const syncFailure = {
+      send: vi.fn(async (type: string) =>
+        type === CORE_MESSAGE_TYPES.UPSERT_CONVERSATION
+          ? { ok: true, data: { id: 9, __isNew: false }, error: null }
+          : { ok: false, data: null, error: { message: 'sync failed' } },
+      ),
+    };
+    await expect(
+      createVideoTranscriptCaptureService({ runtime: syncFailure }).captureVideoTranscript(),
+    ).rejects.toThrow('sync failed');
+  });
+});

--- a/tests/unit/video-transcript-extract.test.ts
+++ b/tests/unit/video-transcript-extract.test.ts
@@ -135,7 +135,37 @@ describe('video transcript extraction', () => {
     expect(extracted.chapters).toBeNull();
   });
 
-  it('treats a current-page empty view_points array as an explicit chapter clear', async () => {
+  it('falls back to an earlier current-page WBI response when the latest response cannot determine chapters', async () => {
+    const page = 'https://www.bilibili.com/video/BV1BBBBBBBBB/';
+    installDom(page);
+    installMetaResponder({ state: { platform: 'bilibili', identityUrl: page }, dom: null });
+    setResponses([
+      {
+        url: 'https://aisubtitle.hdslb.com/bfs/ai_subtitle/b.json',
+        pageUrl: page,
+        bodyText: JSON.stringify({ body: [{ from: 1, to: 2, content: 'subtitle' }] }),
+        at: 1,
+      },
+      {
+        url: 'https://api.bilibili.com/x/player/wbi/v2?cid=valid',
+        pageUrl: page,
+        bodyText: JSON.stringify({ code: 0, data: { view_points: [{ content: 'Valid', from: 0, to: 20 }] } }),
+        at: 2,
+      },
+      {
+        url: 'https://api.bilibili.com/x/player/wbi/v2?cid=latest-incomplete',
+        pageUrl: page,
+        bodyText: JSON.stringify({ code: 0, data: {} }),
+        at: 3,
+      },
+    ]);
+
+    expect((await extractVideoTranscriptFromCurrentPage()).chapters).toEqual([
+      { title: 'Valid', startSeconds: 0, endSeconds: 20 },
+    ]);
+  });
+
+  it('treats the latest current-page explicit empty view_points array as a chapter clear', async () => {
     const page = 'https://www.bilibili.com/video/BV1BBBBBBBBB/';
     installDom(page);
     installMetaResponder({ state: { platform: 'bilibili', identityUrl: page }, dom: null });

--- a/tests/unit/video-transcript-extract.test.ts
+++ b/tests/unit/video-transcript-extract.test.ts
@@ -1,0 +1,268 @@
+import { JSDOM } from 'jsdom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { requestVideoPageMeta } from '../../src/collectors/video/video-bridge-store';
+import { extractVideoTranscriptFromCurrentPage } from '../../src/collectors/video/video-transcript-extract';
+
+const STORE_KEY = '__SYNCNOS_VIDEO_TRANSCRIPT_BRIDGE__';
+
+let dom: JSDOM;
+
+function installDom(url: string, html = '<!doctype html><html><head></head><body></body></html>') {
+  dom = new JSDOM(html, { url });
+  vi.stubGlobal('window', dom.window as unknown as Window & typeof globalThis);
+  vi.stubGlobal('document', dom.window.document);
+  vi.stubGlobal('location', dom.window.location);
+}
+
+function setResponses(responses: any[]) {
+  (globalThis as any)[STORE_KEY] = { responses };
+}
+
+function installMetaResponder(meta: any) {
+  vi.spyOn(window, 'postMessage').mockImplementation((data: any) => {
+    if (data?.type !== 'SYNCNOS_VIDEO_META_REQUEST') return;
+    window.dispatchEvent(
+      new (window as any).MessageEvent('message', {
+        source: window,
+        data: {
+          __syncnos: true,
+          type: 'SYNCNOS_VIDEO_META_RESPONSE',
+          requestId: data.requestId,
+          meta,
+        },
+      }),
+    );
+  });
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  delete (globalThis as any)[STORE_KEY];
+});
+
+afterEach(() => {
+  delete (globalThis as any)[STORE_KEY];
+  vi.unstubAllGlobals();
+  dom?.window.close();
+});
+
+describe('video transcript extraction', () => {
+  it('uses only Bilibili subtitle and chapter responses bound to the current canonical page', async () => {
+    const pageA = 'https://www.bilibili.com/video/BV1AAAAAAAAA/';
+    const pageB = 'https://www.bilibili.com/video/BV1BBBBBBBBB/';
+    installDom(pageB, '<div class="bpx-player-subtitle-panel-text"><span>stale DOM subtitle</span></div>');
+    installMetaResponder({
+      state: {
+        platform: 'bilibili',
+        identityUrl: pageB,
+        title: 'B title',
+        author: 'B author',
+        description: 'B description',
+        durationSeconds: 123.5,
+        thumbnailUrl: 'https://example.com/b.jpg',
+      },
+      dom: null,
+    });
+    setResponses([
+      {
+        url: 'https://aisubtitle.hdslb.com/bfs/ai_subtitle/a.json',
+        pageUrl: pageA,
+        bodyText: JSON.stringify({ body: [{ from: 1, to: 2, content: 'A subtitle' }] }),
+        at: 10,
+      },
+      {
+        url: 'https://api.bilibili.com/x/player/wbi/v2?cid=a',
+        pageUrl: pageA,
+        bodyText: JSON.stringify({ code: 0, data: { view_points: [{ content: 'A chapter', from: 0, to: 10 }] } }),
+        at: 11,
+      },
+      {
+        url: 'https://aisubtitle.hdslb.com/bfs/ai_subtitle/b.json',
+        pageUrl: pageB,
+        bodyText: JSON.stringify({ body: [{ from: 1.234, to: 3.456, content: 'B subtitle' }] }),
+        at: 20,
+      },
+      {
+        url: 'https://api.bilibili.com/x/player/wbi/v2?cid=b',
+        pageUrl: pageB,
+        bodyText: JSON.stringify({ code: 0, data: { view_points: [{ content: 'B chapter', from: 0, to: 30 }] } }),
+        at: 21,
+      },
+    ]);
+
+    const extracted = await extractVideoTranscriptFromCurrentPage();
+
+    expect(extracted).toEqual({
+      meta: {
+        platform: 'bilibili',
+        url: pageB,
+        title: 'B title',
+        author: 'B author',
+        description: 'B description',
+        durationSeconds: 123.5,
+        thumbnailUrl: 'https://example.com/b.jpg',
+      },
+      cues: [{ start: 1.234, end: 3.456, text: 'B subtitle' }],
+      chapters: [{ title: 'B chapter', startSeconds: 0, endSeconds: 30 }],
+    });
+  });
+
+  it('returns empty subtitles and unknown chapters when only stale or identity-less Bilibili responses exist', async () => {
+    const pageA = 'https://www.bilibili.com/video/BV1AAAAAAAAA/';
+    const pageB = 'https://www.bilibili.com/video/BV1BBBBBBBBB/';
+    installDom(pageB, '<div class="bpx-player-subtitle-panel-text"><span>must not be used</span></div>');
+    installMetaResponder({
+      state: { platform: 'bilibili', identityUrl: pageB, title: 'B' },
+      dom: null,
+    });
+    setResponses([
+      {
+        url: 'https://aisubtitle.hdslb.com/bfs/ai_subtitle/a.json',
+        pageUrl: pageA,
+        bodyText: JSON.stringify({ body: [{ from: 1, to: 2, content: 'A subtitle' }] }),
+        at: 10,
+      },
+      {
+        url: 'https://api.bilibili.com/x/player/wbi/v2?cid=missing-page',
+        bodyText: JSON.stringify({ code: 0, data: { view_points: [{ content: 'old', from: 0, to: 10 }] } }),
+        at: 11,
+      },
+    ]);
+
+    const extracted = await extractVideoTranscriptFromCurrentPage();
+    expect(extracted.cues).toEqual([]);
+    expect(extracted.chapters).toBeNull();
+  });
+
+  it('treats a current-page empty view_points array as an explicit chapter clear', async () => {
+    const page = 'https://www.bilibili.com/video/BV1BBBBBBBBB/';
+    installDom(page);
+    installMetaResponder({ state: { platform: 'bilibili', identityUrl: page }, dom: null });
+    setResponses([
+      {
+        url: 'https://aisubtitle.hdslb.com/bfs/ai_subtitle/b.json',
+        pageUrl: page,
+        bodyText: JSON.stringify({ body: [{ from: 1, to: 2, content: 'subtitle' }] }),
+        at: 1,
+      },
+      {
+        url: 'https://api.bilibili.com/x/player/wbi/v2?cid=b',
+        pageUrl: page,
+        bodyText: JSON.stringify({ code: 0, data: { view_points: [] } }),
+        at: 2,
+      },
+    ]);
+
+    expect((await extractVideoTranscriptFromCurrentPage()).chapters).toEqual([]);
+  });
+
+  it('rejects stale state metadata as a whole and selects an identity-matched Bilibili DOM candidate', async () => {
+    const pageA = 'https://www.bilibili.com/video/BV1AAAAAAAAA/';
+    const pageB = 'https://www.bilibili.com/video/BV1BBBBBBBBB/';
+    installDom(pageB);
+    installMetaResponder({
+      state: {
+        platform: 'bilibili',
+        identityUrl: pageA,
+        title: 'A title',
+        author: 'A author',
+        description: 'A description',
+        durationSeconds: 999,
+        thumbnailUrl: 'https://example.com/a.jpg',
+      },
+      dom: {
+        platform: 'bilibili',
+        identityUrl: pageB,
+        title: 'B title',
+        author: 'B author',
+        description: 'B description',
+      },
+    });
+    setResponses([]);
+
+    const { meta } = await extractVideoTranscriptFromCurrentPage();
+    expect(meta).toEqual({
+      platform: 'bilibili',
+      url: pageB,
+      title: 'B title',
+      author: 'B author',
+      description: 'B description',
+      durationSeconds: null,
+      thumbnailUrl: '',
+    });
+  });
+
+  it('does not use stale YouTube transcript DOM when no current timedtext response exists', async () => {
+    const page = 'https://www.youtube.com/watch?v=current';
+    installDom(
+      page,
+      '<ytd-transcript-segment-renderer><span class="segment-timestamp">0:01</span><span class="segment-text">stale</span></ytd-transcript-segment-renderer>',
+    );
+    installMetaResponder({
+      state: { platform: 'youtube', identityUrl: page, title: 'Current video' },
+      dom: null,
+    });
+    setResponses([
+      {
+        url: 'https://www.youtube.com/api/timedtext?v=old',
+        pageUrl: 'https://www.youtube.com/watch?v=old',
+        bodyText: '<transcript><text start="1" dur="1">old</text></transcript>',
+        at: 1,
+      },
+    ]);
+
+    const extracted = await extractVideoTranscriptFromCurrentPage();
+    expect(extracted.cues).toEqual([]);
+    expect(extracted.chapters).toBeNull();
+  });
+});
+
+describe('video page metadata request', () => {
+  it('resolves only the matching request id and removes its one-shot listener', async () => {
+    installDom('https://www.bilibili.com/video/BV1BBBBBBBBB/');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+    let requestId = '';
+    vi.spyOn(window, 'postMessage').mockImplementation((data: any) => {
+      if (data?.type !== 'SYNCNOS_VIDEO_META_REQUEST') return;
+      requestId = data.requestId;
+      window.dispatchEvent(
+        new (window as any).MessageEvent('message', {
+          source: window,
+          data: {
+            __syncnos: true,
+            type: 'SYNCNOS_VIDEO_META_RESPONSE',
+            requestId: 'wrong-id',
+            meta: { state: { platform: 'bilibili', identityUrl: 'wrong' }, dom: null },
+          },
+        }),
+      );
+      window.dispatchEvent(
+        new (window as any).MessageEvent('message', {
+          source: window,
+          data: {
+            __syncnos: true,
+            type: 'SYNCNOS_VIDEO_META_RESPONSE',
+            requestId,
+            meta: { state: { platform: 'bilibili', identityUrl: location.href }, dom: null },
+          },
+        }),
+      );
+    });
+
+    await expect(requestVideoPageMeta({ timeoutMs: 50 })).resolves.toEqual({
+      state: { platform: 'bilibili', identityUrl: location.href },
+      dom: null,
+    });
+    expect(removeSpy).toHaveBeenCalledWith('message', expect.any(Function));
+  });
+
+  it('times out without polling or retaining a pending request', async () => {
+    installDom('https://www.youtube.com/watch?v=current');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+    vi.spyOn(window, 'postMessage').mockImplementation(() => undefined);
+
+    await expect(requestVideoPageMeta({ timeoutMs: 1 })).resolves.toBeNull();
+    expect(removeSpy).toHaveBeenCalledWith('message', expect.any(Function));
+  });
+});

--- a/tests/unit/video-transcript-parse.test.ts
+++ b/tests/unit/video-transcript-parse.test.ts
@@ -129,9 +129,12 @@ describe('video transcript parsers', () => {
     ]);
   });
 
-  it('distinguishes an explicit empty chapter list from an unknown response', () => {
+  it('distinguishes an explicit empty chapter list from an unknown or non-success response', () => {
     expect(parseBilibiliViewPointsJson(JSON.stringify({ code: 0, data: { view_points: [] } }))).toEqual([]);
     expect(parseBilibiliViewPointsJson(JSON.stringify({ code: -1, data: { view_points: [] } }))).toBeNull();
+    expect(parseBilibiliViewPointsJson(JSON.stringify({ code: null, data: { view_points: [] } }))).toBeNull();
+    expect(parseBilibiliViewPointsJson(JSON.stringify({ code: '', data: { view_points: [] } }))).toBeNull();
+    expect(parseBilibiliViewPointsJson(JSON.stringify({ data: { view_points: [] } }))).toBeNull();
     expect(parseBilibiliViewPointsJson(JSON.stringify({ code: 0, data: {} }))).toBeNull();
     expect(parseBilibiliViewPointsJson('{bad')).toBeNull();
   });

--- a/tests/unit/video-transcript-parse.test.ts
+++ b/tests/unit/video-transcript-parse.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  parseBilibiliSubtitleJson,
+  parseBilibiliViewPointsJson,
+  parseWebVtt,
+  parseYoutubeJson3,
+  parseYoutubeTimedtextXml,
+} from '../../src/collectors/video/video-transcript-parse';
+
+describe('video transcript parsers', () => {
+  it('preserves Bilibili fractional cue timing and drops platform-only fields', () => {
+    const cues = parseBilibiliSubtitleJson(
+      JSON.stringify({
+        body: [
+          {
+            from: 1.234,
+            to: 3.456,
+            content: '  hello  ',
+            sid: 7,
+            location: 2,
+            music: 0,
+            font_color: '#fff',
+          },
+        ],
+      }),
+    );
+
+    expect(cues).toEqual([{ start: 1.234, end: 3.456, text: 'hello' }]);
+  });
+
+  it('accepts only the current top-level Bilibili subtitle body shape', () => {
+    expect(parseBilibiliSubtitleJson(JSON.stringify({ data: { body: [{ from: 1, to: 2, content: 'x' }] } }))).toEqual(
+      [],
+    );
+    expect(parseBilibiliSubtitleJson(JSON.stringify({ result: { body: [{ from: 1, to: 2, content: 'x' }] } }))).toEqual(
+      [],
+    );
+    expect(
+      parseBilibiliSubtitleJson(JSON.stringify({ subtitle: { body: [{ from: 1, to: 2, content: 'x' }] } })),
+    ).toEqual([]);
+  });
+
+  it('rejects missing, blank, negative, and non-finite starts without inventing zero', () => {
+    const cues = parseBilibiliSubtitleJson(
+      JSON.stringify({
+        body: [
+          { from: null, to: 1, content: 'null' },
+          { from: '', to: 1, content: 'empty' },
+          { from: '   ', to: 1, content: 'blank' },
+          { from: -1, to: 1, content: 'negative' },
+          { from: 'nope', to: 1, content: 'nan' },
+          { from: 2, to: 1, content: 'bad-end' },
+          { from: 3, to: '', content: 'blank-end' },
+          { from: 4, to: 5, content: '' },
+        ],
+      }),
+    );
+
+    expect(cues).toEqual([
+      { start: 2, text: 'bad-end' },
+      { start: 3, text: 'blank-end' },
+    ]);
+  });
+
+  it('parses YouTube timedtext start and dur independently', () => {
+    expect(
+      parseYoutubeTimedtextXml('<transcript><text start="1.234" dur="2.222">A &amp; B</text></transcript>'),
+    ).toEqual([{ start: 1.234, end: 3.456, text: 'A & B' }]);
+    expect(parseYoutubeTimedtextXml('<transcript><text dur="2">missing start</text></transcript>')).toEqual([]);
+    expect(parseYoutubeTimedtextXml('<transcript><text start="2" dur="">blank dur</text></transcript>')).toEqual([
+      { start: 2, text: 'blank dur' },
+    ]);
+  });
+
+  it('rejects invalid YouTube json3 timing without inventing zero', () => {
+    const json = JSON.stringify({
+      events: [
+        { tStartMs: null, dDurationMs: 1000, segs: [{ utf8: 'null' }] },
+        { tStartMs: '', dDurationMs: 1000, segs: [{ utf8: 'empty' }] },
+        { tStartMs: -1, dDurationMs: 1000, segs: [{ utf8: 'negative' }] },
+        { tStartMs: 1500, dDurationMs: null, segs: [{ utf8: 'no end' }] },
+        { tStartMs: 2500, dDurationMs: -1, segs: [{ utf8: 'bad duration' }] },
+        { tStartMs: 3500, dDurationMs: 500, segs: [{ utf8: 'timed' }] },
+      ],
+    });
+
+    expect(parseYoutubeJson3(json)).toEqual([
+      { start: 1.5, text: 'no end' },
+      { start: 2.5, text: 'bad duration' },
+      { start: 3.5, end: 4, text: 'timed' },
+    ]);
+  });
+
+  it('keeps WebVTT fractional timing and ignores an end before start', () => {
+    expect(parseWebVtt('WEBVTT\n\n00:01.234 --> 00:03.456\nhello\n\n00:05.000 --> 00:04.000\nsecond')).toEqual([
+      { start: 1.234, end: 3.456, text: 'hello' },
+      { start: 5, text: 'second' },
+    ]);
+  });
+
+  it('parses Bilibili view_points into platform-neutral chapters', () => {
+    const chapters = parseBilibiliViewPointsJson(
+      JSON.stringify({
+        code: 0,
+        data: {
+          view_points: [
+            {
+              content: '  Intro\nsection  ',
+              from: 0,
+              to: 30.5,
+              type: 1,
+              imgUrl: 'https://example.com/image.jpg',
+              logoUrl: 'https://example.com/logo.png',
+              team_type: 2,
+              team_name: 'team',
+            },
+            { content: 'Bad end', from: 31, to: 20 },
+            { content: '', from: 40, to: 50 },
+            { content: 'Bad start', from: null, to: 50 },
+          ],
+        },
+      }),
+    );
+
+    expect(chapters).toEqual([
+      { title: 'Intro section', startSeconds: 0, endSeconds: 30.5 },
+      { title: 'Bad end', startSeconds: 31, endSeconds: null },
+    ]);
+  });
+
+  it('distinguishes an explicit empty chapter list from an unknown response', () => {
+    expect(parseBilibiliViewPointsJson(JSON.stringify({ code: 0, data: { view_points: [] } }))).toEqual([]);
+    expect(parseBilibiliViewPointsJson(JSON.stringify({ code: -1, data: { view_points: [] } }))).toBeNull();
+    expect(parseBilibiliViewPointsJson(JSON.stringify({ code: 0, data: {} }))).toBeNull();
+    expect(parseBilibiliViewPointsJson('{bad')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Related issue

Part of #556

## Why

SyncNos already had a Video capture path, but it only persisted a flattened transcript and mixed page/network state in ways that could lose timing precision or cross-contaminate data after SPA navigation. Bilibili chapters (`view_points`) and stable Video metadata also were not part of the canonical local model.

This PR establishes the capture/storage foundation before routing and UI changes are layered on top.

## Scope

### In scope

- Bind intercepted subtitle/chapter responses to the page URL that initiated the request.
- Parse YouTube/Bilibili network transcript responses with millisecond timing.
- Capture Bilibili `view_points` chapters without issuing an extra platform API request.
- Persist canonical transcript cues, chapters, description, platform, duration, and thumbnail data.
- Preserve/restore the new Video fields through Backup export/import.
- Remove obsolete DOM transcript fallbacks and anonymous A/B/C transcript-source diagnostics.

### Non-goals

- No Current Page routing/UI consolidation in this PR.
- No Reader/export/provider projection changes in this PR.
- No active requests to fetch subtitles or chapters that the page did not naturally load.

## What changed

- Added a shared Video capture contract and canonical conversation-domain Video content helpers.
- Reworked MAIN-world interception and the isolated-world bridge to classify exact supported subtitle/chapter endpoints and attach request-page identity.
- Deleted untrusted DOM transcript fallbacks; successful transcript cues now come from identity-bound network responses.
- Added canonical `{startSeconds,endSeconds,text}` transcript cues and `{title,startSeconds,endSeconds}` chapters.
- Added canonical Video metadata persistence to Conversation records and structured transcript/chapter persistence to the `video_transcript` message.
- Updated Backup merge/round-trip handling so Video structured data is recoverable without mixing losing-row cues/chapters into the winning message.

## Architecture / invariants

- Capture remains collector/service/domain layered: cross-world endpoint/type helpers live under `services/shared`, collector extraction owns source parsing, and Conversation domain owns canonical persistence/projection types.
- No second Video store or message type was introduced; `video_transcript` remains the single timeline message.
- SPA safety is identity-based rather than timer/retry heuristics: responses are accepted only when their request-page canonical Video identity matches the current Video.
- Untrusted page `postMessage` data remains bounded at the isolated bridge boundary.

## Data, migration & recovery

No IndexedDB schema-version bump is required because the new fields are additive on existing records.

Runtime writes sanitize canonical cues/chapters before persistence. Backup restore performs the same canonical checks and keeps local valid metadata when the incoming backup only provides missing/empty values. Existing Backup schema remains unchanged and repeated restore remains idempotent.

If transcript/message persistence fails after Conversation upsert, SyncNos keeps the existing local record and surfaces the failure; it does not perform a Video-specific destructive rollback that could delete previously valid data.

## Permissions & privacy

No new browser permissions, OAuth scopes, secrets, or network destinations.

Bilibili chapters are consumed only from the player's naturally loaded `x/player/wbi/v2` response; SyncNos does not add a new Bilibili API request. Persisted Video metadata remains local unless the user later uses an existing sync/export path.

## Compatibility

- YouTube network timedtext / JSON transcript responses remain supported.
- Bilibili BV video transcript responses and player `view_points` chapters are supported.
- DOM transcript fallbacks are intentionally removed because they cannot prove Video identity across SPA transitions.
- Existing remote Notion schema columns are not destructively removed in this PR.

## Demo

N/A — this PR changes capture/storage internals and does not add or redesign a visible surface.

## Drawbacks / risks

- If the page has not naturally loaded a subtitle/chapter response, SyncNos will not synthesize or fetch it in this layer.
- The bridge keeps a bounded recent response history to prevent unbounded memory growth from page-originated messages.

## Tests & validation

### Automated

- `npm run gate:ci`
- Result: 291 test files / 2265 tests passed.
- Targeted coverage includes Video parser, interceptor, bridge, extraction, capture, IDB persistence, and Backup round-trip tests.

### Manual

N/A — routing/UI is introduced by the next stacked PR. Final stack-level Bilibili browser validation is documented in the closing PR.

## Documentation

No canonical product documentation changes are required yet because this PR only establishes the internal capture/storage foundation; user-facing behavior is introduced by subsequent stacked PRs.
