### PR TITLE
refactor: 审计并清理 Video 捕获链冗余与边界缺陷

### DIFF
--- a/src/collectors/video/video-bridge-store.ts
+++ b/src/collectors/video/video-bridge-store.ts
@@ -39,10 +39,7 @@ function randomId(): string {
   return `${Date.now()}_${Math.random().toString(16).slice(2)}`;
 }
 
-export function requestVideoPageMeta(options?: { timeoutMs?: number }): Promise<VideoPageMetaCandidates | null> {
-  const requestedTimeout = Number(options?.timeoutMs);
-  const timeoutMs =
-    Number.isFinite(requestedTimeout) && requestedTimeout >= 0 ? Math.floor(requestedTimeout) : DEFAULT_META_TIMEOUT_MS;
+export function requestVideoPageMeta(): Promise<VideoPageMetaCandidates | null> {
   const requestId = randomId();
 
   return new Promise((resolve) => {
@@ -74,7 +71,7 @@ export function requestVideoPageMeta(options?: { timeoutMs?: number }): Promise<
     };
 
     window.addEventListener('message', onMessage);
-    timer = setTimeout(() => finish(null), timeoutMs);
+    timer = setTimeout(() => finish(null), DEFAULT_META_TIMEOUT_MS);
 
     try {
       window.postMessage({ __syncnos: true, type: 'SYNCNOS_VIDEO_META_REQUEST', requestId }, '*');

--- a/src/collectors/video/video-bridge-store.ts
+++ b/src/collectors/video/video-bridge-store.ts
@@ -3,7 +3,6 @@ import type { VideoPageMetaCandidates } from '@services/shared/video-capture';
 type StoreResponse = {
   url: string;
   pageUrl: string;
-  contentType?: string;
   bodyText: string;
   at: number;
 };

--- a/src/collectors/video/video-transcript-extract.ts
+++ b/src/collectors/video/video-transcript-extract.ts
@@ -7,7 +7,7 @@ import {
   parseYoutubeTimedtextXml,
   type TranscriptCue,
 } from '@collectors/video/video-transcript-parse';
-import { canonicalizeVideoUrl } from '@services/url-cleaning/video-url';
+import { canonicalizeVideoUrl, detectSupportedVideoPagePlatform } from '@services/url-cleaning/video-url';
 import {
   classifyVideoResponseUrl,
   type VideoChapter,
@@ -17,8 +17,8 @@ import {
   type VideoResponseKind,
 } from '@services/shared/video-capture';
 
-export type VideoTranscriptMeta = {
-  platform: VideoPlatform | 'unknown';
+type VideoTranscriptMeta = {
+  platform: VideoPlatform;
   url: string;
   title: string;
   author: string;
@@ -27,7 +27,7 @@ export type VideoTranscriptMeta = {
   thumbnailUrl: string;
 };
 
-export type VideoTranscriptExtraction = {
+type VideoTranscriptExtraction = {
   meta: VideoTranscriptMeta;
   cues: TranscriptCue[];
   chapters: VideoChapter[] | null;
@@ -41,13 +41,6 @@ function normalizeText(value: unknown): string {
     .trim();
 }
 
-function inferPlatform(): VideoTranscriptMeta['platform'] {
-  const host = String(location.hostname || '').toLowerCase();
-  if (host === 'www.youtube.com' || host === 'youtube.com' || host === 'youtu.be') return 'youtube';
-  if (host === 'www.bilibili.com' || host === 'bilibili.com') return 'bilibili';
-  return 'unknown';
-}
-
 function normalizeDuration(value: unknown): number | null {
   if (value == null || (typeof value === 'string' && !value.trim())) return null;
   const duration = Number(value);
@@ -57,11 +50,10 @@ function normalizeDuration(value: unknown): number | null {
 function selectMetaCandidate(
   candidates: VideoPageMetaCandidates | null,
   currentUrl: string,
-  platform: VideoTranscriptMeta['platform'],
 ): VideoPageMetaCandidate | null {
-  if (!candidates || platform === 'unknown') return null;
+  if (!candidates) return null;
   for (const candidate of [candidates.state, candidates.dom]) {
-    if (!candidate || candidate.platform !== platform) continue;
+    if (!candidate) continue;
     const identityUrl = canonicalizeVideoUrl(candidate.identityUrl);
     if (identityUrl && identityUrl === currentUrl) return candidate;
   }
@@ -69,11 +61,13 @@ function selectMetaCandidate(
 }
 
 async function collectMeta(): Promise<VideoTranscriptMeta> {
-  const platform = inferPlatform();
   const href = String(location.href || '');
-  const canonical = canonicalizeVideoUrl(href) || href;
+  const platform = detectSupportedVideoPagePlatform(href);
+  if (!platform) throw new Error('unsupported video page');
+  const canonical = canonicalizeVideoUrl(href);
+  if (!canonical) throw new Error('invalid video URL');
   const candidates = await requestVideoPageMeta();
-  const candidate = selectMetaCandidate(candidates, canonical, platform);
+  const candidate = selectMetaCandidate(candidates, canonical);
 
   return {
     platform,
@@ -140,13 +134,9 @@ export async function extractVideoTranscriptFromCurrentPage(): Promise<VideoTran
     };
   }
 
-  if (meta.platform === 'bilibili') {
-    return {
-      meta,
-      cues: extractBilibiliCuesFromIntercept(meta.url),
-      chapters: extractBilibiliChaptersFromIntercept(meta.url),
-    };
-  }
-
-  return { meta, cues: [], chapters: null };
+  return {
+    meta,
+    cues: extractBilibiliCuesFromIntercept(meta.url),
+    chapters: extractBilibiliChaptersFromIntercept(meta.url),
+  };
 }

--- a/src/collectors/video/video-transcript-extract.ts
+++ b/src/collectors/video/video-transcript-extract.ts
@@ -106,8 +106,11 @@ function parseYoutubeBody(bodyText: string): TranscriptCue[] {
 }
 
 function extractYoutubeCuesFromIntercept(currentUrl: string): TranscriptCue[] {
-  const picked = listCurrentResponses(currentUrl, 'youtube-timedtext')[0];
-  return picked ? parseYoutubeBody(picked.bodyText) : [];
+  for (const item of listCurrentResponses(currentUrl, 'youtube-timedtext')) {
+    const cues = parseYoutubeBody(item.bodyText);
+    if (cues.length) return cues;
+  }
+  return [];
 }
 
 function extractBilibiliCuesFromIntercept(currentUrl: string): TranscriptCue[] {

--- a/src/entrypoints/video-transcript-bridge.content.ts
+++ b/src/entrypoints/video-transcript-bridge.content.ts
@@ -3,7 +3,6 @@ import { classifyVideoResponseUrl } from '@services/shared/video-capture';
 type StoreResponse = {
   url: string;
   pageUrl: string;
-  contentType?: string;
   bodyText: string;
   at: number;
 };
@@ -34,7 +33,6 @@ function pushResponse(store: VideoTranscriptBridgeStore, next: StoreResponse) {
   store.responses.push({
     url,
     pageUrl,
-    contentType: next?.contentType ? String(next.contentType) : undefined,
     bodyText,
     at: Number(next?.at) || Date.now(),
   });
@@ -56,7 +54,6 @@ export default defineContentScript({
       pushResponse(store, {
         url: String(data.url || ''),
         pageUrl: String(data.pageUrl || ''),
-        contentType: data.contentType ? String(data.contentType) : undefined,
         bodyText: String(data.bodyText || ''),
         at: Number(data.at) || Date.now(),
       });

--- a/src/entrypoints/video-transcript-bridge.content.ts
+++ b/src/entrypoints/video-transcript-bridge.content.ts
@@ -24,17 +24,18 @@ function getStore(): VideoTranscriptBridgeStore {
   return created;
 }
 
-function pushResponse(store: VideoTranscriptBridgeStore, next: StoreResponse) {
-  const url = String(next?.url || '').trim();
-  const pageUrl = String(next?.pageUrl || '').trim();
-  const bodyText = String(next?.bodyText || '');
+function pushResponse(store: VideoTranscriptBridgeStore, next: unknown) {
+  const input = next && typeof next === 'object' ? (next as Record<string, unknown>) : {};
+  const url = String(input.url || '').trim();
+  const pageUrl = String(input.pageUrl || '').trim();
+  const bodyText = String(input.bodyText || '');
   if (!classifyVideoResponseUrl(url) || !pageUrl || !bodyText || bodyText.length > MAX_BODY_CHARS) return;
 
   store.responses.push({
     url,
     pageUrl,
     bodyText,
-    at: Number(next?.at) || Date.now(),
+    at: Number(input.at) || Date.now(),
   });
   if (store.responses.length > MAX_RESPONSES) {
     store.responses.splice(0, store.responses.length - MAX_RESPONSES);
@@ -51,12 +52,7 @@ export default defineContentScript({
       if (event.source !== window) return;
       const data: any = event.data;
       if (!data || data.__syncnos !== true || data.type !== 'SYNCNOS_VIDEO_INTERCEPTED') return;
-      pushResponse(store, {
-        url: String(data.url || ''),
-        pageUrl: String(data.pageUrl || ''),
-        bodyText: String(data.bodyText || ''),
-        at: Number(data.at) || Date.now(),
-      });
+      pushResponse(store, data);
     });
   },
 });

--- a/src/entrypoints/video-transcript-interceptor.content.ts
+++ b/src/entrypoints/video-transcript-interceptor.content.ts
@@ -1,4 +1,4 @@
-import { canonicalizeVideoUrl } from '@services/url-cleaning/video-url';
+import { canonicalizeVideoUrl, detectSupportedVideoPagePlatform } from '@services/url-cleaning/video-url';
 import {
   classifyVideoResponseUrl,
   type VideoPageMetaCandidate,
@@ -76,7 +76,6 @@ function collectYoutubeStateCandidate(): VideoPageMetaCandidate | null {
     const thumbs = Array.isArray(details?.thumbnail?.thumbnails) ? details.thumbnail.thumbnails : [];
     const bestThumb = thumbs.length ? thumbs[thumbs.length - 1] : null;
     return {
-      platform: 'youtube',
       identityUrl,
       title: normalizeText(details?.title),
       author: normalizeText(details?.author),
@@ -118,7 +117,6 @@ function collectBilibiliStateCandidate(): VideoPageMetaCandidate | null {
       : '';
 
     return {
-      platform: 'bilibili',
       identityUrl,
       title: normalizeText(videoData?.title),
       author: normalizeText(videoData?.owner?.name),
@@ -136,7 +134,6 @@ function collectBilibiliDomCandidate(): VideoPageMetaCandidate | null {
     const identityUrl = canonicalizeVideoUrl(document.querySelector('link[rel="canonical"]')?.getAttribute('href'));
     if (!identityUrl) return null;
     return {
-      platform: 'bilibili',
       identityUrl,
       title: normalizeText((document.querySelector('h1.video-title') as HTMLElement | null)?.innerText),
       author: normalizeText((document.querySelector('a.up-name') as HTMLElement | null)?.innerText),
@@ -148,11 +145,9 @@ function collectBilibiliDomCandidate(): VideoPageMetaCandidate | null {
 }
 
 function collectMetaForPage(): VideoPageMetaCandidates {
-  const host = String(location.hostname || '').toLowerCase();
-  if (host === 'www.youtube.com' || host === 'youtube.com' || host === 'youtu.be') {
-    return { state: collectYoutubeStateCandidate(), dom: null };
-  }
-  if (host === 'www.bilibili.com' || host === 'bilibili.com') {
+  const platform = detectSupportedVideoPagePlatform(location.href);
+  if (platform === 'youtube') return { state: collectYoutubeStateCandidate(), dom: null };
+  if (platform === 'bilibili') {
     return { state: collectBilibiliStateCandidate(), dom: collectBilibiliDomCandidate() };
   }
   return { state: null, dom: null };

--- a/src/entrypoints/video-transcript-interceptor.content.ts
+++ b/src/entrypoints/video-transcript-interceptor.content.ts
@@ -10,7 +10,6 @@ type InterceptedResponsePayload = {
   type: 'SYNCNOS_VIDEO_INTERCEPTED';
   url: string;
   pageUrl: string;
-  contentType?: string;
   bodyText: string;
   at: number;
 };
@@ -38,10 +37,6 @@ function normalizeDuration(value: unknown): number | null {
   if (value == null || (typeof value === 'string' && !value.trim())) return null;
   const duration = Number(value);
   return Number.isFinite(duration) && duration >= 0 ? duration : null;
-}
-
-function parseContentType(value: unknown): string {
-  return String(value || '').trim();
 }
 
 function resolveAbsoluteUrl(raw: unknown): string {
@@ -180,7 +175,6 @@ function wrapFetch() {
       postIntercept({
         url,
         pageUrl,
-        contentType: parseContentType(cloned?.headers?.get?.('content-type')),
         bodyText,
         at: Date.now(),
       });
@@ -243,7 +237,6 @@ function wrapXhr() {
               postIntercept({
                 url,
                 pageUrl,
-                contentType: parseContentType((this as any).getResponseHeader?.('content-type')),
                 bodyText,
                 at: Date.now(),
               });

--- a/src/services/bootstrap/video-transcript-capture.ts
+++ b/src/services/bootstrap/video-transcript-capture.ts
@@ -10,12 +10,6 @@ type RuntimeClient = {
   send?: (type: string, payload?: Record<string, unknown>) => Promise<any>;
 };
 
-function normalizeText(text: unknown) {
-  return String(text || '')
-    .replace(/\r\n/g, '\n')
-    .trim();
-}
-
 function toError(message: unknown) {
   return new Error(String(message || 'unknown error'));
 }
@@ -34,26 +28,21 @@ export function createVideoTranscriptCaptureService(deps: { runtime: RuntimeClie
     conversationId: number;
     title?: string;
     isNew: boolean;
-    url?: string;
+    url: string;
     subtitleStatus: 'ok' | 'empty';
   }> {
     const extracted = await extractVideoTranscriptFromCurrentPage();
     const activityAt = Date.now();
-
-    const rawUrl = normalizeText(extracted?.meta?.url || location.href);
-    const url = normalizeText(rawUrl);
-
-    const title = normalizeText(extracted?.meta?.title || '');
-    const author = normalizeText(extracted?.meta?.author || '');
-    const platform = normalizeText(extracted?.meta?.platform || '');
-    const durationSeconds =
-      extracted?.meta?.durationSeconds != null && Number.isFinite(Number(extracted.meta.durationSeconds))
-        ? Math.max(0, Number(extracted.meta.durationSeconds))
-        : null;
-    const thumbnailUrl = normalizeText(extracted?.meta?.thumbnailUrl || '');
-    const videoDescription = normalizeText(extracted?.meta?.description || '');
-
-    const transcriptCues = toCanonicalVideoTranscriptCues(Array.isArray(extracted?.cues) ? extracted.cues : []);
+    const {
+      url,
+      title,
+      author,
+      platform,
+      durationSeconds,
+      thumbnailUrl,
+      description: videoDescription,
+    } = extracted.meta;
+    const transcriptCues = toCanonicalVideoTranscriptCues(extracted.cues);
     const transcriptMarkdown = formatVideoTranscriptMarkdown(transcriptCues);
     const subtitleStatus: 'ok' | 'empty' = transcriptCues.length ? 'ok' : 'empty';
 
@@ -65,7 +54,6 @@ export function createVideoTranscriptCaptureService(deps: { runtime: RuntimeClie
         title,
         url,
         author,
-        lastActivityAt: 0,
         platform,
         durationSeconds,
         thumbnailUrl,
@@ -89,18 +77,15 @@ export function createVideoTranscriptCaptureService(deps: { runtime: RuntimeClie
     if (transcriptCues.length) {
       message.transcriptCues = transcriptCues;
     }
-    if (extracted?.chapters !== null) {
-      message.videoChapters = normalizeCanonicalVideoChapters(extracted?.chapters);
+    if (extracted.chapters !== null) {
+      message.videoChapters = normalizeCanonicalVideoChapters(extracted.chapters);
     }
-    const messages = [message];
 
     const messagesRes = await send(CORE_MESSAGE_TYPES.SYNC_CONVERSATION_MESSAGES, {
       conversationId: conversation.id,
-      messages,
+      messages: [message],
       mode: 'snapshot',
-      diff: null,
       conversationSourceType: 'video',
-      conversationUrl: url,
       activityAt,
     });
     if (!messagesRes?.ok) {

--- a/src/services/conversations/background/handlers.ts
+++ b/src/services/conversations/background/handlers.ts
@@ -240,23 +240,30 @@ export function registerConversationHandlers(router: AnyRouter, deps: Conversati
         .toLowerCase() || 'chat';
 
     let messages = Array.isArray(msg.messages) ? msg.messages : [];
-    try {
-      const local = await storageGet([ABOUT_YOU_USER_NAME_STORAGE_KEY]);
-      const aboutYouUserName =
-        normalizeUserName(local?.[ABOUT_YOU_USER_NAME_STORAGE_KEY]) || DEFAULT_ABOUT_YOU_USER_NAME;
+    const needsDefaultUserAuthor = messages.some((message: any) => {
+      if (!message || typeof message !== 'object') return false;
+      const role = String(message.role || '')
+        .trim()
+        .toLowerCase();
+      return role === 'user' && !String(message.authorName || '').trim();
+    });
+    if (needsDefaultUserAuthor) {
+      try {
+        const local = await storageGet([ABOUT_YOU_USER_NAME_STORAGE_KEY]);
+        const aboutYouUserName =
+          normalizeUserName(local?.[ABOUT_YOU_USER_NAME_STORAGE_KEY]) || DEFAULT_ABOUT_YOU_USER_NAME;
 
-      messages = messages.map((m: any) => {
-        if (!m || typeof m !== 'object') return m;
-        const role = String((m as any).role || '')
-          .trim()
-          .toLowerCase();
-        if (role !== 'user') return m;
-        const currentAuthor = String((m as any).authorName || '').trim();
-        if (currentAuthor) return m;
-        return { ...(m as any), authorName: aboutYouUserName };
-      });
-    } catch (_e) {
-      // ignore: authorName is optional and will fallback during rendering
+        messages = messages.map((message: any) => {
+          if (!message || typeof message !== 'object') return message;
+          const role = String(message.role || '')
+            .trim()
+            .toLowerCase();
+          if (role !== 'user' || String(message.authorName || '').trim()) return message;
+          return { ...message, authorName: aboutYouUserName };
+        });
+      } catch (_e) {
+        // ignore: authorName is optional and will fallback during rendering
+      }
     }
     if (sourceType !== 'video') {
       try {

--- a/src/services/conversations/background/handlers.ts
+++ b/src/services/conversations/background/handlers.ts
@@ -234,6 +234,10 @@ export function registerConversationHandlers(router: AnyRouter, deps: Conversati
     if (hasActivityAt && (!Number.isFinite(activityAt) || Number(activityAt) <= 0)) {
       return router.err('invalid activityAt');
     }
+    const sourceType =
+      String(msg?.conversationSourceType || '')
+        .trim()
+        .toLowerCase() || 'chat';
 
     let messages = Array.isArray(msg.messages) ? msg.messages : [];
     try {
@@ -254,54 +258,52 @@ export function registerConversationHandlers(router: AnyRouter, deps: Conversati
     } catch (_e) {
       // ignore: authorName is optional and will fallback during rendering
     }
-    try {
-      const sourceType =
-        String(msg?.conversationSourceType || '')
-          .trim()
-          .toLowerCase() || 'chat';
-      const local = await storageGet(['ai_chat_cache_images_enabled', 'web_article_cache_images_enabled']);
-      const enabled =
-        sourceType === 'article'
-          ? local?.web_article_cache_images_enabled === true
-          : local?.ai_chat_cache_images_enabled === true;
-      const keys =
-        (mode === 'incremental' || mode === 'append') && diff
-          ? new Set(
-              [...(Array.isArray(diff.added) ? diff.added : []), ...(Array.isArray(diff.updated) ? diff.updated : [])]
-                .map((x) => String(x || '').trim())
-                .filter(Boolean),
-            )
-          : null;
-      const inlined = await inlineChatImagesInMessages({
-        conversationId,
-        conversationUrl: String(msg?.conversationUrl || ''),
-        messages,
-        onlyMessageKeys: keys,
-        enableHttpImages: enabled,
-      });
-      messages = inlined.messages;
-      if (
-        inlined.inlinedCount > 0 ||
-        inlined.downloadedCount > 0 ||
-        inlined.fromCacheCount > 0 ||
-        (Array.isArray(inlined.warningFlags) && inlined.warningFlags.length)
-      ) {
-        console.info('[ImageInline]', {
+    if (sourceType !== 'video') {
+      try {
+        const local = await storageGet(['ai_chat_cache_images_enabled', 'web_article_cache_images_enabled']);
+        const enabled =
+          sourceType === 'article'
+            ? local?.web_article_cache_images_enabled === true
+            : local?.ai_chat_cache_images_enabled === true;
+        const keys =
+          (mode === 'incremental' || mode === 'append') && diff
+            ? new Set(
+                [...(Array.isArray(diff.added) ? diff.added : []), ...(Array.isArray(diff.updated) ? diff.updated : [])]
+                  .map((x) => String(x || '').trim())
+                  .filter(Boolean),
+              )
+            : null;
+        const inlined = await inlineChatImagesInMessages({
+          conversationId,
+          conversationUrl: String(msg?.conversationUrl || ''),
+          messages,
+          onlyMessageKeys: keys,
+          enableHttpImages: enabled,
+        });
+        messages = inlined.messages;
+        if (
+          inlined.inlinedCount > 0 ||
+          inlined.downloadedCount > 0 ||
+          inlined.fromCacheCount > 0 ||
+          (Array.isArray(inlined.warningFlags) && inlined.warningFlags.length)
+        ) {
+          console.info('[ImageInline]', {
+            conversationId,
+            mode,
+            inlinedCount: inlined.inlinedCount,
+            downloadedCount: inlined.downloadedCount,
+            fromCacheCount: inlined.fromCacheCount,
+            inlinedBytes: inlined.inlinedBytes,
+            warningFlags: inlined.warningFlags,
+          });
+        }
+      } catch (error) {
+        console.warn('[ImageInline] failed but capture continues', {
           conversationId,
           mode,
-          inlinedCount: inlined.inlinedCount,
-          downloadedCount: inlined.downloadedCount,
-          fromCacheCount: inlined.fromCacheCount,
-          inlinedBytes: inlined.inlinedBytes,
-          warningFlags: inlined.warningFlags,
+          error: error instanceof Error ? error.message : String(error || ''),
         });
       }
-    } catch (error) {
-      console.warn('[ImageInline] failed but capture continues', {
-        conversationId,
-        mode,
-        error: error instanceof Error ? error.message : String(error || ''),
-      });
     }
 
     const res = await syncConversationMessages(conversationId, messages, {

--- a/src/services/conversations/domain/text-count.ts
+++ b/src/services/conversations/domain/text-count.ts
@@ -13,7 +13,7 @@ type CountableMessage = {
 };
 
 const VIDEO_TIMESTAMP_PREFIX_RE =
-  /^\s*(?:\[(?:\d{2}:)?\d{2}:\d{2}(?:\.\d{1,3})?(?:\s+→\s+(?:\d{2}:)?\d{2}:\d{2}(?:\.\d{1,3})?)?\]|(?:\d{2}:)?\d{2}:\d{2})\s+/gm;
+  /^\s*(?:\[(?:\d{2,}:)?\d{2}:\d{2}(?:\.\d{1,3})?(?:\s+→\s+(?:\d{2,}:)?\d{2}:\d{2}(?:\.\d{1,3})?)?\]|(?:\d{2,}:)?\d{2}:\d{2})\s+/gm;
 
 function isEastAsianCountChar(char: string): boolean {
   return LETTER_OR_NUMBER_RE.test(char) && EAST_ASIAN_SCRIPT_RE.test(char);

--- a/src/services/conversations/domain/video-content.ts
+++ b/src/services/conversations/domain/video-content.ts
@@ -1,4 +1,4 @@
-import type { VideoChapter, VideoPlatform } from '@services/shared/video-capture';
+import type { VideoChapter } from '@services/shared/video-capture';
 
 export type VideoTranscriptCue = {
   startSeconds: number;

--- a/src/services/conversations/domain/video-content.ts
+++ b/src/services/conversations/domain/video-content.ts
@@ -6,8 +6,6 @@ export type VideoTranscriptCue = {
   text: string;
 };
 
-export type { VideoChapter, VideoPlatform };
-
 function normalizeText(value: unknown): string {
   return String(value ?? '')
     .replace(/\r\n/g, '\n')

--- a/src/services/shared/video-capture.ts
+++ b/src/services/shared/video-capture.ts
@@ -7,7 +7,6 @@ export type VideoChapter = {
 };
 
 export type VideoPageMetaCandidate = {
-  platform: VideoPlatform;
   identityUrl: string;
   title?: string;
   author?: string;

--- a/src/services/sync/local/json-export.ts
+++ b/src/services/sync/local/json-export.ts
@@ -59,7 +59,7 @@ type JsonVideoItem = JsonCommon & {
   author: string | null;
   description: string | null;
   transcript: JsonContent;
-  cues: Array<{ startSeconds: number | null; endSeconds: number | null; text: string }>;
+  cues: Array<{ startSeconds: number; endSeconds: number | null; text: string }>;
   chapters: Array<{ title: string; startSeconds: number; endSeconds: number | null }>;
 };
 

--- a/src/viewmodels/settings/insight-stats.ts
+++ b/src/viewmodels/settings/insight-stats.ts
@@ -2,6 +2,7 @@ import { formatConversationTitle, t } from '@i18n';
 import type { Conversation } from '@services/conversations/domain/models';
 import type { InsightStatsSourceData } from '@services/insight/insight-stats-source';
 import { parseHostnameFromUrl } from '@services/url-cleaning/hostname';
+import { detectVideoPlatformHost } from '@services/url-cleaning/video-url';
 import { encodeConversationLoc } from '@services/shared/conversation-loc';
 import { shiftLocalCalendarDays, startOfLocalCalendarDay } from '@services/shared/local-calendar-day';
 
@@ -98,14 +99,14 @@ function parseHostname(value: unknown): string {
   return hostname || INSIGHT_UNKNOWN_DOMAIN_LABEL;
 }
 
-function parseVideoPlatform(url: unknown, source: unknown): string {
-  const hostname = parseHostnameFromUrl(url).toLowerCase();
-  if (hostname === 'youtu.be' || hostname === 'youtube.com' || hostname.endsWith('.youtube.com')) return 'YouTube';
-  if (hostname === 'bilibili.com' || hostname.endsWith('.bilibili.com')) return 'Bilibili';
+function parseVideoPlatform(conversation: Conversation): string {
+  const platform = safeString(conversation.platform).toLowerCase();
+  if (platform === 'youtube') return 'YouTube';
+  if (platform === 'bilibili') return 'Bilibili';
 
-  const sourceName = safeString(source).toLowerCase();
-  if (sourceName === 'youtube') return 'YouTube';
-  if (sourceName === 'bilibili') return 'Bilibili';
+  const urlPlatform = detectVideoPlatformHost(conversation.url);
+  if (urlPlatform === 'youtube') return 'YouTube';
+  if (urlPlatform === 'bilibili') return 'Bilibili';
   return INSIGHT_UNKNOWN_SOURCE_LABEL;
 }
 
@@ -286,7 +287,7 @@ export function buildInsightStats(
 
     if (sourceType === 'video') {
       stats.videoCount += 1;
-      const platform = parseVideoPlatform(conversation.url, conversation.source);
+      const platform = parseVideoPlatform(conversation);
       videoPlatforms.set(platform, (videoPlatforms.get(platform) || 0) + 1);
 
       const commentCount = Number(data.commentCounts.get(Number(conversation.id)) || 0);

--- a/tests/services/conversation-text-count.test.ts
+++ b/tests/services/conversation-text-count.test.ts
@@ -151,10 +151,11 @@ describe('countConversationMessageTextUnits', () => {
             '[00:01.234] alpha beta',
             '[00:01.234 → 00:03.456] gamma',
             '[01:02:03.004 → 01:02:05.006] delta',
+            '[100:00:00 → 100:00:01] epsilon',
           ].join('\n'),
         },
       ]),
-    ).toBe(9);
+    ).toBe(10);
   });
 
   it('keeps timestamp-like text for ordinary messages', () => {

--- a/tests/smoke/background-router-conversations.test.ts
+++ b/tests/smoke/background-router-conversations.test.ts
@@ -269,6 +269,37 @@ describe('background-router conversations', () => {
     );
   });
 
+  it('skips chat/article image inlining for Video transcript messages', async () => {
+    storageMocks.syncConversationMessages.mockResolvedValue({ upserted: 1, deleted: 0 });
+    const router = createRouter();
+    const messages = [
+      {
+        messageKey: 'video_transcript',
+        role: 'transcript',
+        contentMarkdown: '[00:01] ![caption](https://example.com/not-an-image.png)',
+      },
+    ];
+
+    const res = await router.__handleMessageForTests({
+      type: 'syncConversationMessages',
+      conversationId: 2004,
+      conversationSourceType: 'video',
+      conversationUrl: 'https://www.bilibili.com/video/BV1TEST12345/',
+      messages,
+    });
+
+    expect(res.ok).toBe(true);
+    expect(localStorageMocks.storageGet).not.toHaveBeenCalledWith([
+      'ai_chat_cache_images_enabled',
+      'web_article_cache_images_enabled',
+    ]);
+    expect(imageInlineMocks.inlineChatImagesInMessages).not.toHaveBeenCalled();
+    expect(storageMocks.syncConversationMessages).toHaveBeenCalledWith(2004, messages, {
+      mode: 'snapshot',
+      diff: null,
+    });
+  });
+
   it('keeps transient protective policies through author normalization and image inlining', async () => {
     storageMocks.syncConversationMessages.mockResolvedValue({ upserted: 1, deleted: 0 });
     imageInlineMocks.inlineChatImagesInMessages.mockImplementation(async (input: any) =>

--- a/tests/smoke/background-router-conversations.test.ts
+++ b/tests/smoke/background-router-conversations.test.ts
@@ -289,10 +289,7 @@ describe('background-router conversations', () => {
     });
 
     expect(res.ok).toBe(true);
-    expect(localStorageMocks.storageGet).not.toHaveBeenCalledWith([
-      'ai_chat_cache_images_enabled',
-      'web_article_cache_images_enabled',
-    ]);
+    expect(localStorageMocks.storageGet).not.toHaveBeenCalled();
     expect(imageInlineMocks.inlineChatImagesInMessages).not.toHaveBeenCalled();
     expect(storageMocks.syncConversationMessages).toHaveBeenCalledWith(2004, messages, {
       mode: 'snapshot',

--- a/tests/smoke/video-transcript-bridge.test.ts
+++ b/tests/smoke/video-transcript-bridge.test.ts
@@ -59,7 +59,6 @@ describe('video transcript isolated bridge', () => {
       type: 'SYNCNOS_VIDEO_INTERCEPTED',
       url: 'https://aisubtitle.hdslb.com/bfs/ai_subtitle/current.json',
       pageUrl: location.href,
-      contentType: 'application/json',
       bodyText: '{"body":[]}',
       at: 10,
     });
@@ -90,7 +89,6 @@ describe('video transcript isolated bridge', () => {
         {
           url: 'https://aisubtitle.hdslb.com/bfs/ai_subtitle/current.json',
           pageUrl: location.href,
-          contentType: 'application/json',
           bodyText: '{"body":[]}',
           at: 10,
         },

--- a/tests/smoke/video-transcript-interceptor.test.ts
+++ b/tests/smoke/video-transcript-interceptor.test.ts
@@ -232,7 +232,6 @@ describe('video transcript main-world interceptor', () => {
       requestId: 'youtube-meta',
       meta: {
         state: {
-          platform: 'youtube',
           identityUrl: 'https://www.youtube.com/watch?v=abc',
           title: 'Title',
           author: 'Author',
@@ -277,7 +276,6 @@ describe('video transcript main-world interceptor', () => {
     dispatchMetaRequest('bilibili-meta');
     const response = findPosted(postSpy, 'SYNCNOS_VIDEO_META_RESPONSE')[0];
     expect(response.meta.state).toEqual({
-      platform: 'bilibili',
       identityUrl: 'https://www.bilibili.com/video/BV1STATE1234/?p=2',
       title: 'State title',
       author: 'State author',
@@ -286,7 +284,6 @@ describe('video transcript main-world interceptor', () => {
       thumbnailUrl: 'https://example.com/state.jpg',
     });
     expect(response.meta.dom).toEqual({
-      platform: 'bilibili',
       identityUrl: 'https://www.bilibili.com/video/BV1DOM123456/?p=2',
       title: 'DOM title',
       author: 'DOM author',

--- a/tests/smoke/video-transcript-interceptor.test.ts
+++ b/tests/smoke/video-transcript-interceptor.test.ts
@@ -139,7 +139,6 @@ describe('video transcript main-world interceptor', () => {
     expect(posted[0]).toMatchObject({
       url: 'https://www.youtube.com/api/timedtext',
       pageUrl: pageB,
-      contentType: 'application/json',
       bodyText: JSON.stringify(xhr.response),
     });
   });

--- a/tests/storage/insight-stats.test.ts
+++ b/tests/storage/insight-stats.test.ts
@@ -151,7 +151,8 @@ describe('insight stats', () => {
     });
     const videoId = await seedConversation({
       sourceType: 'video',
-      source: 'YouTube',
+      source: 'video',
+      platform: 'youtube',
       conversationKey: 'video-key-only',
       title: 'Key only video',
       url: 'https://youtube.com/watch?v=key-only',
@@ -431,7 +432,8 @@ describe('insight stats', () => {
     });
     await seedConversation({
       sourceType: 'video',
-      source: 'YouTube',
+      source: 'video',
+      platform: 'youtube',
       conversationKey: 'video-known',
       title: 'Saved transcript',
       url: 'https://www.youtube.com/watch?v=abc',
@@ -555,7 +557,8 @@ describe('insight stats', () => {
     });
     const videoMost = await seedConversation({
       sourceType: 'video',
-      source: 'YouTube',
+      source: 'video',
+      platform: 'youtube',
       conversationKey: 'video-most-comments',
       title: 'Most commented video',
       url: 'https://youtube.com/watch?v=most',
@@ -563,7 +566,8 @@ describe('insight stats', () => {
     });
     const videoSecond = await seedConversation({
       sourceType: 'video',
-      source: 'Bilibili',
+      source: 'video',
+      platform: 'bilibili',
       conversationKey: 'video-second-comments',
       title: 'Second commented video',
       url: 'https://bilibili.com/video/BV1xx411c7mD',

--- a/tests/unit/video-transcript-capture.test.ts
+++ b/tests/unit/video-transcript-capture.test.ts
@@ -68,7 +68,6 @@ describe('video transcript capture service', () => {
         title: 'Video title',
         url: 'https://www.bilibili.com/video/BV1TEST12345/',
         author: 'Author',
-        lastActivityAt: 0,
         platform: 'bilibili',
         durationSeconds: 123.5,
         thumbnailUrl: 'https://example.com/thumb.jpg',
@@ -87,7 +86,6 @@ describe('video transcript capture service', () => {
         conversationId: 7,
         mode: 'snapshot',
         conversationSourceType: 'video',
-        conversationUrl: 'https://www.bilibili.com/video/BV1TEST12345/',
         messages: [
           {
             messageKey: 'video_transcript',

--- a/tests/unit/video-transcript-extract.test.ts
+++ b/tests/unit/video-transcript-extract.test.ts
@@ -257,6 +257,32 @@ describe('video transcript extraction', () => {
     });
   });
 
+  it('falls back to an earlier current-page YouTube timedtext response when the latest response is not parseable', async () => {
+    const page = 'https://www.youtube.com/watch?v=current';
+    installDom(page);
+    installMetaResponder({
+      state: { platform: 'youtube', identityUrl: page, title: 'Current video' },
+      dom: null,
+    });
+    setResponses([
+      {
+        url: 'https://www.youtube.com/api/timedtext?v=current&lang=en',
+        pageUrl: page,
+        bodyText: '<transcript><text start="1.25" dur="1.5">valid</text></transcript>',
+        at: 1,
+      },
+      {
+        url: 'https://www.youtube.com/api/timedtext?v=current&lang=en&fmt=invalid',
+        pageUrl: page,
+        bodyText: '{not valid json',
+        at: 2,
+      },
+    ]);
+
+    const extracted = await extractVideoTranscriptFromCurrentPage();
+    expect(extracted.cues).toEqual([{ start: 1.25, end: 2.75, text: 'valid' }]);
+  });
+
   it('does not use stale YouTube transcript DOM when no current timedtext response exists', async () => {
     const page = 'https://www.youtube.com/watch?v=current';
     installDom(

--- a/tests/unit/video-transcript-extract.test.ts
+++ b/tests/unit/video-transcript-extract.test.ts
@@ -340,7 +340,7 @@ describe('video page metadata request', () => {
       );
     });
 
-    await expect(requestVideoPageMeta({ timeoutMs: 50 })).resolves.toEqual({
+    await expect(requestVideoPageMeta()).resolves.toEqual({
       state: { platform: 'bilibili', identityUrl: location.href },
       dom: null,
     });
@@ -348,11 +348,18 @@ describe('video page metadata request', () => {
   });
 
   it('times out without polling or retaining a pending request', async () => {
-    installDom('https://www.youtube.com/watch?v=current');
-    const removeSpy = vi.spyOn(window, 'removeEventListener');
-    vi.spyOn(window, 'postMessage').mockImplementation(() => undefined);
+    vi.useFakeTimers();
+    try {
+      installDom('https://www.youtube.com/watch?v=current');
+      const removeSpy = vi.spyOn(window, 'removeEventListener');
+      vi.spyOn(window, 'postMessage').mockImplementation(() => undefined);
 
-    await expect(requestVideoPageMeta({ timeoutMs: 1 })).resolves.toBeNull();
-    expect(removeSpy).toHaveBeenCalledWith('message', expect.any(Function));
+      const pending = requestVideoPageMeta();
+      await vi.advanceTimersByTimeAsync(1_200);
+      await expect(pending).resolves.toBeNull();
+      expect(removeSpy).toHaveBeenCalledWith('message', expect.any(Function));
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/unit/video-transcript-extract.test.ts
+++ b/tests/unit/video-transcript-extract.test.ts
@@ -54,7 +54,6 @@ describe('video transcript extraction', () => {
     installDom(pageB, '<div class="bpx-player-subtitle-panel-text"><span>stale DOM subtitle</span></div>');
     installMetaResponder({
       state: {
-        platform: 'bilibili',
         identityUrl: pageB,
         title: 'B title',
         author: 'B author',
@@ -108,13 +107,19 @@ describe('video transcript extraction', () => {
     });
   });
 
+  it('rejects direct extraction on unsupported pages instead of constructing an unknown Video', async () => {
+    installDom('https://www.bilibili.com/opus/123456');
+    setResponses([]);
+
+    await expect(extractVideoTranscriptFromCurrentPage()).rejects.toThrow('unsupported video page');
+  });
+
   it('canonicalizes a Bilibili watch-later container to the same BV identity for metadata, subtitles, and chapters', async () => {
     const watchLater = 'https://www.bilibili.com/list/watchlater?bvid=BV1FwY4zkEef&oid=115049943269792';
     const canonical = 'https://www.bilibili.com/video/BV1FwY4zkEef/';
     installDom(watchLater);
     installMetaResponder({
       state: {
-        platform: 'bilibili',
         identityUrl: canonical,
         title: 'Watch later title',
         description: 'Watch later description',
@@ -147,7 +152,6 @@ describe('video transcript extraction', () => {
     const pageB = 'https://www.bilibili.com/video/BV1BBBBBBBBB/';
     installDom(pageB, '<div class="bpx-player-subtitle-panel-text"><span>must not be used</span></div>');
     installMetaResponder({
-      state: { platform: 'bilibili', identityUrl: pageB, title: 'B' },
       dom: null,
     });
     setResponses([
@@ -172,7 +176,6 @@ describe('video transcript extraction', () => {
   it('falls back to an earlier current-page WBI response when the latest response cannot determine chapters', async () => {
     const page = 'https://www.bilibili.com/video/BV1BBBBBBBBB/';
     installDom(page);
-    installMetaResponder({ state: { platform: 'bilibili', identityUrl: page }, dom: null });
     setResponses([
       {
         url: 'https://aisubtitle.hdslb.com/bfs/ai_subtitle/b.json',
@@ -202,7 +205,6 @@ describe('video transcript extraction', () => {
   it('treats the latest current-page explicit empty view_points array as a chapter clear', async () => {
     const page = 'https://www.bilibili.com/video/BV1BBBBBBBBB/';
     installDom(page);
-    installMetaResponder({ state: { platform: 'bilibili', identityUrl: page }, dom: null });
     setResponses([
       {
         url: 'https://aisubtitle.hdslb.com/bfs/ai_subtitle/b.json',
@@ -227,7 +229,6 @@ describe('video transcript extraction', () => {
     installDom(pageB);
     installMetaResponder({
       state: {
-        platform: 'bilibili',
         identityUrl: pageA,
         title: 'A title',
         author: 'A author',
@@ -236,7 +237,6 @@ describe('video transcript extraction', () => {
         thumbnailUrl: 'https://example.com/a.jpg',
       },
       dom: {
-        platform: 'bilibili',
         identityUrl: pageB,
         title: 'B title',
         author: 'B author',
@@ -261,7 +261,6 @@ describe('video transcript extraction', () => {
     const page = 'https://www.youtube.com/watch?v=current';
     installDom(page);
     installMetaResponder({
-      state: { platform: 'youtube', identityUrl: page, title: 'Current video' },
       dom: null,
     });
     setResponses([
@@ -290,7 +289,6 @@ describe('video transcript extraction', () => {
       '<ytd-transcript-segment-renderer><span class="segment-timestamp">0:01</span><span class="segment-text">stale</span></ytd-transcript-segment-renderer>',
     );
     installMetaResponder({
-      state: { platform: 'youtube', identityUrl: page, title: 'Current video' },
       dom: null,
     });
     setResponses([
@@ -323,7 +321,7 @@ describe('video page metadata request', () => {
             __syncnos: true,
             type: 'SYNCNOS_VIDEO_META_RESPONSE',
             requestId: 'wrong-id',
-            meta: { state: { platform: 'bilibili', identityUrl: 'wrong' }, dom: null },
+            meta: { state: { identityUrl: 'wrong' }, dom: null },
           },
         }),
       );
@@ -334,14 +332,14 @@ describe('video page metadata request', () => {
             __syncnos: true,
             type: 'SYNCNOS_VIDEO_META_RESPONSE',
             requestId,
-            meta: { state: { platform: 'bilibili', identityUrl: location.href }, dom: null },
+            meta: { state: { identityUrl: location.href }, dom: null },
           },
         }),
       );
     });
 
     await expect(requestVideoPageMeta()).resolves.toEqual({
-      state: { platform: 'bilibili', identityUrl: location.href },
+      state: { identityUrl: location.href },
       dom: null,
     });
     expect(removeSpy).toHaveBeenCalledWith('message', expect.any(Function));

--- a/tests/unit/video-transcript-extract.test.ts
+++ b/tests/unit/video-transcript-extract.test.ts
@@ -152,6 +152,7 @@ describe('video transcript extraction', () => {
     const pageB = 'https://www.bilibili.com/video/BV1BBBBBBBBB/';
     installDom(pageB, '<div class="bpx-player-subtitle-panel-text"><span>must not be used</span></div>');
     installMetaResponder({
+      state: { identityUrl: pageB, title: 'B' },
       dom: null,
     });
     setResponses([
@@ -176,6 +177,7 @@ describe('video transcript extraction', () => {
   it('falls back to an earlier current-page WBI response when the latest response cannot determine chapters', async () => {
     const page = 'https://www.bilibili.com/video/BV1BBBBBBBBB/';
     installDom(page);
+    installMetaResponder({ state: { identityUrl: page }, dom: null });
     setResponses([
       {
         url: 'https://aisubtitle.hdslb.com/bfs/ai_subtitle/b.json',
@@ -205,6 +207,7 @@ describe('video transcript extraction', () => {
   it('treats the latest current-page explicit empty view_points array as a chapter clear', async () => {
     const page = 'https://www.bilibili.com/video/BV1BBBBBBBBB/';
     installDom(page);
+    installMetaResponder({ state: { identityUrl: page }, dom: null });
     setResponses([
       {
         url: 'https://aisubtitle.hdslb.com/bfs/ai_subtitle/b.json',
@@ -261,6 +264,7 @@ describe('video transcript extraction', () => {
     const page = 'https://www.youtube.com/watch?v=current';
     installDom(page);
     installMetaResponder({
+      state: { identityUrl: page, title: 'Current video' },
       dom: null,
     });
     setResponses([
@@ -289,6 +293,7 @@ describe('video transcript extraction', () => {
       '<ytd-transcript-segment-renderer><span class="segment-timestamp">0:01</span><span class="segment-text">stale</span></ytd-transcript-segment-renderer>',
     );
     installMetaResponder({
+      state: { identityUrl: page, title: 'Current video' },
       dom: null,
     });
     setResponses([


### PR DESCRIPTION
## Related issue

Closes #556

Depends on #560.

## Why

After the full Video feature was implemented, a commit-by-commit post-implementation audit found several correctness edges and pieces of dead/redundant production surface that should not be carried forward. This PR contains only those audit hardening fixes so the preceding feature PRs stay reviewable.

## Scope

### In scope

- Fix YouTube transcript response fallback when the newest same-page response is malformed/empty.
- Fix Video text count for 100+ hour canonical timecodes.
- Remove stale nullable JSON cue types and other dead Video type exports/imports.
- Remove test-only production configuration and unused cross-world response fields.
- Consolidate Video platform/identity classification and bridge validation.
- Prevent Video transcript messages from entering Chat/Article image-inline processing.
- Avoid unnecessary About You storage reads for message batches that contain no missing user author.
- Remove redundant Video persistence payload fields and a test-created legacy Insight platform fallback.

### Non-goals

- No new supported site or provider.
- No new storage schema, permission, or remote sync target.
- No destructive migration of historical user records.

## What changed

- YouTube extraction now scans current-page timedtext responses newest-to-oldest and uses the first non-empty parseable cue set rather than allowing one bad newest response to hide valid subtitles.
- Video text-count timestamp stripping accepts canonical hour components beyond two digits.
- JSON cue typing now matches the canonical model (`startSeconds` is required).
- Removed the test-only metadata timeout option; tests use fake timers against the single production timeout.
- Removed the unused `contentType` MAIN→bridge→store data channel.
- Reused the shared Video URL/platform classifier instead of maintaining a second host-only inference path; unsupported pages now fail explicitly rather than constructing an `unknown` Video.
- Removed duplicate isolated-bridge input normalization and unused Video type/re-export surfaces.
- Background message persistence now skips Chat/Article image-inline entirely for `sourceType:'video'`, preventing transcript Markdown that resembles an image from triggering unrelated downloads/cache work.
- About You storage is read only when a message batch actually contains a user message missing `authorName`.
- Simplified Video capture persistence payload by removing values that downstream code ignored or normalized identically.
- Insight platform stats now use canonical `conversation.platform` first and URL inference second; the old `source:'YouTube'/'Bilibili'` fallback had no production writer and existed only in legacy fixtures.

## Architecture / invariants

- Video URL/platform identity remains owned by the shared Video URL helpers; collection, routing, Article protection, statistics, and SPA identity no longer maintain parallel platform truth sources.
- Video persistence is not treated as Chat image processing. The background handler branches on the canonical conversation source type.
- Real trust/memory boundaries remain intact: isolated bridge response-count/body-size bounds, metadata listener timeout, SPA page-identity checks, and transcript/chapter partial-update semantics were reviewed and intentionally retained.
- Migration/Backup cleanup for obsolete `transcriptSource` / `hasTimestamps` fields is intentionally retained because it removes stale persisted data; there is no runtime compatibility reader for those fields.

## Data, migration & recovery

No schema-version change.

This PR removes redundant payload and compatibility branches but does not change the canonical Video record shape established by the preceding PRs. Existing Backup/IDB cleanup for obsolete Video diagnostic fields remains so old databases/backups do not reintroduce them.

Video recapture still preserves an existing transcript when the current capture has no trusted cues, preventing destructive loss from transient page state.

## Permissions & privacy

No new permissions, network destinations, OAuth scopes, secrets, or data categories.

Removing Video from Chat image-inline also avoids unnecessary network/image-cache work for transcript Markdown that merely resembles an image reference.

## Compatibility

- Supported YouTube/Bilibili Video URLs and Watch Later canonicalization are unchanged from #560.
- Browser capability fallback for UUID generation is retained because the project does not define a single minimum runtime across Chromium/Firefox/Safari.
- The isolated bridge 30-response / 2 MB limits are retained as the actual untrusted page-message memory boundary.

## Demo

N/A — no new visual surface. This PR is correctness/performance/dead-code hardening of the preceding Video feature stack.

## Drawbacks / risks

None beyond the intended removal of unreachable/test-only legacy behavior. Existing data migrations/cleanup boundaries and user-visible capture semantics remain unchanged.

## Tests & validation

### Automated

- `npm run gate`
- Result: 294 test files / 2304 tests passed.
- ESLint, Prettier, TypeScript compile, and production Chrome MV3 build all passed.
- Targeted Video regression before the full gate: 34 files / 463 tests passed.
- Additional regressions cover malformed-newest YouTube timedtext fallback, Video image-inline bypass, on-demand author settings reads, canonical platform statistics, and bridge/input cleanup.

### Manual

Reloaded the local unpacked production build and exercised the real Bilibili Watch Later page:

`https://www.bilibili.com/list/watchlater?bvid=BV1FwY4zkEef&oid=115049943269792`

Verified:
- Current Page reports `kind:'video'`.
- Save succeeds while the page has no trusted subtitle cues.
- Read-back remains the canonical `video:https://www.bilibili.com/video/BV1FwY4zkEef/` identity.
- Conversation retains Bilibili platform, title/author, duration, thumbnail, full description, and 10 chapters.
- No synthetic transcript/cues are created when subtitles are not observed.

## Documentation

No additional repository product documentation became stale in this hardening-only PR. The preceding PRs contain the user-facing Video/Watch Later documentation changes.
