### PR TITLE
清理 Notion 同步旧兼容与冗余围栏

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ collectors -> services/shared
 - `markdown_reading_profile_v1` 未知值归一到 `medium`。
 - `anti_hotlink_rules_v1` 命中后补 referer 并尝试缓存图片，但图片失败不得阻断正文采集。
 - Provider 的手动同步与自动同步必须收敛到同一 orchestrator / SyncJob 生命周期；scheduler、handler 或 UI 不得另写第二套 progress / terminal job 状态。某 conversation 的非空标题一旦已知，后续空 progress/error payload 不得把它降级回仅 ID；provider 自己的事务、并发和远端写入语义不能被共享 lifecycle 改写。
+- Notion 中由 SyncNos 创建的受管数据库字段与 section 不支持用户自定义其 schema/结构。旧库存在 `Date: date` 且缺少 `Last Activity` 时必须直接把 `Date` 重命名为 `Last Activity`，不能保留 `Date` 再新增第二个 Activity 字段；托管 section 的 list/retrieve 失败必须按远端失败传播或重试，不能降级成“未找到”后创建重复 section。
 - IndexedDB 业务层统一借用 `src/platform/idb/schema.ts` 的 canonical connection；受 revision 跟踪的 writer 必须让业务变更与 revision 同事务提交，consumer 以 durable revision + canonical reread 为正确性真源，禁止重新引入自定义 event/Port 总线作为第二套数据一致性协议。恢复/失败语义见 [`docs/storage.md`](docs/storage.md)。
 
 ## Agent 实现约束

--- a/docs/GENERATION.md
+++ b/docs/GENERATION.md
@@ -21,7 +21,7 @@
 | `PRIVACY.md` | 用户：权限、凭据、本地/外部数据流与第三方边界 | manifest/host permission、OAuth 模式、secret storage/backup exclusion、外部网络目标或本地→远端数据范围变化；核对 `wxt.config.ts`、provider auth/network、backup filtering | README；发布/商店隐私声明 |
 | `docs/storage.md` | 维护者：local-first、一致性、备份/恢复、失败语义 | IDB/revision、canonical read、backup/import、asset remap、continuity/恢复边界变化；核对 storage/backup 源码与 migration/revision/backup tests | `AGENTS.md`、README Backup 入口、PRIVACY、CONTRIBUTING 的数据审查要求 |
 | `docs/CONTRIBUTING.md` | 贡献者：开发工作流、提交/PR 和验证责任 | package scripts、CI gate、贡献流程、manual validation 或文档治理责任变化；以 `package.json`、workflows、PR/Issue templates 为证据 | README、AGENTS、PR template、issue flow |
-| `docs/troubleshooting.md` | 维护者：可复用故障诊断，不拥有产品契约 | 消息生命周期、OAuth/发布诊断、Zen 流程变化；以对应源码、脚本和 regression tests 为证据 | CONTRIBUTING |
+| `docs/troubleshooting.md` | 维护者：可复用故障诊断，不拥有产品契约 | 消息生命周期、OAuth/发布、provider 同步失败/恢复诊断、Zen 流程变化；以对应源码、脚本和 regression tests 为证据 | CONTRIBUTING |
 | Feishu EN/ZH setup guides | 用户：配置飞书 OAuth/DocX 同步 | OAuth redirect/scope、Direct/Proxy 模式、Settings 字段或必要用户步骤变化；以 Feishu auth/Settings 源码与 tests 为证据 | README；Settings 的 “Open Setup Guide” |
 | Obsidian EN/ZH setup guides | 用户：配置 Local REST API | transport 支持、默认 endpoint/header、Settings 字段或必要插件步骤变化；以 Obsidian settings/client 源码与 tests 为证据 | README；Settings 的 “Open Setup Guide” |
 | `.github/scripts/webclipper/STORE_LISTING_COPY.md` | 发布维护者：浏览器商店长/短文案的人工 source copy | 用户可见来源/输出能力、隐私声明或商店文案变化；与 README/Privacy 对照。localized manifest 描述另由 `public/_locales/*/messages.json` 拥有，长度由仓库脚本校验 | 人工商店发布流程；不是 workflow 自动上传输入 |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 # 排障
 
-本页面向维护者，只记录可复用的开发/运行故障诊断，不拥有产品契约或验证门槛。通用环境与提交前验证见 [CONTRIBUTING.md](CONTRIBUTING.md)；仅检查默认浏览器产物时可运行 `npm run check`。当消息生命周期、OAuth/发布诊断或 Zen 流程发生变化时同步更新本页。
+本页面向维护者，只记录可复用的开发/运行故障诊断，不拥有产品契约或验证门槛。通用环境与提交前验证见 [CONTRIBUTING.md](CONTRIBUTING.md)；仅检查默认浏览器产物时可运行 `npm run check`。当消息生命周期、OAuth/发布、provider 同步失败/恢复诊断或 Zen 流程发生变化时同步更新本页。
 
 ## 常见问题
 
@@ -10,6 +10,8 @@
 | Vitest 不退出 | 未释放的 timer、listener 或 React root；超时不是 PASS。 |
 | manifest/version 发布失败 | `wxt.config.ts`、tag 和 workflow 的版本校验。 |
 | OAuth Connect 无响应 | client id、redirect URI、pending state、Worker endpoint 和浏览器日志。 |
+| Notion 同步报 `notion database schema incompatible` | 先确认目标仍是 SyncNos 管理的数据库 schema。旧 `Date: date` 会自动重命名为 `Last Activity`；`Date` 或 `Last Activity` 类型不符属于真实不兼容状态。不要通过新增第二个 Activity 字段或放宽类型检查绕过迁移。 |
+| Notion 在托管 section 扫描/恢复时遇到 5xx 或 block retrieve 失败 | 按远端失败处理并重试；不要把 list/retrieve 失败转成“未找到”，否则会在已有 heading 旁创建重复 section。服务恢复后应重新扫描并复用原 heading。 |
 | GitHub 手动同步选中了多条，但 commit 的 changed files 更少 | 这是可能的正常结果：手动同步使用 `reconcile`，未变化的受管路径也可能参与声明，但 GitHub 最终 tree diff 只显示真正变化的文件。SyncNos commit message 固定为 `SyncNos GitHub sync`，不再用选中数或 staged 数冒充 changed-file 数。 |
 | article 只有文本没有图片 | 图片设置、anti-hotlink rule、referer 与下载 warning；文本成功仍是成功。 |
 | 视频提示没有字幕 | 这次没有可信字幕时仍会保存可用的视频信息，不会降级成 Article；如需补充字幕，等字幕加载后再次保存即可更新 transcript。 |

--- a/src/services/sync/notion/notion-api.ts
+++ b/src/services/sync/notion/notion-api.ts
@@ -9,20 +9,14 @@ interface NotionApiError extends Error {
 }
 
 interface NotionFetchArgs {
-  accessToken?: string | null;
+  accessToken: string;
   method: string;
   path: string;
   body?: unknown;
-  notionVersion?: string | null;
+  notionVersion?: string;
 }
 
-interface NotionSearchArgs {
-  accessToken?: string | null;
-  query?: string | null;
-  pageSize?: number | null;
-}
-
-function safeJsonParse(text: string | null | undefined): unknown {
+function safeJsonParse(text: string): unknown {
   try {
     return text ? JSON.parse(text) : null;
   } catch (_e) {
@@ -30,22 +24,15 @@ function safeJsonParse(text: string | null | undefined): unknown {
   }
 }
 
-function parseRetryAfterMs(res: Response | null | undefined): number {
-  try {
-    const raw =
-      res && res.headers && typeof res.headers.get === 'function'
-        ? String(res.headers.get('Retry-After') || '').trim()
-        : '';
-    if (!raw) return 0;
-    const sec = Number(raw);
-    if (Number.isFinite(sec) && sec > 0) return Math.round(sec * 1000);
-    const dateMs = Date.parse(raw);
-    if (!Number.isFinite(dateMs)) return 0;
-    const delta = dateMs - Date.now();
-    return delta > 0 ? delta : 0;
-  } catch (_e) {
-    return 0;
-  }
+function parseRetryAfterMs(res: Response): number {
+  const raw = String(res.headers.get('Retry-After') || '').trim();
+  if (!raw) return 0;
+  const sec = Number(raw);
+  if (Number.isFinite(sec) && sec > 0) return Math.round(sec * 1000);
+  const dateMs = Date.parse(raw);
+  if (!Number.isFinite(dateMs)) return 0;
+  const delta = dateMs - Date.now();
+  return delta > 0 ? delta : 0;
 }
 
 async function notionFetch({ accessToken, method, path, body, notionVersion }: NotionFetchArgs) {
@@ -83,70 +70,18 @@ async function notionFetch({ accessToken, method, path, body, notionVersion }: N
   return text ? JSON.parse(text) : {};
 }
 
-function getPageTitle(page: { properties?: Record<string, any>; url?: string } | null | undefined): string {
-  try {
-    const props = page && page.properties ? page.properties : {};
-    for (const key of Object.keys(props)) {
-      const p = props[key];
-      if (p && p.type === 'title' && Array.isArray(p.title)) {
-        const t = p.title
-          .map((x: any) => x.plain_text || '')
-          .join('')
-          .trim();
-        if (t) return t;
-      }
-    }
-  } catch (_e) {
-    // ignore
+function getPageTitle(page: { properties?: Record<string, any>; url?: string }): string {
+  const props = page.properties || {};
+  for (const key of Object.keys(props)) {
+    const property = props[key];
+    if (property?.type !== 'title' || !Array.isArray(property.title)) continue;
+    const title = property.title
+      .map((item: any) => item.plain_text || '')
+      .join('')
+      .trim();
+    if (title) return title;
   }
-  return page && page.url ? page.url : 'Untitled';
+  return page.url || 'Untitled';
 }
 
-function buildSearchBody({
-  query,
-  pageSize,
-  startCursor,
-}: {
-  query?: string | null;
-  pageSize?: number;
-  startCursor?: string | null;
-}): Record<string, unknown> {
-  const body: Record<string, unknown> = {
-    filter: { property: 'object', value: 'page' },
-    page_size: pageSize || 50,
-  };
-  const q = String(query || '').trim();
-  if (q) body.query = q;
-  if (startCursor) body.start_cursor = String(startCursor);
-  return body;
-}
-
-async function searchPages({ accessToken, query, pageSize }: NotionSearchArgs) {
-  const size = Number.isFinite(Number(pageSize)) && Number(pageSize) > 0 ? Number(pageSize) : 50;
-  let cursor: string | null = null;
-  let guard = 0;
-
-  while (guard < 20) {
-    guard += 1;
-    const body = buildSearchBody({ query, pageSize: size, startCursor: cursor });
-    const res = await notionFetch({ accessToken, method: 'POST', path: '/v1/search', body });
-    const results = Array.isArray(res && res.results) ? res.results : [];
-    const usableParentPages = results.filter((item: any) => {
-      if (!item || item.object !== 'page') return false;
-      const parent = item.parent || null;
-      if (!parent) return true;
-      if (parent.database_id) return false;
-      if (parent.type === 'database_id') return false;
-      return true;
-    });
-    if (usableParentPages.length) {
-      return { ...(res || {}), results: usableParentPages };
-    }
-    if (!res || !res.has_more || !res.next_cursor) break;
-    cursor = res.next_cursor;
-  }
-
-  return { results: [], has_more: false, next_cursor: null };
-}
-
-export { notionFetch, searchPages, getPageTitle, NOTION_VERSION };
+export { notionFetch, getPageTitle };

--- a/src/services/sync/notion/notion-db-manager.ts
+++ b/src/services/sync/notion/notion-db-manager.ts
@@ -4,39 +4,18 @@ import type { ConversationKindDbSpec } from '@services/protocols/conversation-ki
 import { storageGet, storageRemove, storageSet } from '@platform/storage/local';
 
 const SEARCH_PAGE_SIZE = 100;
-const SEARCH_MAX_PAGES = 10;
-
-function requireStorageKey(storageKey: unknown): string {
-  const key = String(storageKey || '').trim();
-  if (!key) throw new Error('notion database storageKey required');
-  return key;
-}
-
-function requireDbSpec(dbSpec: unknown): ConversationKindDbSpec {
-  if (!dbSpec || typeof dbSpec !== 'object') throw new Error('notion dbSpec required');
-  const spec = dbSpec as ConversationKindDbSpec;
-  if (!String(spec.title || '').trim()) throw new Error('notion dbSpec title required');
-  requireStorageKey(spec.storageKey);
-  if (!spec.properties || typeof spec.properties !== 'object') throw new Error('notion dbSpec properties required');
-  return spec;
-}
 
 async function getCachedDatabaseId(storageKey: string) {
-  const key = requireStorageKey(storageKey);
-  const res = await storageGet([key]);
-  return String((res && (res as any)[key]) || '');
+  const res = await storageGet([storageKey]);
+  return String((res as any)?.[storageKey] || '');
 }
 
-async function setCachedDatabaseId(storageKey: string, databaseId: unknown) {
-  const key = requireStorageKey(storageKey);
-  await storageSet({ [key]: databaseId || '' });
-  return true;
+async function setCachedDatabaseId(storageKey: string, databaseId: string) {
+  await storageSet({ [storageKey]: databaseId });
 }
 
 async function clearCachedDatabaseId(storageKey: string) {
-  const key = requireStorageKey(storageKey);
-  await storageRemove([key]);
-  return true;
+  await storageRemove([storageKey]);
 }
 
 function isUsableDatabase(database: any): boolean {
@@ -55,19 +34,11 @@ function normalizeNotionId(id: unknown): string {
 }
 
 function readParentPageId(database: any): string {
-  try {
-    const parent = database && database.parent ? database.parent : null;
-    if (!parent || typeof parent !== 'object') return '';
-    if (parent.page_id) return String(parent.page_id).trim();
-    return '';
-  } catch (_e) {
-    return '';
-  }
+  return database?.parent?.page_id ? String(database.parent.page_id).trim() : '';
 }
 
-function matchesParentPage(database: any, parentPageId: unknown): boolean {
+function matchesParentPage(database: any, parentPageId: string): boolean {
   const expected = normalizeNotionId(parentPageId);
-  if (!expected) return true;
   const actual = normalizeNotionId(readParentPageId(database));
   return !!actual && actual === expected;
 }
@@ -86,45 +57,25 @@ function normalizeTitle(value: unknown): string {
     .toLowerCase();
 }
 
-function parseHttpStatus(error: unknown): number {
-  const fromField = Number(error && (error as any).status);
-  if (Number.isFinite(fromField) && fromField > 0) return fromField;
-  const message = String((error && (error as any).message) || error || '');
-  const matched = message.match(/\bHTTP\s+(\d{3})\b/i);
-  return matched ? Number(matched[1]) : 0;
-}
-
-function parseNotionErrorCode(error: unknown): string {
-  const direct = String((error && (error as any).code) || '').trim();
-  if (direct) return direct;
-  const message = String((error && (error as any).message) || error || '');
-  const matched = message.match(/"code"\s*:\s*"([^"]+)"/i);
-  return matched ? String(matched[1] || '').trim() : '';
-}
-
 function isMissingDatabaseError(error: unknown): boolean {
-  const status = parseHttpStatus(error);
-  if (status === 404 || status === 410) return true;
-  const code = parseNotionErrorCode(error).toLowerCase();
-  return code === 'object_not_found';
+  const status = Number((error as any)?.status || 0);
+  const code = String((error as any)?.code || '')
+    .trim()
+    .toLowerCase();
+  return status === 404 || status === 410 || code === 'object_not_found';
 }
 
 async function getDatabase(accessToken: string, databaseId: string) {
   return notionFetch({ accessToken, method: 'GET', path: `/v1/databases/${databaseId}` });
 }
 
-async function searchDatabases(
-  accessToken: string,
-  { query, parentPageId }: { query?: string; parentPageId?: string },
-) {
+async function searchDatabases(accessToken: string, { query, parentPageId }: { query: string; parentPageId: string }) {
   const results: any[] = [];
   let cursor = '';
-  let pageCount = 0;
 
-  while (pageCount < SEARCH_MAX_PAGES) {
-    pageCount += 1;
+  for (;;) {
     const body = {
-      query: query || '',
+      query,
       filter: { property: 'object', value: 'database' },
       sort: { direction: 'descending', timestamp: 'last_edited_time' },
       page_size: SEARCH_PAGE_SIZE,
@@ -169,11 +120,10 @@ async function createDatabase(
   accessToken: string,
   { parentPageId, dbSpec }: { parentPageId: string; dbSpec: ConversationKindDbSpec },
 ) {
-  const spec = dbSpec;
   const body = {
     parent: { type: 'page_id', page_id: parentPageId },
-    title: [{ type: 'text', text: { content: spec.title } }],
-    properties: materializeDbProperties(spec),
+    title: [{ type: 'text', text: { content: dbSpec.title } }],
+    properties: materializeDbProperties(dbSpec),
   };
   return notionFetch({ accessToken, method: 'POST', path: '/v1/databases', body });
 }
@@ -197,10 +147,9 @@ async function ensureDatabaseSchema({
   databaseId: string;
   dbSpec: ConversationKindDbSpec;
 }) {
-  const spec = dbSpec;
   const db = await getDatabase(accessToken, databaseId);
   const props = { ...(db && db.properties ? db.properties : {}) } as Record<string, any>;
-  const patch = spec.ensureSchemaPatch && typeof spec.ensureSchemaPatch === 'object' ? spec.ensureSchemaPatch : {};
+  const patch = dbSpec.ensureSchemaPatch || {};
 
   const lastActivity = props['Last Activity'];
   if (lastActivity) {
@@ -229,13 +178,12 @@ async function ensureDatabaseSchema({
   for (const [k, v] of Object.entries(patch)) {
     if (!props[k]) missing[k] = v;
   }
-  if (!Object.keys(missing).length) return true;
+  if (!Object.keys(missing).length) return;
 
   if (missing.AI && missing.AI.multi_select && typeof missing.AI.multi_select === 'object') {
     missing.AI = { multi_select: { ...missing.AI.multi_select, options: buildAiOptions() } };
   }
   await updateDatabase(accessToken, { databaseId, properties: missing });
-  return true;
 }
 
 async function ensureDatabase({
@@ -247,46 +195,45 @@ async function ensureDatabase({
   parentPageId: string;
   dbSpec: ConversationKindDbSpec;
 }) {
-  const spec = requireDbSpec(dbSpec);
-  const cached = await getCachedDatabaseId(spec.storageKey);
+  const cached = await getCachedDatabaseId(dbSpec.storageKey);
   if (cached) {
     try {
       const db = await getDatabase(accessToken, cached);
       if (!isUsableDatabase(db)) {
-        await clearCachedDatabaseId(spec.storageKey);
+        await clearCachedDatabaseId(dbSpec.storageKey);
       } else if (!matchesParentPage(db, parentPageId)) {
-        await clearCachedDatabaseId(spec.storageKey);
+        await clearCachedDatabaseId(dbSpec.storageKey);
       } else {
-        await ensureDatabaseSchema({ accessToken, databaseId: cached, dbSpec: spec });
-        return { databaseId: cached, title: spec.title, reused: true, database: db };
+        await ensureDatabaseSchema({ accessToken, databaseId: cached, dbSpec });
+        return { databaseId: cached, title: dbSpec.title, reused: true, database: db };
       }
     } catch (error) {
       if (isMissingDatabaseError(error)) {
-        await clearCachedDatabaseId(spec.storageKey);
+        await clearCachedDatabaseId(dbSpec.storageKey);
       } else {
         throw error;
       }
     }
   }
 
-  const found = await searchDatabases(accessToken, { query: spec.title, parentPageId });
-  const results = Array.isArray(found.results) ? found.results : [];
-  const wantedTitle = normalizeTitle(spec.title);
+  const found = await searchDatabases(accessToken, { query: dbSpec.title, parentPageId });
+  const results = found.results;
+  const wantedTitle = normalizeTitle(dbSpec.title);
   const exact = results.find((d: any) => {
     if (!matchesParentPage(d, parentPageId)) return false;
     const title = readDatabaseTitle(d);
     return normalizeTitle(title) === wantedTitle;
   });
   if (exact && exact.id) {
-    await setCachedDatabaseId(spec.storageKey, exact.id);
-    await ensureDatabaseSchema({ accessToken, databaseId: exact.id, dbSpec: spec });
-    return { databaseId: exact.id, title: spec.title, reused: true, database: exact };
+    await setCachedDatabaseId(dbSpec.storageKey, exact.id);
+    await ensureDatabaseSchema({ accessToken, databaseId: exact.id, dbSpec });
+    return { databaseId: exact.id, title: dbSpec.title, reused: true, database: exact };
   }
 
-  const created = await createDatabase(accessToken, { parentPageId, dbSpec: spec });
+  const created = await createDatabase(accessToken, { parentPageId, dbSpec });
   if (!created || !created.id) throw new Error('create database failed');
-  await setCachedDatabaseId(spec.storageKey, created.id);
-  return { databaseId: created.id, title: spec.title, reused: false, database: created };
+  await setCachedDatabaseId(dbSpec.storageKey, created.id);
+  return { databaseId: created.id, title: dbSpec.title, reused: false, database: created };
 }
 
 export { ensureDatabase, clearCachedDatabaseId };

--- a/src/services/sync/notion/notion-files-api.ts
+++ b/src/services/sync/notion/notion-files-api.ts
@@ -8,23 +8,18 @@ function sleep(ms: number) {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-function isHttpUrl(url: unknown): boolean {
-  const text = String(url || '').trim();
-  return /^https?:\/\//i.test(text);
+function isHttpUrl(url: string): boolean {
+  return /^https?:\/\//i.test(url.trim());
 }
 
-function sanitizeFilename(name: unknown): string {
-  const cleaned = String(name || '')
-    .replaceAll('"', '')
-    .replaceAll('\n', '')
-    .replaceAll('\r', '')
-    .trim();
+function sanitizeFilename(name: string): string {
+  const cleaned = name.replaceAll('"', '').replaceAll('\n', '').replaceAll('\r', '').trim();
   return cleaned || 'image.jpg';
 }
 
-function guessFilenameFromUrl(url: unknown): string {
+function guessFilenameFromUrl(url: string): string {
   try {
-    const u = new URL(String(url || ''));
+    const u = new URL(url);
     const last =
       String(u.pathname || '')
         .split('/')
@@ -44,18 +39,10 @@ function describeFileImportResult(value: unknown): string {
   if (typeof value === 'number' || typeof value === 'boolean') return String(value);
   if (Array.isArray(value)) return `[${value.length} items]`;
   if (typeof value === 'object') {
-    try {
-      const keys = Object.keys(value);
-      if (keys.length <= 6) return `{${keys.join(',')}}`;
-    } catch (_e) {
-      // ignore
-    }
-    try {
-      const s = JSON.stringify(value);
-      return s && s.length > 220 ? `${s.slice(0, 220)}…` : s || '';
-    } catch (_e) {
-      return '{object}';
-    }
+    const keys = Object.keys(value);
+    if (keys.length <= 6) return `{${keys.join(',')}}`;
+    const text = JSON.stringify(value);
+    return text.length > 220 ? `${text.slice(0, 220)}…` : text;
   }
   return String(value);
 }
@@ -66,12 +53,12 @@ async function createExternalURLUpload({
   filename,
   contentType,
 }: {
-  accessToken?: string | null;
-  url?: string;
+  accessToken: string;
+  url: string;
   filename?: string;
   contentType?: string;
 }) {
-  const target = String(url || '').trim();
+  const target = url.trim();
   if (!isHttpUrl(target)) throw new Error('invalid external image url');
   const body: Record<string, unknown> = {
     mode: 'external_url',
@@ -93,15 +80,13 @@ async function createFileUpload({
   accessToken,
   filename,
   contentType,
-  contentLength: _contentLength,
 }: {
-  accessToken?: string | null;
-  filename?: string;
-  contentType?: string;
-  contentLength?: number;
+  accessToken: string;
+  filename: string;
+  contentType: string;
 }) {
-  const name = sanitizeFilename(filename || '');
-  const ct = String(contentType || '').trim() || 'application/octet-stream';
+  const name = sanitizeFilename(filename);
+  const ct = contentType.trim() || 'application/octet-stream';
   const body = {
     mode: 'single_part',
     filename: name,
@@ -123,21 +108,18 @@ async function sendFileUpload({
   filename,
   contentType,
 }: {
-  accessToken?: string | null;
-  id?: string;
-  bytes?: Uint8Array | ArrayBuffer;
-  filename?: string;
-  contentType?: string;
+  accessToken: string;
+  id: string;
+  bytes: Uint8Array;
+  filename: string;
+  contentType: string;
 }) {
-  const uploadId = String(id || '').trim();
+  const uploadId = id.trim();
   if (!uploadId) throw new Error('missing upload id');
-  if (!(bytes instanceof Uint8Array) && !(bytes instanceof ArrayBuffer)) throw new Error('invalid bytes');
-  if (typeof FormData === 'undefined' || typeof Blob === 'undefined') throw new Error('FormData/Blob missing');
-  const name = sanitizeFilename(filename || 'image.jpg');
-  const ct = String(contentType || '').trim() || 'application/octet-stream';
-  const data = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  const name = sanitizeFilename(filename);
+  const ct = contentType.trim() || 'application/octet-stream';
   const form = new FormData();
-  const blob = new Blob([data as BlobPart], { type: ct });
+  const blob = new Blob([bytes as BlobPart], { type: ct });
   form.append('file', blob, name);
 
   const res = await fetch(`https://api.notion.com/v1/file_uploads/${encodeURIComponent(uploadId)}/send`, {
@@ -149,13 +131,13 @@ async function sendFileUpload({
     },
     body: form,
   });
-  const text = await res.text().catch(() => '');
+  const text = await res.text();
   if (!res.ok) throw new Error(`notion api failed: POST /v1/file_uploads/${uploadId}/send HTTP ${res.status} ${text}`);
   return text ? JSON.parse(text) : {};
 }
 
-async function retrieveUpload({ accessToken, id }: { accessToken?: string | null; id?: string }) {
-  const uploadId = String(id || '').trim();
+async function retrieveUpload({ accessToken, id }: { accessToken: string; id: string }) {
+  const uploadId = id.trim();
   if (!uploadId) throw new Error('missing upload id');
   return defaultNotionFetch({
     accessToken,
@@ -172,12 +154,12 @@ async function waitUntilUploaded({
   pollIntervalMs,
   maxAttempts,
 }: {
-  accessToken?: string | null;
-  id?: string;
+  accessToken: string;
+  id: string;
   pollIntervalMs?: number;
   maxAttempts?: number;
-} = {}) {
-  const uploadId = String(id || '').trim();
+}) {
+  const uploadId = id.trim();
   if (!uploadId) throw new Error('missing upload id');
   const interval = Number.isFinite(Number(pollIntervalMs))
     ? Math.max(50, Number(pollIntervalMs))
@@ -201,13 +183,4 @@ async function waitUntilUploaded({
   throw new Error('file upload timed out');
 }
 
-export {
-  FILE_UPLOAD_VERSION,
-  sanitizeFilename,
-  guessFilenameFromUrl,
-  createExternalURLUpload,
-  createFileUpload,
-  sendFileUpload,
-  retrieveUpload,
-  waitUntilUploaded,
-};
+export { guessFilenameFromUrl, createExternalURLUpload, createFileUpload, sendFileUpload, waitUntilUploaded };

--- a/src/services/sync/notion/notion-image-upload-upgrader.ts
+++ b/src/services/sync/notion/notion-image-upload-upgrader.ts
@@ -36,37 +36,18 @@ function parseDataImageUrl(dataUrl: unknown) {
   const approxBytes = Math.max(0, Math.floor((payload.length * 3) / 4) - padding);
   if (approxBytes > MAX_IMAGE_BYTES) throw new Error(`image too large: ${approxBytes}`);
 
-  function base64ToBytes(b64: unknown): Uint8Array {
-    const raw = String(b64 || '');
-    if (!raw) return new Uint8Array();
-    if (typeof atob === 'function') {
-      const bin = atob(raw);
-      const out = new Uint8Array(bin.length);
-      for (let i = 0; i < bin.length; i += 1) out[i] = bin.charCodeAt(i);
-      return out;
-    }
-    if (typeof Buffer !== 'undefined') {
-      try {
-        const buf = Buffer.from(raw, 'base64');
-        return new Uint8Array(buf);
-      } catch (_e) {
-        return new Uint8Array();
-      }
-    }
-    return new Uint8Array();
-  }
-
-  const bytes = base64ToBytes(payload);
+  const binary = atob(payload);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
   if (!bytes.byteLength) throw new Error('data image decoded empty');
   return { bytes, contentType };
 }
 
-function paragraphBlock(text: unknown) {
-  const content = String(text || '').trim();
+function paragraphBlock(content: string) {
   return {
     object: 'block',
     type: 'paragraph',
-    paragraph: { rich_text: [{ type: 'text', text: { content: content || '[Image omitted]' } }] },
+    paragraph: { rich_text: [{ type: 'text', text: { content } }] },
   };
 }
 
@@ -93,22 +74,12 @@ function guessContentTypeFromUrl(url: unknown): string {
   return '';
 }
 
-function guessFilenameFromUrl(url: unknown): string {
-  return notionFilesApi.guessFilenameFromUrl(url);
-}
-
-async function downloadBytes(url: unknown) {
-  if (typeof fetch !== 'function') throw new Error('fetch missing');
-  const target = String(url || '').trim();
-  let credentials: RequestCredentials = 'include';
-  try {
-    const u = new URL(target);
-    // Attachment URLs may require Notion auth cookies on `notion.so`.
-    // The redirected CDN (`notionusercontent.com`) should work without credentials.
-    if (/(\.|^)notionusercontent\.com$/i.test(u.hostname)) credentials = 'omit';
-  } catch (_e) {
-    // ignore
-  }
+async function downloadBytes(url: string) {
+  const target = url.trim();
+  const hostname = new URL(target).hostname;
+  // Attachment URLs may require Notion auth cookies on `notion.so`.
+  // The redirected CDN (`notionusercontent.com`) should work without credentials.
+  const credentials: RequestCredentials = /(\.|^)notionusercontent\.com$/i.test(hostname) ? 'omit' : 'include';
   const res = await fetch(target, {
     method: 'GET',
     redirect: 'follow',
@@ -117,19 +88,18 @@ async function downloadBytes(url: unknown) {
     headers: { Accept: 'image/*,*/*;q=0.8' },
   });
   if (!res.ok) {
-    const finalUrl = res && res.url ? String(res.url) : target;
+    const finalUrl = res.url ? String(res.url) : target;
     throw new Error(`image download failed HTTP ${res.status} ${sanitizeUrlForLog(finalUrl)}`);
   }
-  const ct = res.headers && res.headers.get ? String(res.headers.get('content-type') || '') : '';
+  const ct = String(res.headers.get('content-type') || '');
   const buf = await res.arrayBuffer();
   const bytes = new Uint8Array(buf);
-  return { bytes, contentType: ct.split(';')[0].trim(), contentLength: bytes.byteLength };
+  return { bytes, contentType: ct.split(';')[0].trim() };
 }
 
-function toFileUploadImageBlock(block: any, uploadId: unknown) {
+function toFileUploadImageBlock(block: any, uploadId: string) {
   return {
     ...block,
-    type: 'image',
     image: {
       type: 'file_upload',
       file_upload: { id: uploadId },
@@ -137,53 +107,53 @@ function toFileUploadImageBlock(block: any, uploadId: unknown) {
   };
 }
 
-async function uploadFromExternalUrl(files: any, accessToken: string, url: unknown) {
-  const created = await files.createExternalURLUpload({ accessToken, url });
+async function uploadFromExternalUrl(accessToken: string, url: string) {
+  const created = await notionFilesApi.createExternalURLUpload({ accessToken, url });
   const id = created && created.id ? String(created.id).trim() : '';
   if (!id) throw new Error('missing file upload id');
-  const ready = await files.waitUntilUploaded({ accessToken, id });
-  return ready && ready.id ? String(ready.id).trim() : id;
+  await notionFilesApi.waitUntilUploaded({ accessToken, id });
+  return id;
 }
 
-async function uploadFromBytes(files: any, accessToken: string, url: unknown) {
+async function uploadFromBytes(accessToken: string, url: string) {
   const dl = await downloadBytes(url);
-  if (!dl || !(dl.bytes instanceof Uint8Array) || !dl.bytes.byteLength) throw new Error('download empty');
+  if (!dl.bytes.byteLength) throw new Error('download empty');
   if (dl.bytes.byteLength > MAX_IMAGE_BYTES) throw new Error(`image too large: ${dl.bytes.byteLength}`);
   const ct = dl.contentType || guessContentTypeFromUrl(url) || 'application/octet-stream';
-  const filename = guessFilenameFromUrl(url);
-  const up = await files.createFileUpload({
+  const filename = notionFilesApi.guessFilenameFromUrl(url);
+  const up = await notionFilesApi.createFileUpload({
     accessToken,
     filename,
     contentType: ct,
   });
   const fileId = up && up.id ? String(up.id).trim() : '';
   if (!fileId) throw new Error('missing file upload id');
-  await files.sendFileUpload({ accessToken, id: fileId, bytes: dl.bytes, filename, contentType: ct });
-  const ready = await files.waitUntilUploaded({ accessToken, id: fileId });
-  return ready && ready.id ? String(ready.id).trim() : fileId;
+  await notionFilesApi.sendFileUpload({ accessToken, id: fileId, bytes: dl.bytes, filename, contentType: ct });
+  await notionFilesApi.waitUntilUploaded({ accessToken, id: fileId });
+  return fileId;
 }
 
-async function uploadFromDataUrl(files: any, accessToken: string, dataUrl: unknown) {
+async function uploadFromDataUrl(accessToken: string, dataUrl: string) {
   const parsed = parseDataImageUrl(dataUrl);
   const bytes = parsed.bytes;
-  const contentType = parsed.contentType || 'application/octet-stream';
+  const contentType = parsed.contentType;
   if (bytes.byteLength > MAX_IMAGE_BYTES) throw new Error(`image too large: ${bytes.byteLength}`);
 
   const ext = guessExtensionFromContentType(contentType);
   const filename = `image.${ext}`;
-  const up = await files.createFileUpload({
+  const up = await notionFilesApi.createFileUpload({
     accessToken,
     filename,
     contentType,
   });
   const fileId = up && up.id ? String(up.id).trim() : '';
   if (!fileId) throw new Error('missing file upload id');
-  await files.sendFileUpload({ accessToken, id: fileId, bytes, filename, contentType });
-  const ready = await files.waitUntilUploaded({ accessToken, id: fileId });
-  return ready && ready.id ? String(ready.id).trim() : fileId;
+  await notionFilesApi.sendFileUpload({ accessToken, id: fileId, bytes, filename, contentType });
+  await notionFilesApi.waitUntilUploaded({ accessToken, id: fileId });
+  return fileId;
 }
 
-async function uploadFromSyncnosAsset(files: any, accessToken: string, assetId: number, asset: ImageCacheAsset | null) {
+async function uploadFromSyncnosAsset(accessToken: string, assetId: number, asset: ImageCacheAsset | null) {
   if (!asset || !(asset.blob instanceof Blob)) throw new Error(`missing local asset blob: ${assetId}`);
 
   const bytes = new Uint8Array(await asset.blob.arrayBuffer());
@@ -196,27 +166,24 @@ async function uploadFromSyncnosAsset(files: any, accessToken: string, assetId: 
   const ext = guessExtensionFromContentType(contentType);
   const filename = `image-${assetId}.${ext}`;
 
-  const up = await files.createFileUpload({
+  const up = await notionFilesApi.createFileUpload({
     accessToken,
     filename,
     contentType,
   });
   const fileId = up && up.id ? String(up.id).trim() : '';
   if (!fileId) throw new Error('missing file upload id');
-  await files.sendFileUpload({ accessToken, id: fileId, bytes, filename, contentType });
-  const ready = await files.waitUntilUploaded({ accessToken, id: fileId });
-  return ready && ready.id ? String(ready.id).trim() : fileId;
+  await notionFilesApi.sendFileUpload({ accessToken, id: fileId, bytes, filename, contentType });
+  await notionFilesApi.waitUntilUploaded({ accessToken, id: fileId });
+  return fileId;
 }
 
-async function upgradeImageBlocksToFileUploads(accessToken: string, blocks: any, conversationId: number) {
-  const list = Array.isArray(blocks) ? blocks : [];
-  if (!list.length) return [];
-  const files = notionFilesApi;
+async function upgradeImageBlocksToFileUploads(accessToken: string, blocks: any[], conversationId: number) {
   const localAssetIds: number[] = [];
   const seenLocalAssetIds = new Set<number>();
-  for (const block of list) {
-    if (!block || block.type !== 'image' || !block.image || block.image.type !== 'external') continue;
-    const url = block.image?.external?.url ? String(block.image.external.url).trim() : '';
+  for (const block of blocks) {
+    if (block?.type !== 'image' || block.image?.type !== 'external') continue;
+    const url = String(block.image.external?.url || '').trim();
     const assetId = parseSyncnosAssetId(url);
     if (assetId == null || seenLocalAssetIds.has(assetId)) continue;
     seenLocalAssetIds.add(assetId);
@@ -230,12 +197,12 @@ async function upgradeImageBlocksToFileUploads(accessToken: string, blocks: any,
   const cache = new Map<string, string>();
   const out: any[] = [];
 
-  for (const b of list) {
-    if (!b || b.type !== 'image' || !b.image || b.image.type !== 'external') {
+  for (const b of blocks) {
+    if (b?.type !== 'image' || b.image?.type !== 'external') {
       out.push(b);
       continue;
     }
-    const url = b.image && b.image.external && b.image.external.url ? String(b.image.external.url).trim() : '';
+    const url = String(b.image.external?.url || '').trim();
     if (!url) {
       out.push(b);
       continue;
@@ -243,66 +210,48 @@ async function upgradeImageBlocksToFileUploads(accessToken: string, blocks: any,
 
     const assetId = parseSyncnosAssetId(url);
     const isInternalAsset = isSyncnosAssetUrl(url);
+    const isDataImage = isDataImageUrl(url);
     let uploadId = cache.get(url) || '';
     if (!uploadId) {
-      if (isDataImageUrl(url)) {
+      if (isDataImage) {
         try {
-          uploadId = await uploadFromDataUrl(files, accessToken, url);
-          if (uploadId) cache.set(url, uploadId);
+          uploadId = await uploadFromDataUrl(accessToken, url);
+          cache.set(url, uploadId);
         } catch (e) {
           const msg = e && (e as any).message ? String((e as any).message) : String(e);
-          try {
-            console.warn('[NotionImageUpload] data_url upload failed:', msg);
-          } catch (_e2) {
-            // ignore
-          }
-          uploadId = '';
+          console.warn('[NotionImageUpload] data_url upload failed:', msg);
         }
       } else if (isInternalAsset) {
         if (assetId != null) {
           try {
-            uploadId = await uploadFromSyncnosAsset(files, accessToken, assetId, localAssets.get(assetId) || null);
-            if (uploadId) cache.set(url, uploadId);
+            uploadId = await uploadFromSyncnosAsset(accessToken, assetId, localAssets.get(assetId) || null);
+            cache.set(url, uploadId);
           } catch (e) {
             const msg = e && (e as any).message ? String((e as any).message) : String(e);
-            try {
-              console.warn('[NotionImageUpload] syncnos_asset upload failed:', assetId, msg);
-            } catch (_e2) {
-              // ignore
-            }
-            uploadId = '';
+            console.warn('[NotionImageUpload] syncnos_asset upload failed:', assetId, msg);
           }
         }
       } else {
         try {
-          uploadId = await uploadFromExternalUrl(files, accessToken, url);
-          if (uploadId) cache.set(url, uploadId);
+          uploadId = await uploadFromExternalUrl(accessToken, url);
+          cache.set(url, uploadId);
         } catch (e) {
           const brief = sanitizeUrlForLog(url);
           const msg = e && (e as any).message ? String((e as any).message) : String(e);
+          console.warn('[NotionImageUpload] external_url failed:', brief, msg);
           try {
-            console.warn('[NotionImageUpload] external_url failed:', brief, msg);
-          } catch (_e2) {
-            // ignore
-          }
-          try {
-            uploadId = await uploadFromBytes(files, accessToken, url);
-            if (uploadId) cache.set(url, uploadId);
+            uploadId = await uploadFromBytes(accessToken, url);
+            cache.set(url, uploadId);
           } catch (e2) {
             const msg2 = e2 && (e2 as any).message ? String((e2 as any).message) : String(e2);
-            try {
-              console.warn('[NotionImageUpload] byte upload failed:', brief, msg2);
-            } catch (_e3) {
-              // ignore
-            }
-            uploadId = '';
+            console.warn('[NotionImageUpload] byte upload failed:', brief, msg2);
           }
         }
       }
     }
 
     if (!uploadId) {
-      if (isDataImageUrl(url) || isInternalAsset) {
+      if (isDataImage || isInternalAsset) {
         out.push(paragraphBlock('[Image omitted: local image upload failed]'));
       } else out.push(b);
       continue;

--- a/src/services/sync/notion/notion-managed-sections.ts
+++ b/src/services/sync/notion/notion-managed-sections.ts
@@ -1,3 +1,4 @@
+import type { NotionServices } from '@services/sync/notion/notion-services';
 import {
   buildToggleHeadingBlock,
   findHeadingBlocksByTitle,
@@ -8,28 +9,30 @@ import {
 } from '@services/sync/notion/notion-section-blocks.ts';
 
 type ToggleHeadingLevel = 1 | 2 | 3;
+type NotionAppendService = Pick<NotionServices['syncService'], 'appendChildren'>;
+type NotionMappingStorage = Pick<NotionServices['storage'], 'patchSyncMapping'>;
 
-export type NotionManagedSectionSpec = {
+type NotionManagedSectionSpec = {
   id: string;
   title: string;
   level: ToggleHeadingLevel;
 };
 
-export type NotionManagedLayoutSpec = {
+type NotionManagedLayoutSpec = {
   sections: NotionManagedSectionSpec[];
 };
 
-export type NotionSectionAnchors = Record<string, { headingBlockId?: string }>;
+type NotionSectionAnchors = Record<string, { headingBlockId?: string }>;
 
 function safeString(value: unknown): string {
   return String(value == null ? '' : value).trim();
 }
 
-export function getNotionSectionAnchorsFromMapping(mapping: unknown): NotionSectionAnchors {
+function getNotionSectionAnchorsFromMapping(mapping: unknown): NotionSectionAnchors {
   const m = mapping && typeof mapping === 'object' ? (mapping as any) : {};
   const raw = m.notionSections && typeof m.notionSections === 'object' ? (m.notionSections as any) : {};
   const out: NotionSectionAnchors = {};
-  for (const [key, value] of Object.entries(raw || {})) {
+  for (const [key, value] of Object.entries(raw)) {
     const sectionId = safeString(key);
     if (!sectionId) continue;
     const headingBlockId = safeString((value as any)?.headingBlockId);
@@ -39,7 +42,7 @@ export function getNotionSectionAnchorsFromMapping(mapping: unknown): NotionSect
 }
 
 export function layoutSpecForConversationKind(kindId: string): NotionManagedLayoutSpec {
-  const id = safeString(kindId).toLowerCase();
+  const id = kindId.trim().toLowerCase();
   if (id === 'article') {
     return {
       sections: [
@@ -58,68 +61,61 @@ export function layoutSpecForConversationKind(kindId: string): NotionManagedLayo
   };
 }
 
+async function findToggleHeadingBlockId(accessToken: string, pageId: string, title: string): Promise<string> {
+  const candidates = findHeadingBlocksByTitle(await listBlockChildren(accessToken, pageId), title);
+  const directId = safeString(candidates.find(isToggleHeadingBlock)?.id);
+  if (directId) return directId;
+
+  for (const candidate of candidates) {
+    const candidateId = safeString(candidate?.id);
+    if (!candidateId) continue;
+    const full = await retrieveBlock(accessToken, candidateId);
+    if (isToggleHeadingBlock(full)) return candidateId;
+  }
+  return '';
+}
+
+async function persistHeadingIdToMapping(
+  storage: NotionMappingStorage,
+  conversationId: number,
+  sectionId: string,
+  headingBlockId: string,
+): Promise<void> {
+  await storage.patchSyncMapping(conversationId, {
+    notionSections: { [sectionId]: { headingBlockId } },
+  });
+}
+
 export async function ensureSectionHeadingBlockId(input: {
   accessToken: string;
   pageId: string;
   section: NotionManagedSectionSpec;
   mapping: any | null | undefined;
-  notionSyncService: { appendChildren: (accessToken: string, blockId: string, blocks: any[]) => Promise<any> };
-  storage?: { patchSyncMapping?: (conversationId: number, patch: Record<string, unknown>) => Promise<any> };
-  conversationId?: number;
+  notionSyncService: NotionAppendService;
+  storage: NotionMappingStorage;
+  conversationId: number;
 }): Promise<{ headingBlockId: string; discoveredBy: 'mapping' | 'scan' | 'created' }> {
-  const sectionId = safeString(input?.section?.id);
-  const title = safeString(input?.section?.title);
-  const level = input?.section?.level || 2;
+  const sectionId = safeString(input.section.id);
+  const title = safeString(input.section.title);
   if (!sectionId || !title) throw new Error('invalid section spec');
 
-  const anchors = getNotionSectionAnchorsFromMapping(input?.mapping);
-  const fromMapping = safeString(anchors?.[sectionId]?.headingBlockId);
+  const anchors = getNotionSectionAnchorsFromMapping(input.mapping);
+  const fromMapping = safeString(anchors[sectionId]?.headingBlockId);
   if (fromMapping) return { headingBlockId: fromMapping, discoveredBy: 'mapping' };
 
-  const children = await listBlockChildren(input.accessToken, input.pageId);
-  const candidates = findHeadingBlocksByTitle(children, title);
-  let foundId = safeString(candidates.find((block) => isToggleHeadingBlock(block))?.id);
-  if (!foundId && candidates.length) {
-    for (const candidate of candidates) {
-      const candidateId = safeString((candidate as any)?.id);
-      if (!candidateId) continue;
-      const full = await retrieveBlock(input.accessToken, candidateId).catch(() => null);
-      if (!full) continue;
-      if (!isToggleHeadingBlock(full)) continue;
-      foundId = candidateId;
-      break;
-    }
-  }
-
+  const foundId = await findToggleHeadingBlockId(input.accessToken, input.pageId, title);
   if (foundId) {
-    await maybePersistHeadingIdToMapping(input, sectionId, foundId);
+    await persistHeadingIdToMapping(input.storage, input.conversationId, sectionId, foundId);
     return { headingBlockId: foundId, discoveredBy: 'scan' };
   }
 
   const appended = await input.notionSyncService.appendChildren(input.accessToken, input.pageId, [
-    buildToggleHeadingBlock(title, level),
+    buildToggleHeadingBlock(title, input.section.level),
   ]);
-  const results = Array.isArray((appended as any)?.results) ? (appended as any).results : [];
-  const createdId = safeString(results?.[0]?.id);
+  const createdId = safeString(appended.results[0]?.id);
   if (!createdId) throw new Error('failed to create section heading');
-  await maybePersistHeadingIdToMapping(input, sectionId, createdId);
+  await persistHeadingIdToMapping(input.storage, input.conversationId, sectionId, createdId);
   return { headingBlockId: createdId, discoveredBy: 'created' };
-}
-
-async function maybePersistHeadingIdToMapping(
-  input: {
-    storage?: { patchSyncMapping?: (conversationId: number, patch: Record<string, unknown>) => Promise<any> };
-    conversationId?: number;
-  },
-  sectionId: string,
-  headingBlockId: string,
-): Promise<void> {
-  const conversationId = Number(input?.conversationId);
-  if (!Number.isFinite(conversationId) || conversationId <= 0) return;
-  if (!input?.storage?.patchSyncMapping) return;
-  await input.storage.patchSyncMapping(conversationId, {
-    notionSections: { [sectionId]: { headingBlockId } },
-  });
 }
 
 export async function rebuildSectionByArchivingHeading(input: {
@@ -128,52 +124,18 @@ export async function rebuildSectionByArchivingHeading(input: {
   section: NotionManagedSectionSpec;
   currentHeadingBlockId: string;
   desiredBlocks: any[];
-  notionSyncService: { appendChildren: (accessToken: string, blockId: string, blocks: any[]) => Promise<any> };
+  notionSyncService: NotionAppendService;
 }): Promise<{ headingBlockId: string }> {
-  const currentId = safeString(input?.currentHeadingBlockId);
-  if (currentId) {
-    await archiveBlock(input.accessToken, currentId);
-  }
-  const heading = buildToggleHeadingBlock(input.section.title, input.section.level);
-  const headingRes = await input.notionSyncService.appendChildren(input.accessToken, input.pageId, [heading]);
-  const created = Array.isArray((headingRes as any)?.results) ? (headingRes as any).results : [];
-  const headingBlockId = safeString(created?.[0]?.id);
+  const currentId = safeString(input.currentHeadingBlockId);
+  if (currentId) await archiveBlock(input.accessToken, currentId);
+
+  const headingRes = await input.notionSyncService.appendChildren(input.accessToken, input.pageId, [
+    buildToggleHeadingBlock(input.section.title, input.section.level),
+  ]);
+  const headingBlockId = safeString(headingRes.results[0]?.id);
   if (!headingBlockId) throw new Error('failed to recreate section heading');
-  const blocks = Array.isArray(input.desiredBlocks) ? input.desiredBlocks : [];
-  if (blocks.length) {
-    await input.notionSyncService.appendChildren(input.accessToken, headingBlockId, blocks);
+  if (input.desiredBlocks.length) {
+    await input.notionSyncService.appendChildren(input.accessToken, headingBlockId, input.desiredBlocks);
   }
   return { headingBlockId };
-}
-
-export async function recoverSectionHeadingBlockId(input: {
-  accessToken: string;
-  pageId: string;
-  section: NotionManagedSectionSpec;
-  notionSyncService: { appendChildren: (accessToken: string, blockId: string, blocks: any[]) => Promise<any> };
-}): Promise<string> {
-  const title = safeString(input?.section?.title);
-  if (!title) throw new Error('invalid section spec');
-  const children = await listBlockChildren(input.accessToken, input.pageId);
-  const candidates = findHeadingBlocksByTitle(children, title);
-  let foundId = safeString(candidates.find((block) => isToggleHeadingBlock(block))?.id);
-  if (!foundId && candidates.length) {
-    for (const candidate of candidates) {
-      const candidateId = safeString((candidate as any)?.id);
-      if (!candidateId) continue;
-      const full = await retrieveBlock(input.accessToken, candidateId).catch(() => null);
-      if (!full) continue;
-      if (!isToggleHeadingBlock(full)) continue;
-      foundId = candidateId;
-      break;
-    }
-  }
-  if (foundId) return foundId;
-  const appended = await input.notionSyncService.appendChildren(input.accessToken, input.pageId, [
-    buildToggleHeadingBlock(title, input.section.level),
-  ]);
-  const results = Array.isArray((appended as any)?.results) ? (appended as any).results : [];
-  const createdId = safeString(results?.[0]?.id);
-  if (!createdId) throw new Error('failed to create section heading');
-  return createdId;
 }

--- a/src/services/sync/notion/notion-parent-pages.ts
+++ b/src/services/sync/notion/notion-parent-pages.ts
@@ -1,8 +1,8 @@
-import { getPageTitle, notionFetch as defaultNotionFetch } from '@services/sync/notion/notion-api.ts';
+import { getPageTitle, notionFetch } from '@services/sync/notion/notion-api.ts';
 
-export type NotionParentPageOption = { id: string; title: string };
+type NotionParentPageOption = { id: string; title: string };
 
-type NotionFetch = typeof defaultNotionFetch;
+const SEARCH_PAGE_SIZE = 50;
 
 function normalizeId(id: unknown) {
   return String(id || '')
@@ -21,8 +21,7 @@ function isSearchUsableParentPage(item: any) {
   const parent = item.parent || null;
   if (!parent) return true;
   if (parent.database_id) return false;
-  if (parent.type === 'database_id') return false;
-  return true;
+  return parent.type !== 'database_id';
 }
 
 function toOption(page: any): NotionParentPageOption | null {
@@ -34,39 +33,34 @@ function toOption(page: any): NotionParentPageOption | null {
 function dedupeOptions(list: NotionParentPageOption[]) {
   const out: NotionParentPageOption[] = [];
   const seen = new Set<string>();
-  for (const item of Array.isArray(list) ? list : []) {
-    const id = normalizeId(item?.id);
+  for (const item of list) {
+    const id = normalizeId(item.id);
     if (!id || seen.has(id)) continue;
     seen.add(id);
-    out.push({ id: String(item.id || '').trim(), title: String(item.title || '').trim() || String(item.id || '') });
+    out.push({ id: item.id.trim(), title: item.title.trim() || item.id });
   }
   return out;
 }
 
-async function searchParentPagesOnce(
-  notionFetch: NotionFetch,
-  accessToken: string,
-  input: { pageSize: number; startCursor?: string | null },
-) {
-  const body: any = {
+async function searchParentPagesOnce(accessToken: string, startCursor: string | null) {
+  const body = {
     filter: { property: 'object', value: 'page' },
     sort: { direction: 'descending', timestamp: 'last_edited_time' },
-    page_size: input.pageSize,
+    page_size: SEARCH_PAGE_SIZE,
+    ...(startCursor ? { start_cursor: startCursor } : {}),
   };
-  if (input.startCursor) body.start_cursor = String(input.startCursor);
   const res = await notionFetch({ accessToken, method: 'POST', path: '/v1/search', body });
   const results = Array.isArray(res?.results) ? res.results : [];
-  const pages = results.filter(isSearchUsableParentPage);
   return {
-    pages,
+    pages: results.filter(isSearchUsableParentPage),
     allResults: results,
     hasMore: !!res?.has_more,
     nextCursor: res?.next_cursor ? String(res.next_cursor) : '',
   };
 }
 
-async function retrievePage(notionFetch: NotionFetch, accessToken: string, pageId: string) {
-  const safeId = String(pageId || '').trim();
+async function retrievePage(accessToken: string, pageId: string) {
+  const safeId = pageId.trim();
   if (!safeId) return null;
   try {
     const page = await notionFetch({
@@ -74,8 +68,7 @@ async function retrievePage(notionFetch: NotionFetch, accessToken: string, pageI
       method: 'GET',
       path: `/v1/pages/${encodeURIComponent(safeId)}`,
     });
-    if (!page || page.object !== 'page') return null;
-    if (isPageArchived(page)) return null;
+    if (!page || page.object !== 'page' || isPageArchived(page)) return null;
     return page;
   } catch (_e) {
     return null;
@@ -84,31 +77,21 @@ async function retrievePage(notionFetch: NotionFetch, accessToken: string, pageI
 
 export async function listNotionParentPages(
   accessToken: string,
-  {
-    savedPageId,
-    pageSize = 50,
-    maxPages = 20,
-    notionFetchImpl = defaultNotionFetch,
-  }: { savedPageId?: string; pageSize?: number; maxPages?: number; notionFetchImpl?: NotionFetch } = {},
+  { savedPageId }: { savedPageId?: string } = {},
 ): Promise<{ pages: NotionParentPageOption[]; resolvedSaved: NotionParentPageOption | null }> {
-  const token = String(accessToken || '').trim();
+  const token = accessToken.trim();
   if (!token) throw new Error('missing notion access token');
 
   const savedNorm = normalizeId(savedPageId);
   let cursor: string | null = null;
-  let guard = 0;
   let foundPages: any[] = [];
   let resolvedSaved: any = null;
 
-  while (guard < maxPages) {
-    guard += 1;
-    const { pages, allResults, hasMore, nextCursor } = await searchParentPagesOnce(notionFetchImpl, token, {
-      pageSize,
-      startCursor: cursor,
-    });
+  for (;;) {
+    const { pages, allResults, hasMore, nextCursor } = await searchParentPagesOnce(token, cursor);
 
     if (savedNorm && !resolvedSaved) {
-      const hit = allResults.find((p: any) => normalizeId(p?.id) === savedNorm) || null;
+      const hit = allResults.find((page: any) => normalizeId(page?.id) === savedNorm) || null;
       if (hit && hit.object === 'page' && !isPageArchived(hit)) resolvedSaved = hit;
     }
 
@@ -121,15 +104,13 @@ export async function listNotionParentPages(
   }
 
   if (savedNorm && !resolvedSaved) {
-    resolvedSaved = await retrievePage(notionFetchImpl, token, String(savedPageId || '').trim());
+    resolvedSaved = await retrievePage(token, String(savedPageId || '').trim());
   }
 
   const list = foundPages.map(toOption).filter(Boolean) as NotionParentPageOption[];
-  const savedOpt = resolvedSaved ? toOption(resolvedSaved) : null;
-  const merged = savedOpt ? [savedOpt, ...list] : list;
-
+  const savedOption = resolvedSaved ? toOption(resolvedSaved) : null;
   return {
-    pages: dedupeOptions(merged),
-    resolvedSaved: savedOpt,
+    pages: dedupeOptions(savedOption ? [savedOption, ...list] : list),
+    resolvedSaved: savedOption,
   };
 }

--- a/src/services/sync/notion/notion-section-blocks.ts
+++ b/src/services/sync/notion/notion-section-blocks.ts
@@ -7,11 +7,7 @@ function safeString(value: unknown): string {
 }
 
 function isArchivedBlock(block: any): boolean {
-  try {
-    return (block as any)?.archived === true || (block as any)?.in_trash === true;
-  } catch (_e) {
-    return false;
-  }
+  return block?.archived === true || block?.in_trash === true;
 }
 
 function readPlainTextFromRichText(items: unknown): string {
@@ -39,10 +35,9 @@ function isHeadingType(type: unknown): type is 'heading_1' | 'heading_2' | 'head
   return t === 'heading_1' || t === 'heading_2' || t === 'heading_3';
 }
 
-export function buildToggleHeadingBlock(title: string, level: ToggleHeadingLevel = 2) {
-  const resolvedTitle = safeString(title);
+export function buildToggleHeadingBlock(title: string, level: ToggleHeadingLevel) {
   const type = headingTypeForLevel(level);
-  const rich_text = [{ type: 'text', text: { content: resolvedTitle || 'Untitled' } }];
+  const rich_text = [{ type: 'text', text: { content: safeString(title) } }];
   return {
     object: 'block',
     type,
@@ -59,11 +54,11 @@ export async function listBlockChildren(accessToken: string, blockId: string): P
   for (;;) {
     const qs = cursor ? `?page_size=100&start_cursor=${encodeURIComponent(String(cursor))}` : '?page_size=100';
 
-    const res = await notionFetch({ accessToken, method: 'GET', path: `/v1/blocks/${blockId}/children${qs}` } as any);
-    const results = Array.isArray((res as any)?.results) ? (res as any).results : [];
+    const res = await notionFetch({ accessToken, method: 'GET', path: `/v1/blocks/${blockId}/children${qs}` });
+    const results = Array.isArray(res?.results) ? res.results : [];
     out.push(...results);
-    if (!(res as any)?.has_more) break;
-    cursor = (res as any)?.next_cursor ? String((res as any).next_cursor) : null;
+    if (!res?.has_more) break;
+    cursor = res?.next_cursor ? String(res.next_cursor) : null;
     if (!cursor) break;
   }
   return out;
@@ -72,14 +67,14 @@ export async function listBlockChildren(accessToken: string, blockId: string): P
 export async function retrieveBlock(accessToken: string, blockId: string): Promise<any> {
   const id = safeString(blockId);
   if (!id) throw new Error('missing blockId');
-  return notionFetch({ accessToken, method: 'GET', path: `/v1/blocks/${encodeURIComponent(id)}` } as any);
+  return notionFetch({ accessToken, method: 'GET', path: `/v1/blocks/${encodeURIComponent(id)}` });
 }
 
 export async function archiveBlock(accessToken: string, blockId: string): Promise<any> {
   const id = safeString(blockId);
   if (!id) throw new Error('missing blockId');
   // Notion uses DELETE to archive blocks.
-  return notionFetch({ accessToken, method: 'DELETE', path: `/v1/blocks/${id}` } as any);
+  return notionFetch({ accessToken, method: 'DELETE', path: `/v1/blocks/${id}` });
 }
 
 export function isToggleHeadingBlock(block: any): boolean {
@@ -88,13 +83,7 @@ export function isToggleHeadingBlock(block: any): boolean {
   if (!isHeadingType(type)) return false;
   const payload = (block as any)?.[type];
   if (!payload) return false;
-  const isToggleable = (payload as any).is_toggleable;
-  if (isToggleable === true) return true;
-  // Some Notion API responses (or older API versions) may omit `is_toggleable` even for toggle headings.
-  // When the block already has children, treat it as a toggle heading so we can re-discover anchors and
-  // avoid appending duplicate section headings on subsequent sync runs.
-  if (isToggleable == null && (block as any)?.has_children === true) return true;
-  return false;
+  return (payload as any).is_toggleable === true;
 }
 
 function toggleHeadingTitle(block: any): string {
@@ -103,7 +92,7 @@ function toggleHeadingTitle(block: any): string {
   return readPlainTextFromRichText(payload?.rich_text);
 }
 
-export function isHeadingBlock(block: any): boolean {
+function isHeadingBlock(block: any): boolean {
   if (isArchivedBlock(block)) return false;
   const type = safeString(block?.type);
   if (!isHeadingType(type)) return false;
@@ -111,24 +100,11 @@ export function isHeadingBlock(block: any): boolean {
   return !!payload;
 }
 
-export function findToggleHeadingBlock(children: any[], title: string): any | null {
-  const list = Array.isArray(children) ? children : [];
-  const needle = safeString(title);
-  if (!needle) return null;
-  for (const block of list) {
-    if (!block || typeof block !== 'object') continue;
-    if (!isToggleHeadingBlock(block)) continue;
-    if (toggleHeadingTitle(block) === needle) return block;
-  }
-  return null;
-}
-
 export function findHeadingBlocksByTitle(children: any[], title: string): any[] {
-  const list = Array.isArray(children) ? children : [];
   const needle = safeString(title);
   if (!needle) return [];
   const out: any[] = [];
-  for (const block of list) {
+  for (const block of children) {
     if (!block || typeof block !== 'object') continue;
     if (!isHeadingBlock(block)) continue;
     if (toggleHeadingTitle(block) !== needle) continue;

--- a/src/services/sync/notion/notion-services.ts
+++ b/src/services/sync/notion/notion-services.ts
@@ -1,5 +1,8 @@
 import type { ArticleCommentDto } from '@services/comments/domain/comment-dto';
-import type { ConversationKindDbSpec } from '@services/protocols/conversation-kind-contract';
+import type {
+  ConversationKindDbSpec,
+  ConversationKindDefinition,
+} from '@services/protocols/conversation-kind-contract';
 import type { SyncJobStore } from '@services/sync/sync-job-store';
 
 type NotionToken = {
@@ -12,7 +15,7 @@ type NotionTokenStore = {
 };
 
 type NotionConversationKinds = {
-  pick: (input: { source?: unknown; sourceType?: unknown }) => any;
+  pick: (input: { source?: unknown; sourceType?: unknown }) => ConversationKindDefinition | null;
 };
 
 type NotionBackgroundStorage = {
@@ -24,7 +27,7 @@ type NotionBackgroundStorage = {
     meta?: { notionPageUrl?: string; notionWorkspaceSlug?: string },
   ) => Promise<any>;
   setSyncCursor: (conversationId: number, cursor: any) => Promise<any>;
-  patchSyncMapping?: (conversationId: number, patch: Record<string, unknown>) => Promise<any>;
+  patchSyncMapping: (conversationId: number, patch: Record<string, unknown>) => Promise<any>;
   getArticleCommentsByConversationId: (conversationId: number) => Promise<ArticleCommentDto[]>;
   attachOrphanArticleCommentsToConversation: (canonicalUrl: string, conversationId: number) => Promise<any>;
 };
@@ -34,17 +37,23 @@ type NotionDbManager = {
     accessToken: string;
     parentPageId: string;
     dbSpec: ConversationKindDbSpec;
-  }) => Promise<{ databaseId?: unknown }>;
+  }) => Promise<{ databaseId: string }>;
   clearCachedDatabaseId: (storageKey: string) => Promise<any>;
 };
 
 type NotionSyncService = {
   getPage: (accessToken: string, pageId: string) => Promise<any>;
-  createPageInDatabase: (accessToken: string, input: any) => Promise<any>;
-  updatePageProperties: (accessToken: string, input: any) => Promise<any>;
-  appendChildren: (accessToken: string, pageId: string, blocks: any[]) => Promise<any>;
+  createPageInDatabase: (
+    accessToken: string,
+    input: { databaseId: string; properties: Record<string, unknown> },
+  ) => Promise<any>;
+  updatePageProperties: (
+    accessToken: string,
+    input: { pageId: string; properties: Record<string, unknown> },
+  ) => Promise<any>;
+  appendChildren: (accessToken: string, pageId: string, blocks: any[]) => Promise<{ results: any[]; count: number }>;
   messagesToBlocks: (messages: any[]) => any[];
-  isPageUsableForDatabase: (page: any, databaseId?: string) => boolean;
+  isPageUsableForDatabase: (page: any, databaseId: string) => boolean;
   upgradeImageBlocksToFileUploads: (accessToken: string, blocks: any[], conversationId: number) => Promise<any[]>;
 };
 

--- a/src/services/sync/notion/notion-sync-orchestrator.ts
+++ b/src/services/sync/notion/notion-sync-orchestrator.ts
@@ -8,12 +8,15 @@ import {
 } from '@services/comments/sync/notion-comments-renderer';
 import { computeArticleCommentThreadCount } from '@services/comments/domain/comment-metrics';
 import { parseArticleCommentDtos, type ArticleCommentDto } from '@services/comments/domain/comment-dto';
+import type {
+  ConversationKindDbSpec,
+  ConversationKindDefinition,
+} from '@services/protocols/conversation-kind-contract';
 import { buildToggleHeadingBlock as buildNotionToggleHeadingBlock } from '@services/sync/notion/notion-section-blocks.ts';
 import {
   ensureSectionHeadingBlockId,
   layoutSpecForConversationKind,
   rebuildSectionByArchivingHeading,
-  recoverSectionHeadingBlockId,
 } from '@services/sync/notion/notion-managed-sections.ts';
 import { normalizeStandaloneImageCaptionLines } from '@services/sync/shared/markdown-image-normalizer';
 import { formatVideoContentMarkdown } from '@services/conversations/domain/markdown';
@@ -25,48 +28,6 @@ import type { SyncJobSnapshot } from '@services/sync/models';
 const SYNC_PROVIDER = 'notion';
 const SYNC_CONVERSATION_CONCURRENCY = 2;
 
-function notionTraceEnabled() {
-  try {
-    return !!(globalThis as any).__SYNCNOS_NOTION_TRACE__;
-  } catch (_e) {
-    return false;
-  }
-}
-
-function createConversationTrace(conversationId: unknown) {
-  const enabled = notionTraceEnabled();
-  const startedAt = Date.now();
-  let lastAt = startedAt;
-  const stages: any[] = [];
-
-  function mark(stage: unknown) {
-    if (!enabled) return;
-    const now = Date.now();
-    stages.push({
-      stage: String(stage || 'unknown'),
-      elapsedMs: now - startedAt,
-      sinceLastMs: now - lastAt,
-    });
-    lastAt = now;
-  }
-
-  function flush(meta: any = {}) {
-    if (!enabled || !stages.length) return;
-    try {
-      console.debug('[SyncNos][NotionTrace]', {
-        conversationId: Number(conversationId) || 0,
-        totalMs: Date.now() - startedAt,
-        stages: stages.slice(),
-        ...meta,
-      });
-    } catch (_e) {
-      // ignore debug logging failures
-    }
-  }
-
-  return { mark, flush };
-}
-
 function toConvoLabel(convo: any): string {
   if (!convo) return '(missing conversation)';
   const t = convo.title || '';
@@ -74,86 +35,42 @@ function toConvoLabel(convo: any): string {
 }
 
 function isObjectNotFoundError(error: unknown): boolean {
-  const message = error && (error as any).message ? String((error as any).message) : String(error || '');
-  if (!message) return false;
-  return message.includes('object_not_found');
+  return (
+    String((error as any)?.code || '')
+      .trim()
+      .toLowerCase() === 'object_not_found'
+  );
 }
 
 function isMissingDatabaseError(error: unknown): boolean {
-  const message = error && (error as any).message ? String((error as any).message) : String(error || '');
-  if (!message) return false;
   if (!isObjectNotFoundError(error)) return false;
-  return message.toLowerCase().includes('database');
+  return String((error as any)?.notionMessage || '')
+    .toLowerCase()
+    .includes('database');
 }
 
 function buildJobPersistenceError(): Error {
   return Object.assign(new Error('notion sync job persistence failed'), { code: 'notion_sync_job_persist_failed' });
 }
 
-function parseHttpStatus(error: unknown): number {
-  const explicit = error && (error as any).status != null ? Number((error as any).status) : NaN;
-  if (Number.isFinite(explicit) && explicit > 0) return explicit;
-  const message = error && (error as any).message ? String((error as any).message) : String(error || '');
-  const match = message.match(/\bHTTP\s+(\d{3})\b/i);
-  return match ? Number(match[1]) : 0;
-}
-
-function parseNotionErrorCode(error: unknown): string {
-  const explicit = String(error && (error as any).code ? (error as any).code : '').trim();
-  if (explicit) return explicit.toLowerCase();
-  const message = error && (error as any).message ? String((error as any).message) : String(error || '');
-  const codeMatch = message.match(/"code"\s*:\s*"([^"]+)"/i);
-  return codeMatch
-    ? String(codeMatch[1] || '')
-        .trim()
-        .toLowerCase()
-    : '';
-}
-
-function parseNotionErrorMessage(error: unknown): string {
-  const explicit = error && (error as any).notionMessage ? String((error as any).notionMessage) : '';
-  if (explicit.trim()) return explicit.trim();
-  const message = error && (error as any).message ? String((error as any).message) : String(error || '');
-  const apiMessageMatch = message.match(/"message"\s*:\s*"([^"]+)"/i);
-  if (apiMessageMatch && apiMessageMatch[1]) {
-    try {
-      return JSON.parse(`"${apiMessageMatch[1]}"`);
-    } catch (_e) {
-      return String(apiMessageMatch[1]);
-    }
-  }
-  return message;
-}
-
 function formatRetryHint(error: unknown): string {
-  const retryAfterMs = error && (error as any).retryAfterMs != null ? Number((error as any).retryAfterMs) : 0;
+  const retryAfterMs = Number((error as any)?.retryAfterMs || 0);
   if (!Number.isFinite(retryAfterMs) || retryAfterMs <= 0) return '';
   const seconds = Math.max(1, Math.ceil(retryAfterMs / 1000));
   return ` Retry in about ${seconds}s.`;
 }
 
 function normalizeNotionSyncError(error: unknown): string {
-  const rawMessage =
-    error && (error as any).message ? String((error as any).message) : String(error || 'unknown error');
-  if (!rawMessage) return 'unknown error';
-  if (!rawMessage.toLowerCase().includes('notion api failed:')) return rawMessage;
-
-  const status = parseHttpStatus(error);
-  const notionMessage = parseNotionErrorMessage(error)
-    .replace(/^notion api failed:\s*/i, '')
-    .trim();
-  if (status === 429) {
-    const retryHint = formatRetryHint(error);
-    return `${notionMessage || rawMessage}${retryHint}`.trim();
-  }
-  return notionMessage || rawMessage;
+  const rawMessage = String((error as any)?.message || error || 'unknown error');
+  const notionMessage = String((error as any)?.notionMessage || '').trim();
+  const message = notionMessage || rawMessage || 'unknown error';
+  if (Number((error as any)?.status || 0) !== 429) return message;
+  return `${message}${formatRetryHint(error)}`.trim();
 }
 
 function isStaleBlockAnchorError(error: unknown): boolean {
-  const code = parseNotionErrorCode(error);
-  if (code === 'object_not_found') return true;
+  if (isObjectNotFoundError(error)) return true;
   const msg = normalizeNotionSyncError(error).toLowerCase();
-  if (!msg) return false;
   return msg.includes('archived') || msg.includes('in_trash');
 }
 
@@ -286,32 +203,27 @@ async function maybeUpgradeBlocksWithNotionFileUploads({
   return nextBlocks;
 }
 
-function pickArticleBodyMessages(messagesList: unknown) {
-  const list = Array.isArray(messagesList) ? messagesList : [];
-  const preferred = list.filter((m) => m && String(m.messageKey || '').trim() === 'article_body');
-  if (preferred.length) return preferred;
-  return list;
+function pickArticleBodyMessages(messagesList: any[]) {
+  const preferred = messagesList.filter((message) => String(message.messageKey || '').trim() === 'article_body');
+  return preferred.length ? preferred : messagesList;
 }
 
-function pickArticleBodyMarkdown(messagesList: unknown): string {
-  const list = Array.isArray(messagesList) ? messagesList : [];
-  const preferred = list.find((m) => m && String(m.messageKey || '').trim() === 'article_body');
+function pickArticleBodyMarkdown(messagesList: any[]): string {
+  const preferred = messagesList.find((message) => String(message.messageKey || '').trim() === 'article_body');
   const picked =
     preferred ||
-    list.find(
-      (m) =>
-        m &&
-        String(m.role || '')
+    messagesList.find(
+      (message) =>
+        String(message.role || '')
           .trim()
           .toLowerCase() === 'article',
     ) ||
-    list[0] ||
+    messagesList[0] ||
     null;
   return String((picked && picked.contentMarkdown) || '').trim();
 }
 
-function fnv1a32(input: unknown): string {
-  const text = String(input || '');
+function fnv1a32(text: string): string {
   let hash = 0x811c9dc5;
   for (let i = 0; i < text.length; i += 1) {
     hash ^= text.charCodeAt(i);
@@ -320,13 +232,13 @@ function fnv1a32(input: unknown): string {
   return (hash >>> 0).toString(16).padStart(8, '0');
 }
 
-function computeNotionArticleDigest(messagesList: unknown): string {
+function computeNotionArticleDigest(messagesList: any[]): string {
   const markdown = normalizeStandaloneImageCaptionLines(pickArticleBodyMarkdown(messagesList));
   return fnv1a32(JSON.stringify({ markdown }));
 }
 
-function stripLeadingRoleHeading(blocks: unknown, expectedLabel: string) {
-  const list = Array.isArray(blocks) ? blocks.slice() : [];
+function stripLeadingRoleHeading(blocks: any[], expectedLabel: string) {
+  const list = blocks.slice();
   if (!list.length) return list;
   const first = list[0];
   if (!first || typeof first !== 'object') return list;
@@ -381,7 +293,7 @@ async function buildNonArticleBlocksForSync({
   if (kindId !== 'video') return built;
   return {
     ...built,
-    blocks: stripLeadingRoleHeading(Array.isArray(built?.blocks) ? built.blocks : [], 'transcript'),
+    blocks: stripLeadingRoleHeading(built.blocks, 'transcript'),
   };
 }
 
@@ -468,21 +380,19 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
       const recoveredMissingDbByStorageKey = new Set();
       const dbRecoveryPromiseByStorageKey = new Map();
 
-      async function ensureDbForKind(kind: any) {
+      async function ensureDbForKind(kind: ConversationKindDefinition) {
         const existing = dbIdByKindId.get(kind.id);
         if (existing) return String(existing);
         const pending = dbIdPromiseByKindId.get(kind.id);
         if (pending) return pending;
-        const spec = kind && kind.notion && kind.notion.dbSpec ? kind.notion.dbSpec : null;
-        if (!spec) throw new Error(`missing dbSpec for kind ${kind && kind.id ? kind.id : '?'}`);
+        const dbSpec = kind.notion.dbSpec;
         const dbPromise = (async () => {
           const db = await notionDbManager.ensureDatabase({
             accessToken: accessToken,
             parentPageId,
-            dbSpec: spec,
+            dbSpec,
           });
-          const dbId = db && db.databaseId ? String(db.databaseId) : '';
-          if (!dbId) throw new Error(`missing databaseId for kind ${kind.id}`);
+          const dbId = db.databaseId;
           dbIdByKindId.set(kind.id, dbId);
           return dbId;
         })();
@@ -494,8 +404,8 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
         }
       }
 
-      async function recoverDbForStorageKey(kind: any, dbSpec: any) {
-        const storageKey = String(dbSpec && dbSpec.storageKey ? dbSpec.storageKey : '');
+      async function recoverDbForStorageKey(kind: ConversationKindDefinition, dbSpec: ConversationKindDbSpec) {
+        const storageKey = dbSpec.storageKey;
         const pending = dbRecoveryPromiseByStorageKey.get(storageKey);
         if (pending) return pending;
         const recoveryPromise = (async () => {
@@ -505,8 +415,7 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
             parentPageId,
             dbSpec,
           });
-          const rebuiltDbId = rebuiltDb && rebuiltDb.databaseId ? String(rebuiltDb.databaseId) : '';
-          if (!rebuiltDbId) throw new Error(`missing databaseId for kind ${kind.id}`);
+          const rebuiltDbId = rebuiltDb.databaseId;
           dbIdByKindId.set(kind.id, rebuiltDbId);
           recoveredMissingDbByStorageKey.add(storageKey);
           return rebuiltDbId;
@@ -520,13 +429,10 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
       }
 
       async function processConversation(id: number) {
-        const trace = createConversationTrace(id);
         const warnings: any[] = [];
         let conversationTitle = '';
 
         try {
-          trace.mark('load conversation');
-
           const mapped = await storage.getSyncMappingByConversation(id);
           let convo = mapped && mapped.conversation ? mapped.conversation : null;
           const mapping = mapped && mapped.mapping ? mapped.mapping : null;
@@ -547,10 +453,8 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
 
           const kind = conversationKinds.pick(convo);
           if (!kind) throw new Error(`no conversation kind for ${toConvoLabel(convo)}`);
-          const dbSpec = kind && kind.notion && kind.notion.dbSpec ? kind.notion.dbSpec : null;
-          const pageSpec = kind && kind.notion && kind.notion.pageSpec ? kind.notion.pageSpec : null;
-          if (!dbSpec || !dbSpec.storageKey) throw new Error(`missing notion dbSpec for kind ${kind.id}`);
-          if (!pageSpec) throw new Error(`missing notion pageSpec for kind ${kind.id}`);
+          const dbSpec = kind.notion.dbSpec;
+          const pageSpec = kind.notion.pageSpec;
           let articleCommentsLoaded = false;
           let articleCommentsLoadFailed = false;
           let cachedArticleComments: ArticleCommentDto[] = [];
@@ -591,11 +495,10 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
             return cachedArticleComments;
           };
 
-          trace.mark('ensure database');
           let dbId = await ensureDbForKind(kind);
 
           const messages = await storage.getMessagesByConversationId(id);
-          const cursorSectionId = kind && kind.id === 'chat' ? 'conversations' : null;
+          const cursorSectionId = kind.id === 'chat' ? 'conversations' : null;
           const cursor = extractCursor(mapping, cursorSectionId);
 
           let pageId = '';
@@ -605,7 +508,6 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
           let pageUsable = false;
           let existingPage = null;
           if (pageId) {
-            trace.mark('check destination page');
             try {
               const page = await notionSyncService.getPage(accessToken, pageId);
               existingPage = page;
@@ -638,7 +540,6 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
                   ),
                   pageSpec.buildCreateProperties(convo))
                 : pageSpec.buildCreateProperties(convo);
-            trace.mark('create destination page');
             try {
               created = await notionSyncService.createPageInDatabase(accessToken, {
                 databaseId: dbId,
@@ -647,15 +548,13 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
             } catch (createErr) {
               const shouldRecoverDb = isMissingDatabaseError(createErr);
               if (!shouldRecoverDb) throw createErr;
-              const recoveredStorageKey = String(dbSpec.storageKey || '');
-              trace.mark('rebuild database');
+              const recoveredStorageKey = dbSpec.storageKey;
               // Rebuild once per storage key and share the recovery across concurrent conversations.
 
               dbId =
                 recoveredMissingDbByStorageKey.has(recoveredStorageKey) && dbIdByKindId.get(kind.id)
                   ? String(dbIdByKindId.get(kind.id) || '')
                   : await recoverDbForStorageKey(kind, dbSpec);
-              trace.mark('create destination page');
 
               created = await notionSyncService.createPageInDatabase(accessToken, {
                 databaseId: dbId,
@@ -672,14 +571,11 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
               ...(createdSlug ? { notionWorkspaceSlug: createdSlug } : null),
             });
 
-            trace.mark('build blocks');
-
             const layout = layoutSpecForConversationKind(kind.id);
-            const sections = Array.isArray(layout?.sections) ? layout.sections : [];
+            const sections = layout.sections;
             if (!sections.length) throw new Error('missing layout sections');
 
             const nextCursor = lastMessageCursor(messages);
-            let appendedBlockCount = 0;
 
             if (kind.id === 'article') {
               const articleSection = sections.find((s) => s && String(s.id) === 'article');
@@ -689,9 +585,7 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
               const comments = await ensureArticleCommentsLoaded(
                 'Failed to load local article comments; syncing article body only.',
               );
-              const commentsDigest = articleCommentsLoadFailed
-                ? null
-                : computeNotionCommentsDigest(Array.isArray(comments) ? comments : []);
+              const commentsDigest = articleCommentsLoadFailed ? null : computeNotionCommentsDigest(comments);
               let commentThreads = 0;
               let commentItems = 0;
 
@@ -703,26 +597,20 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
                 messagesList: pickArticleBodyMessages(messages),
                 conversationId: id,
               });
-              const articleBlocks = stripLeadingRoleHeading(
-                Array.isArray(builtArticle?.blocks) ? builtArticle.blocks : [],
-                'article',
-              );
-              if (Array.isArray(builtArticle?.warnings) && builtArticle.warnings.length)
-                warnings.push(...builtArticle.warnings);
+              const articleBlocks = stripLeadingRoleHeading(builtArticle.blocks, 'article');
+              if (builtArticle.warnings.length) warnings.push(...builtArticle.warnings);
 
-              const builtComments = buildNotionCommentsBlocks(Array.isArray(comments) ? comments : []);
-              const commentBlocks = Array.isArray(builtComments?.blocks) ? builtComments.blocks : [];
+              const builtComments = buildNotionCommentsBlocks(comments);
+              const commentBlocks = builtComments.blocks;
               commentThreads = Number(builtComments?.threads) || 0;
               commentItems = Number(builtComments?.items) || 0;
-
-              trace.mark('create section headings');
 
               const headingRes = await notionSyncService.appendChildren(
                 accessToken,
                 pageId,
                 sections.map((s) => buildNotionToggleHeadingBlock(s.title, s.level)),
               );
-              const headingResults = Array.isArray(headingRes && headingRes.results) ? headingRes.results : [];
+              const headingResults = headingRes.results;
               const headingIdBySectionId: Record<string, string> = {};
               for (let i = 0; i < sections.length; i += 1) {
                 const section = sections[i];
@@ -736,25 +624,19 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
               const commentsHeadingId = String(headingIdBySectionId.comments || '').trim();
               if (!articleHeadingId || !commentsHeadingId) throw new Error('failed to create section headings');
 
-              if (storage && typeof storage.patchSyncMapping === 'function') {
-                await storage.patchSyncMapping(id, {
-                  notionSections: {
-                    article: { headingBlockId: articleHeadingId },
-                    comments: { headingBlockId: commentsHeadingId },
-                  },
-                });
-              }
+              await storage.patchSyncMapping(id, {
+                notionSections: {
+                  article: { headingBlockId: articleHeadingId },
+                  comments: { headingBlockId: commentsHeadingId },
+                },
+              });
 
-              trace.mark('append children');
               if (articleBlocks.length) {
                 await notionSyncService.appendChildren(accessToken, articleHeadingId, articleBlocks);
               }
               if (commentBlocks.length) {
                 await notionSyncService.appendChildren(accessToken, commentsHeadingId, commentBlocks);
               }
-              appendedBlockCount = sections.length + articleBlocks.length + commentBlocks.length;
-
-              trace.mark('save cursor');
 
               await storage.setSyncCursor(id, {
                 ...nextCursor,
@@ -776,7 +658,6 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
                 warnings,
                 comments: { updated: true, threads: commentThreads, items: commentItems },
               });
-              trace.flush({ mode: 'created', ok: true, blockCount: appendedBlockCount });
               return;
             }
 
@@ -791,32 +672,23 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
               messagesList: messages,
               conversationId: id,
             });
-            const blocks = Array.isArray(built?.blocks) ? built.blocks : [];
-            if (Array.isArray(built?.warnings) && built.warnings.length) warnings.push(...built.warnings);
-
-            trace.mark('create section heading');
+            const blocks = built.blocks;
+            if (built.warnings.length) warnings.push(...built.warnings);
 
             const headingRes = await notionSyncService.appendChildren(accessToken, pageId, [
               buildNotionToggleHeadingBlock(conversationsSection.title, conversationsSection.level),
             ]);
-            const headingResults = Array.isArray(headingRes && headingRes.results) ? headingRes.results : [];
+            const headingResults = headingRes.results;
             const conversationsHeadingId =
               headingResults[0] && headingResults[0].id ? String(headingResults[0].id).trim() : '';
             if (!conversationsHeadingId) throw new Error('failed to create conversations section');
 
-            if (storage && typeof storage.patchSyncMapping === 'function') {
-              await storage.patchSyncMapping(id, {
-                notionSections: { conversations: { headingBlockId: conversationsHeadingId } },
-              });
-            }
+            await storage.patchSyncMapping(id, {
+              notionSections: { conversations: { headingBlockId: conversationsHeadingId } },
+            });
             if (blocks.length) {
-              trace.mark('append children');
-
               await notionSyncService.appendChildren(accessToken, conversationsHeadingId, blocks);
-              appendedBlockCount = blocks.length + 1;
             }
-
-            trace.mark('save cursor');
 
             await storage.setSyncCursor(id, {
               ...nextCursor,
@@ -838,7 +710,6 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
               appended: messages.length,
               warnings,
             });
-            trace.flush({ mode: 'created', ok: true, blockCount: appendedBlockCount });
             return;
           }
 
@@ -849,8 +720,6 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
             const desiredProperties = pageSpec.buildUpdateProperties(convo);
             const needsPropertyUpdate = pagePropertiesNeedUpdate(existingPage, desiredProperties);
             if (needsPropertyUpdate) {
-              trace.mark('update page properties');
-
               await notionSyncService.updatePageProperties(accessToken, {
                 pageId,
                 properties: desiredProperties,
@@ -858,16 +727,11 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
             }
 
             const layout = layoutSpecForConversationKind(kind.id);
-            const articleSection = (layout.sections || []).find((s) => s && String(s.id) === 'article');
-            const commentsSection = (layout.sections || []).find((s) => s && String(s.id) === 'comments');
+            const articleSection = layout.sections.find((s) => s && String(s.id) === 'article');
+            const commentsSection = layout.sections.find((s) => s && String(s.id) === 'comments');
             if (!articleSection || !commentsSection) throw new Error('missing web article layout sections');
 
-            let articleDigest: string | null = null;
-            try {
-              articleDigest = computeNotionArticleDigest(messages);
-            } catch (_e) {
-              articleDigest = null;
-            }
+            const articleDigest = computeNotionArticleDigest(messages);
             const prevArticleDigest =
               mapping &&
               mapping.notionSectionDigests &&
@@ -880,13 +744,11 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
             const shouldUpdateArticle =
               typeof articleDigest === 'string' && String(articleDigest || '') !== prevArticleDigest;
 
-            let articleComments: any[] = Array.isArray(cachedArticleComments) ? cachedArticleComments : [];
+            const articleComments = cachedArticleComments;
             let commentsDigest: string | null = null;
             let commentThreads = 0;
             let commentItems = 0;
-            commentsDigest = articleCommentsLoadFailed
-              ? null
-              : computeNotionCommentsDigest(Array.isArray(articleComments) ? articleComments : []);
+            commentsDigest = articleCommentsLoadFailed ? null : computeNotionCommentsDigest(articleComments);
             const prevCommentsDigest =
               mapping &&
               mapping.notionSectionDigests &&
@@ -905,14 +767,12 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
                 : {};
             const hasArticleAnchor = !!(mappingSections.article && mappingSections.article.headingBlockId);
             const hasCommentsAnchor = !!(mappingSections.comments && mappingSections.comments.headingBlockId);
-            const shouldEnsureAnchors =
-              (!hasArticleAnchor || !hasCommentsAnchor) && typeof storage.patchSyncMapping === 'function';
+            const shouldEnsureAnchors = !hasArticleAnchor || !hasCommentsAnchor;
 
             let articleHeadingBlockId = hasArticleAnchor ? String(mappingSections.article.headingBlockId || '') : '';
             let commentsHeadingBlockId = hasCommentsAnchor ? String(mappingSections.comments.headingBlockId || '') : '';
 
             if (shouldEnsureAnchors) {
-              trace.mark('ensure section anchors');
               const resolvedArticle = await ensureSectionHeadingBlockId({
                 accessToken: accessToken,
                 pageId,
@@ -936,7 +796,6 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
             }
 
             if (shouldUpdateArticle || shouldUpdateComments) {
-              trace.mark('build web article blocks');
               let articleBlocks: any[] = [];
               let commentBlocks: any[] = [];
 
@@ -947,17 +806,14 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
                   messagesList: pickArticleBodyMessages(messages),
                   conversationId: id,
                 });
-                articleBlocks = stripLeadingRoleHeading(
-                  Array.isArray(builtArticle?.blocks) ? builtArticle.blocks : [],
-                  'article',
-                );
-                if (Array.isArray(builtArticle?.warnings) && builtArticle.warnings.length) {
+                articleBlocks = stripLeadingRoleHeading(builtArticle.blocks, 'article');
+                if (builtArticle.warnings.length) {
                   warnings.push(...builtArticle.warnings);
                 }
               }
               if (shouldUpdateComments) {
-                const builtComments = buildNotionCommentsBlocks(Array.isArray(articleComments) ? articleComments : []);
-                commentBlocks = Array.isArray(builtComments?.blocks) ? builtComments.blocks : [];
+                const builtComments = buildNotionCommentsBlocks(articleComments);
+                commentBlocks = builtComments.blocks;
                 commentThreads = Number(builtComments?.threads) || 0;
                 commentItems = Number(builtComments?.items) || 0;
               }
@@ -975,7 +831,6 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
                   });
                   articleHeadingBlockId = resolved.headingBlockId;
                 }
-                trace.mark('rebuild article section');
                 let rebuilt;
                 try {
                   rebuilt = await rebuildSectionByArchivingHeading({
@@ -988,7 +843,6 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
                   });
                 } catch (e) {
                   if (!isStaleBlockAnchorError(e)) throw e;
-                  trace.mark('recover article rebuild');
                   rebuilt = await rebuildSectionByArchivingHeading({
                     accessToken: accessToken,
                     pageId,
@@ -999,11 +853,9 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
                   });
                 }
                 articleHeadingBlockId = rebuilt.headingBlockId;
-                if (storage && typeof storage.patchSyncMapping === 'function') {
-                  await storage.patchSyncMapping(id, {
-                    notionSections: { article: { headingBlockId: articleHeadingBlockId } },
-                  });
-                }
+                await storage.patchSyncMapping(id, {
+                  notionSections: { article: { headingBlockId: articleHeadingBlockId } },
+                });
               }
 
               if (shouldUpdateComments) {
@@ -1019,7 +871,6 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
                   });
                   commentsHeadingBlockId = resolved.headingBlockId;
                 }
-                trace.mark('rebuild comments section');
                 let rebuilt;
                 try {
                   rebuilt = await rebuildSectionByArchivingHeading({
@@ -1032,7 +883,6 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
                   });
                 } catch (e) {
                   if (!isStaleBlockAnchorError(e)) throw e;
-                  trace.mark('recover comments rebuild');
                   rebuilt = await rebuildSectionByArchivingHeading({
                     accessToken: accessToken,
                     pageId,
@@ -1043,16 +893,13 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
                   });
                 }
                 commentsHeadingBlockId = rebuilt.headingBlockId;
-                if (storage && typeof storage.patchSyncMapping === 'function') {
-                  await storage.patchSyncMapping(id, {
-                    notionSections: { comments: { headingBlockId: commentsHeadingBlockId } },
-                  });
-                }
+                await storage.patchSyncMapping(id, {
+                  notionSections: { comments: { headingBlockId: commentsHeadingBlockId } },
+                });
               }
             }
 
             const nextCursor = lastMessageCursor(messages);
-            trace.mark('save cursor');
 
             await storage.setSyncCursor(id, {
               ...nextCursor,
@@ -1095,10 +942,6 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
                   }
                 : null),
             });
-            trace.flush({
-              mode: resultMode,
-              ok: true,
-            });
             return;
           }
 
@@ -1106,24 +949,13 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
           let shouldRebuild = !!inc.rebuild;
           const layout = layoutSpecForConversationKind(kind.id);
           const conversationsSection =
-            (layout.sections || []).find((s) => s && String(s.id) === 'conversations') || layout.sections?.[0];
+            layout.sections.find((s) => s && String(s.id) === 'conversations') || layout.sections[0];
           if (!conversationsSection) throw new Error('missing conversations section spec');
 
-          // Migrate legacy pages (no Conversations section anchor) by forcing a rebuild once,
-          // so subsequent syncs can append under the section without scanning page children.
-          // Also rebuild when local edits happen without new messages (append cannot fix historical edits).
-          const mappingSections =
-            mapping && mapping.notionSections && typeof mapping.notionSections === 'object'
-              ? mapping.notionSections
-              : {};
-          const hasConversationsAnchor = !!(
-            mappingSections.conversations && String(mappingSections.conversations.headingBlockId || '').trim()
-          );
-          if (!hasConversationsAnchor) {
-            shouldRebuild = true;
-          } else if (!shouldRebuild && !(inc.newMessages && inc.newMessages.length)) {
+          // Rebuild when local edits happen without new messages; append cannot fix historical edits.
+          if (!shouldRebuild && !(inc.newMessages && inc.newMessages.length)) {
             let maxUpdatedAt = 0;
-            for (const m of Array.isArray(messages) ? messages : []) {
+            for (const m of messages) {
               const at = Number(m && (m.updatedAt as any));
               if (Number.isFinite(at)) maxUpdatedAt = Math.max(maxUpdatedAt, at);
             }
@@ -1151,13 +983,10 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
               throw new Error(`missing cursor for ${toConvoLabel(convo)} and no local messages to rebuild`);
             }
 
-            trace.mark('rebuild page properties');
-
             await notionSyncService.updatePageProperties(accessToken, {
               pageId,
               properties: pageSpec.buildUpdateProperties(convo),
             });
-            trace.mark('build blocks');
 
             const built = await buildNonArticleBlocksForSync({
               notionSyncService,
@@ -1167,10 +996,9 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
               messagesList: messages,
               conversationId: id,
             });
-            const blocks = Array.isArray(built.blocks) ? built.blocks : [];
-            if (Array.isArray(built.warnings) && built.warnings.length) warnings.push(...built.warnings);
+            const blocks = built.blocks;
+            if (built.warnings.length) warnings.push(...built.warnings);
 
-            trace.mark('rebuild conversations section');
             let rebuilt;
             try {
               const resolved = await ensureSectionHeadingBlockId({
@@ -1192,7 +1020,6 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
               });
             } catch (e) {
               if (!isStaleBlockAnchorError(e)) throw e;
-              trace.mark('recover conversations rebuild');
               rebuilt = await rebuildSectionByArchivingHeading({
                 accessToken: accessToken,
                 pageId,
@@ -1203,13 +1030,10 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
               });
             }
 
-            if (storage && typeof storage.patchSyncMapping === 'function') {
-              await storage.patchSyncMapping(id, {
-                notionSections: { conversations: { headingBlockId: rebuilt.headingBlockId } },
-              });
-            }
+            await storage.patchSyncMapping(id, {
+              notionSections: { conversations: { headingBlockId: rebuilt.headingBlockId } },
+            });
             const nextCursor = lastMessageCursor(messages);
-            trace.mark('save cursor');
 
             await storage.setSyncCursor(id, {
               ...nextCursor,
@@ -1230,16 +1054,12 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
               appended: 0,
               warnings,
             });
-            trace.flush({ mode: 'rebuilt', ok: true, blockCount: blocks.length });
             return;
           } else if (inc.newMessages && inc.newMessages.length) {
-            trace.mark('update page properties');
-
             await notionSyncService.updatePageProperties(accessToken, {
               pageId,
               properties: pageSpec.buildUpdateProperties(convo),
             });
-            trace.mark('build blocks');
 
             const built = await buildNonArticleBlocksForSync({
               notionSyncService,
@@ -1249,13 +1069,12 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
               messagesList: inc.newMessages,
               conversationId: id,
             });
-            const blocks = Array.isArray(built.blocks) ? built.blocks : [];
-            if (Array.isArray(built.warnings) && built.warnings.length) warnings.push(...built.warnings);
+            const blocks = built.blocks;
+            if (built.warnings.length) warnings.push(...built.warnings);
             if (blocks.length) {
-              trace.mark('append children');
               const layout = layoutSpecForConversationKind(kind.id);
               const conversationsSection =
-                (layout.sections || []).find((s) => s && String(s.id) === 'conversations') || layout.sections?.[0];
+                layout.sections.find((s) => s && String(s.id) === 'conversations') || layout.sections[0];
               if (!conversationsSection) throw new Error('missing conversations section spec');
               const resolved = await ensureSectionHeadingBlockId({
                 accessToken: accessToken,
@@ -1270,24 +1089,20 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
                 await notionSyncService.appendChildren(accessToken, resolved.headingBlockId, blocks);
               } catch (e) {
                 if (!isStaleBlockAnchorError(e)) throw e;
-                trace.mark('recover conversations anchor');
-                const recoveredId = await recoverSectionHeadingBlockId({
+                const recovered = await ensureSectionHeadingBlockId({
                   accessToken: accessToken,
                   pageId,
                   section: conversationsSection,
+                  mapping: null,
                   notionSyncService,
+                  storage,
+                  conversationId: id,
                 });
-                if (storage && typeof storage.patchSyncMapping === 'function') {
-                  await storage.patchSyncMapping(id, {
-                    notionSections: { conversations: { headingBlockId: recoveredId } },
-                  });
-                }
 
-                await notionSyncService.appendChildren(accessToken, recoveredId, blocks);
+                await notionSyncService.appendChildren(accessToken, recovered.headingBlockId, blocks);
               }
             }
             const nextCursor = lastMessageCursor(messages);
-            trace.mark('save cursor');
 
             await storage.setSyncCursor(id, {
               ...nextCursor,
@@ -1308,13 +1123,10 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
               appended: inc.newMessages.length,
               warnings,
             });
-            trace.flush({ mode: 'appended', ok: true, blockCount: blocks.length });
           } else {
             const desiredProperties = pageSpec.buildUpdateProperties(convo);
             const needsPropertyUpdate = pagePropertiesNeedUpdate(existingPage, desiredProperties);
             if (needsPropertyUpdate) {
-              trace.mark('update page properties');
-
               await notionSyncService.updatePageProperties(accessToken, {
                 pageId,
                 properties: desiredProperties,
@@ -1322,7 +1134,6 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
             }
             if (inc && inc.ok) {
               const nextCursor = lastMessageCursor(messages);
-              trace.mark('save cursor');
 
               await storage.setSyncCursor(id, {
                 ...nextCursor,
@@ -1343,7 +1154,6 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
               mode: needsPropertyUpdate ? 'updated_properties' : 'no_changes',
               appended: 0,
             });
-            trace.flush({ mode: needsPropertyUpdate ? 'updated_properties' : 'no_changes', ok: true, blockCount: 0 });
           }
         } catch (e) {
           const normalizedError = normalizeNotionSyncError(e);
@@ -1354,7 +1164,6 @@ export function createNotionSyncOrchestrator(services: NotionServices) {
             error: normalizedError,
             warnings,
           });
-          trace.flush({ mode: 'failed', ok: false, error: normalizedError });
         } finally {
           await lifecycle.finishItem(id);
         }

--- a/src/services/sync/notion/notion-sync-service.ts
+++ b/src/services/sync/notion/notion-sync-service.ts
@@ -9,14 +9,6 @@ function sleep(ms: number) {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-function parseHttpStatus(error: unknown): number {
-  const raw = error && (error as any).status != null ? Number((error as any).status) : NaN;
-  if (Number.isFinite(raw) && raw > 0) return raw;
-  const message = error && (error as any).message ? String((error as any).message) : String(error || '');
-  const m = message.match(/\bHTTP\s+(\d{3})\b/i);
-  return m ? Number(m[1]) : 0;
-}
-
 function normalizeNotionId(id: unknown): string {
   return String(id || '')
     .trim()
@@ -34,26 +26,26 @@ function retryDelayMs(error: unknown, attempt: number): number {
   return Math.min(5000, base + jitter);
 }
 
-function headingBlock(label: string, color?: string) {
+function headingBlock(label: string, color: string) {
   return {
     object: 'block',
     type: 'heading_3',
     heading_3: {
       rich_text: [{ type: 'text', text: { content: label } }],
-      color: color || 'default',
+      color,
     },
   };
 }
 
-function messagesToBlocks(messages: any) {
+function messagesToBlocks(messages: any[]) {
   const out = [];
-  for (const m of messages || []) {
+  for (const m of messages) {
     const role = m.role || 'assistant';
-    const authorName = m && m.authorName && String(m.authorName).trim() ? String(m.authorName).trim() : 'You';
+    const authorName = m.authorName && String(m.authorName).trim() ? String(m.authorName).trim() : 'You';
     const label = role === 'user' ? authorName : role === 'assistant' ? 'Assistant' : role;
     out.push(headingBlock(label, role === 'user' ? 'green' : 'blue_background'));
-    const markdown = m && m.contentMarkdown && String(m.contentMarkdown).trim() ? String(m.contentMarkdown) : '';
-    if (!markdown) continue;
+    const markdown = String(m.contentMarkdown || '');
+    if (!markdown.trim()) continue;
     out.push(...markdownToNotionBlocks(markdown));
   }
   return out;
@@ -71,7 +63,7 @@ async function appendBatchWithRetry(accessToken: string, pageId: string, childre
         body: { children },
       });
     } catch (error) {
-      const status = parseHttpStatus(error);
+      const status = Number((error as any)?.status || 0);
       const retryable = status === 429 || status === 503;
       if (!retryable || attempt >= APPEND_MAX_ATTEMPTS) throw error;
 
@@ -81,10 +73,9 @@ async function appendBatchWithRetry(accessToken: string, pageId: string, childre
 }
 
 async function appendChildren(accessToken: string, pageId: string, blocks: any[]) {
-  const children = Array.from(blocks).filter((block) => block && typeof block === 'object');
   const appended = [];
-  for (let start = 0; start < children.length; start += APPEND_BATCH) {
-    const res = await appendBatchWithRetry(accessToken, pageId, children.slice(start, start + APPEND_BATCH));
+  for (let start = 0; start < blocks.length; start += APPEND_BATCH) {
+    const res = await appendBatchWithRetry(accessToken, pageId, blocks.slice(start, start + APPEND_BATCH));
     const results = Array.isArray(res && res.results) ? res.results : [];
     if (results.length) appended.push(...results);
   }
@@ -100,7 +91,7 @@ function requireExplicitProperties(properties: unknown): Record<string, unknown>
 
 async function createPageInDatabase(
   accessToken: string,
-  { databaseId, properties }: { databaseId?: string; properties?: Record<string, unknown> },
+  { databaseId, properties }: { databaseId: string; properties: Record<string, unknown> },
 ) {
   const body = {
     parent: { database_id: databaseId },
@@ -111,7 +102,7 @@ async function createPageInDatabase(
 
 async function updatePageProperties(
   accessToken: string,
-  { pageId, properties }: { pageId?: string; properties?: Record<string, unknown> },
+  { pageId, properties }: { pageId: string; properties: Record<string, unknown> },
 ) {
   const body = { properties: requireExplicitProperties(properties) };
   return notionFetch({ accessToken, method: 'PATCH', path: `/v1/pages/${pageId}`, body });
@@ -121,7 +112,7 @@ async function getPage(accessToken: string, pageId: string) {
   return notionFetch({ accessToken, method: 'GET', path: `/v1/pages/${pageId}` });
 }
 
-function isPageUsableForDatabase(page: any, databaseId: unknown): boolean {
+function isPageUsableForDatabase(page: any, databaseId: string): boolean {
   if (!page || typeof page !== 'object' || page.archived === true || page.in_trash === true) return false;
   const parent = page.parent;
   if (!parent || parent.type !== 'database_id') return false;

--- a/tests/smoke/background-router-notion-sync.test.ts
+++ b/tests/smoke/background-router-notion-sync.test.ts
@@ -84,6 +84,15 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
+let nextMockNotionBlockId = 0;
+
+function notionAppendResult(blocks: any[]) {
+  return {
+    results: blocks.map(() => ({ id: `test_block_${nextMockNotionBlockId++}` })),
+    count: blocks.length,
+  };
+}
+
 async function waitFor(predicate: () => boolean, label: string) {
   for (let i = 0; i < 50; i += 1) {
     if (predicate()) return true;
@@ -139,26 +148,6 @@ function createRouter({
       error: { message: `unknown message type: ${msg?.type}`, extra: null },
     }),
   });
-
-  // The Notion section engine expects `appendChildren()` to return created block ids when
-  // it appends toggle headings. Many unit tests don't care about the ids, so provide a
-  // compatibility wrapper here to keep mocks minimal.
-  if (notionServices?.syncService && typeof notionServices.syncService.appendChildren === 'function') {
-    let appendCounter = 0;
-    const originalAppend = notionServices.syncService.appendChildren.bind(notionServices.syncService);
-    notionServices.syncService.appendChildren = async (accessToken: string, blockId: string, blocks: any[]) => {
-      const res = await originalAppend(accessToken, blockId, blocks);
-      const count = Array.isArray(blocks) ? blocks.length : 0;
-      const existingResults = res && typeof res === 'object' ? (res as any).results : null;
-      if (Array.isArray(existingResults) && existingResults.length >= count) return res;
-      const nextResults = Array.isArray(existingResults) ? existingResults.slice() : [];
-      while (nextResults.length < count) nextResults.push({ id: `test_block_${appendCounter++}` });
-      return {
-        ...(res && typeof res === 'object' ? res : {}),
-        results: nextResults,
-      };
-    };
-  }
 
   const notionSyncOrchestrator = createNotionSyncOrchestrator({
     ...notionServices,
@@ -366,13 +355,14 @@ describe('background-router notion sync', () => {
       notionServices: {
         tokenStore: { getToken: async () => ({ accessToken: 't' }) },
         storage: {
+          patchSyncMapping: async () => true,
           getSyncMappingByConversation: async () => await mappingGate.promise,
           getMessagesByConversationId: async () => [],
         },
         dbManager: { ensureDatabase: async () => ({ databaseId: 'unused' }) },
         syncService: {
           createPageInDatabase: async () => ({ id: 'unused' }),
-          appendChildren: async () => ({ ok: true }),
+          appendChildren: async (_t: string, _blockId: string, blocks: any[]) => notionAppendResult(blocks),
           messagesToBlocks: () => [],
         },
         jobStore,
@@ -489,6 +479,7 @@ describe('background-router notion sync', () => {
         tokenStore: { getToken: async () => ({ accessToken: 't' }) },
         dbManager: { ensureDatabase: async () => ({ databaseId: 'db1' }) },
         storage: {
+          patchSyncMapping: async () => true,
           getSyncMappingByConversation: async () => ({
             conversation: { id: 1, title: 'Hello', url: 'https://x', source: 'chatgpt', notionPageId: 'p_old' },
             mapping: { notionPageId: 'p_old', lastSyncedMessageKey: 'm0' },
@@ -507,7 +498,7 @@ describe('background-router notion sync', () => {
           updatePageProperties: async () => ({ ok: true }),
           appendChildren: async (_t: string, _pageId: string, _blocks: any[]) => {
             calls.push({ op: 'append', pageId: _pageId });
-            return { ok: true };
+            return notionAppendResult(_blocks);
           },
           messagesToBlocks: (messages: any[]) => [{ kind: 'blocks', count: messages.length }],
           isPageUsableForDatabase: () => false,
@@ -540,6 +531,7 @@ describe('background-router notion sync', () => {
         tokenStore: { getToken: async () => ({ accessToken: 't' }) },
         dbManager: { ensureDatabase: async () => ({ databaseId: 'db1' }) },
         storage: {
+          patchSyncMapping: async () => true,
           getSyncMappingByConversation: async () => ({
             conversation: { id: 1, title: 'Hello', url: 'https://x', source: 'chatgpt', notionPageId: 'p1' },
             mapping: {
@@ -562,7 +554,7 @@ describe('background-router notion sync', () => {
           updatePageProperties: async () => ({ ok: true }),
           appendChildren: async (_t: string, _pageId: string, _blocks: any[]) => {
             calls.push({ op: 'append', blocks: _blocks });
-            return { ok: true };
+            return notionAppendResult(_blocks);
           },
           messagesToBlocks: (messages: any[]) => {
             blocksFromCount = messages.length;
@@ -628,6 +620,7 @@ describe('background-router notion sync', () => {
         tokenStore: { getToken: async () => ({ accessToken: 't' }) },
         dbManager: { ensureDatabase: async () => ({ databaseId: 'db1' }) },
         storage: {
+          patchSyncMapping: async () => true,
           getSyncMappingByConversation: async () => ({
             conversation: {
               id: 1,
@@ -678,7 +671,7 @@ describe('background-router notion sync', () => {
           updatePageProperties: async () => ({ ok: true }),
           appendChildren: async (_t: string, targetId: string, blocks: any[]) => {
             calls.push({ op: 'append', targetId, count: Array.isArray(blocks) ? blocks.length : 0 });
-            return { results: [], count: 0 };
+            return notionAppendResult(blocks);
           },
           messagesToBlocks: (_messages: any[]) => [],
           isPageUsableForDatabase: () => true,
@@ -755,6 +748,7 @@ describe('background-router notion sync', () => {
         tokenStore: { getToken: async () => ({ accessToken: 't' }) },
         dbManager: { ensureDatabase: async () => ({ databaseId: 'db1' }) },
         storage: {
+          patchSyncMapping: async () => true,
           getSyncMappingByConversation: async () => ({
             conversation: {
               id: 1,
@@ -798,7 +792,7 @@ describe('background-router notion sync', () => {
           },
           appendChildren: async (_t: string, targetId: string, blocks: any[]) => {
             calls.push({ op: 'append', targetId, count: Array.isArray(blocks) ? blocks.length : 0 });
-            return { results: [], count: 0 };
+            return notionAppendResult(blocks);
           },
           messagesToBlocks: () => {
             calls.push({ op: 'messagesToBlocks' });
@@ -877,6 +871,7 @@ describe('background-router notion sync', () => {
         tokenStore: { getToken: async () => ({ accessToken: 't' }) },
         dbManager: { ensureDatabase: async () => ({ databaseId: 'db1' }) },
         storage: {
+          patchSyncMapping: async () => true,
           getSyncMappingByConversation: async () => ({
             conversation: {
               id: 1,
@@ -906,7 +901,7 @@ describe('background-router notion sync', () => {
           },
           appendChildren: async (_t: string, targetId: string, blocks: any[]) => {
             calls.push({ op: 'append', targetId, count: Array.isArray(blocks) ? blocks.length : 0 });
-            return { results: [], count: 0 };
+            return notionAppendResult(blocks);
           },
           messagesToBlocks: () => [
             {
@@ -950,6 +945,7 @@ describe('background-router notion sync', () => {
         tokenStore: { getToken: async () => ({ accessToken: 't' }) },
         dbManager: { ensureDatabase: async () => ({ databaseId: 'db_articles' }) },
         storage: {
+          patchSyncMapping: async () => true,
           getSyncMappingByConversation: async () => ({
             conversation: {
               id: 1,
@@ -962,6 +958,10 @@ describe('background-router notion sync', () => {
               notionPageId: 'p1',
               lastSyncedMessageKey: 'article_body',
               lastSyncedMessageUpdatedAt: 1000,
+              notionSections: {
+                article: { headingBlockId: 'h_article' },
+                comments: { headingBlockId: 'h_comments' },
+              },
               notionSectionDigests: {
                 article: { digest: computeArticleDigest('same body'), lastSyncedAt: 1000 },
               },
@@ -997,9 +997,9 @@ describe('background-router notion sync', () => {
             calls.push({ op: 'updateProps', req });
             return { ok: true };
           },
-          appendChildren: async () => {
+          appendChildren: async (_t: string, _blockId: string, blocks: any[]) => {
             calls.push({ op: 'append' });
-            return { ok: true };
+            return notionAppendResult(blocks);
           },
           messagesToBlocks: (messages: any[]) => [{ kind: 'blocks', count: messages.length }],
           isPageUsableForDatabase: () => true,
@@ -1026,6 +1026,7 @@ describe('background-router notion sync', () => {
         tokenStore: { getToken: async () => ({ accessToken: 't' }) },
         dbManager: { ensureDatabase: async () => ({ databaseId: 'db_chats' }) },
         storage: {
+          patchSyncMapping: async () => true,
           getSyncMappingByConversation: async () => ({
             conversation: {
               id: 1,
@@ -1072,9 +1073,9 @@ describe('background-router notion sync', () => {
             calls.push({ op: 'updateProps', req });
             return { ok: true };
           },
-          appendChildren: async () => {
+          appendChildren: async (_t: string, _blockId: string, blocks: any[]) => {
             calls.push({ op: 'append' });
-            return { ok: true };
+            return notionAppendResult(blocks);
           },
           messagesToBlocks: (messages: any[]) => [{ kind: 'blocks', count: messages.length }],
           isPageUsableForDatabase: () => true,
@@ -1101,6 +1102,7 @@ describe('background-router notion sync', () => {
         tokenStore: { getToken: async () => ({ accessToken: 't' }) },
         dbManager: { ensureDatabase: async () => ({ databaseId: 'db1' }) },
         storage: {
+          patchSyncMapping: async () => true,
           getSyncMappingByConversation: async () => ({
             conversation: { id: 1, title: 'Hello', url: 'https://x', source: 'chatgpt', notionPageId: 'p1' },
             mapping: {
@@ -1132,7 +1134,7 @@ describe('background-router notion sync', () => {
           updatePageProperties: async () => ({ ok: true }),
           appendChildren: async (_t: string, _pageId: string, _blocks: any[]) => {
             calls.push({ op: 'append', blocks: _blocks });
-            return { ok: true };
+            return notionAppendResult(_blocks);
           },
           messagesToBlocks: (messages: any[]) => {
             blocksFromCount = messages.length;
@@ -1161,6 +1163,7 @@ describe('background-router notion sync', () => {
         tokenStore: { getToken: async () => ({ accessToken: 't' }) },
         dbManager: { ensureDatabase: async () => ({ databaseId: 'db_articles' }) },
         storage: {
+          patchSyncMapping: async () => true,
           getSyncMappingByConversation: async () => ({
             conversation: {
               id: 1,
@@ -1174,6 +1177,10 @@ describe('background-router notion sync', () => {
               notionPageId: 'p1',
               lastSyncedMessageKey: 'article_body',
               lastSyncedMessageUpdatedAt: 1000,
+              notionSections: {
+                article: { headingBlockId: 'h_article' },
+                comments: { headingBlockId: 'h_comments' },
+              },
               notionSectionDigests: {
                 article: { digest: computeArticleDigest('same body'), lastSyncedAt: 1000 },
               },
@@ -1210,9 +1217,9 @@ describe('background-router notion sync', () => {
             calls.push({ op: 'updateProps', req });
             return { ok: true };
           },
-          appendChildren: async () => {
+          appendChildren: async (_t: string, _blockId: string, blocks: any[]) => {
             calls.push({ op: 'append' });
-            return { ok: true };
+            return notionAppendResult(blocks);
           },
           messagesToBlocks: (messages: any[]) => [{ kind: 'blocks', count: messages.length }],
           isPageUsableForDatabase: () => true,
@@ -1246,6 +1253,7 @@ describe('background-router notion sync', () => {
         tokenStore: { getToken: async () => ({ accessToken: 't' }) },
         dbManager: { ensureDatabase: async () => ({ databaseId: 'db1' }) },
         storage: {
+          patchSyncMapping: async () => true,
           getSyncMappingByConversation: async (conversationId: number) => ({
             conversation: {
               id: conversationId,
@@ -1276,7 +1284,7 @@ describe('background-router notion sync', () => {
         syncService: {
           getPage: async () => ({ parent: { type: 'database_id', database_id: 'db1' }, archived: false }),
           updatePageProperties: async () => ({ ok: true }),
-          appendChildren: async (_t: string, pageId: string) => {
+          appendChildren: async (_t: string, pageId: string, blocks: any[]) => {
             const conversationId = Number(String(pageId).split('_')[1]);
             started.push(conversationId);
             active += 1;
@@ -1284,7 +1292,7 @@ describe('background-router notion sync', () => {
             const blocker = blockers.get(conversationId);
             if (blocker) await blocker.promise;
             active -= 1;
-            return { ok: true };
+            return notionAppendResult(blocks);
           },
           messagesToBlocks: (messages: any[]) => [{ kind: 'blocks', count: messages.length }],
           isPageUsableForDatabase: () => true,
@@ -1327,6 +1335,7 @@ describe('background-router notion sync', () => {
         tokenStore: { getToken: async () => ({ accessToken: 't' }) },
         dbManager: { ensureDatabase: async () => ({ databaseId: 'db1' }) },
         storage: {
+          patchSyncMapping: async () => true,
           getSyncMappingByConversation: async (conversationId: number) => ({
             conversation: {
               id: conversationId,
@@ -1346,10 +1355,7 @@ describe('background-router notion sync', () => {
         syncService: {
           getPage: async () => ({ parent: { type: 'database_id', database_id: 'db1' }, archived: false }),
           updatePageProperties: async () => ({ ok: true }),
-          appendChildren: async (_t: string, _blockId: string, blocks: any[]) => ({
-            ok: true,
-            results: Array.isArray(blocks) ? blocks.map((_b, i) => ({ id: `test_block_${_blockId}_${i}` })) : [],
-          }),
+          appendChildren: async (_t: string, _blockId: string, blocks: any[]) => notionAppendResult(blocks),
           messagesToBlocks: (messages: any[]) => [{ kind: 'blocks', count: messages.length }],
           isPageUsableForDatabase: () => true,
         },
@@ -1414,6 +1420,7 @@ describe('background-router notion sync', () => {
         tokenStore: { getToken: async () => ({ accessToken: 't' }) },
         dbManager: { ensureDatabase: async () => ({ databaseId: 'db1' }) },
         storage: {
+          patchSyncMapping: async () => true,
           getSyncMappingByConversation: async () => ({
             conversation: { id: 1, title: 'Hello', url: 'https://x', source: 'chatgpt', notionPageId: 'p1' },
             mapping: { notionPageId: 'p1' },
@@ -1426,7 +1433,10 @@ describe('background-router notion sync', () => {
         syncService: {
           getPage: async () => ({ parent: { type: 'database_id', database_id: 'db1' }, archived: false }),
           updatePageProperties: async () => ({ ok: true }),
-          appendChildren: async () => calls.push({ op: 'append' }),
+          appendChildren: async (_t: string, _blockId: string, blocks: any[]) => {
+            calls.push({ op: 'append' });
+            return notionAppendResult(blocks);
+          },
           messagesToBlocks: (messages: any[]) => [{ kind: 'blocks', count: messages.length }],
           isPageUsableForDatabase: () => true,
         },
@@ -1454,6 +1464,7 @@ describe('background-router notion sync', () => {
         tokenStore: { getToken: async () => ({ accessToken: 't' }) },
         dbManager: { ensureDatabase: async () => ({ databaseId: 'db1' }) },
         storage: {
+          patchSyncMapping: async () => true,
           getSyncMappingByConversation: async () => ({
             conversation: { id: 1, title: 'Hello', url: 'https://x', source: 'chatgpt' },
             mapping: null,
@@ -1470,7 +1481,7 @@ describe('background-router notion sync', () => {
           },
           createPageInDatabase: async () => ({ id: 'p_new' }),
           updatePageProperties: async () => ({ ok: true }),
-          appendChildren: async () => ({ ok: true }),
+          appendChildren: async (_t: string, _blockId: string, blocks: any[]) => notionAppendResult(blocks),
           messagesToBlocks: (messages: any[]) => [{ kind: 'blocks', count: messages.length }],
           isPageUsableForDatabase: () => false,
         },
@@ -1509,6 +1520,7 @@ describe('background-router notion sync', () => {
         tokenStore: { getToken: async () => ({ accessToken: 't' }) },
         dbManager: { ensureDatabase: async () => ({ databaseId: 'db1' }) },
         storage: {
+          patchSyncMapping: async () => true,
           getSyncMappingByConversation: async () => ({
             conversation: { id: 1, title: 'Hello', url: 'https://x', source: 'chatgpt' },
             mapping: null,
@@ -1533,7 +1545,7 @@ describe('background-router notion sync', () => {
           appendChildren: async (_t: string, _pageId: string, blocks: any[]) => {
             appendedBlocks = blocks;
             calls.push({ op: 'append', pageId: _pageId });
-            return { ok: true };
+            return notionAppendResult(blocks);
           },
           messagesToBlocks: () => [
             {
@@ -1572,6 +1584,7 @@ describe('background-router notion sync', () => {
         tokenStore: { getToken: async () => ({ accessToken: 't' }) },
         dbManager: { ensureDatabase: async () => ({ databaseId: 'db1' }) },
         storage: {
+          patchSyncMapping: async () => true,
           getSyncMappingByConversation: async () => ({
             conversation: { id: 1, title: 'Hello', url: 'https://x', source: 'chatgpt' },
             mapping: null,
@@ -1595,7 +1608,7 @@ describe('background-router notion sync', () => {
           updatePageProperties: async () => ({ ok: true }),
           appendChildren: async (_t: string, _pageId: string, blocks: any[]) => {
             appendedBlocks = blocks;
-            return { ok: true };
+            return notionAppendResult(blocks);
           },
           messagesToBlocks: () => [
             {
@@ -1627,6 +1640,7 @@ describe('background-router notion sync', () => {
         tokenStore: { getToken: async () => ({ accessToken: 't' }) },
         dbManager: { ensureDatabase: async () => ({ databaseId: 'db1' }) },
         storage: {
+          patchSyncMapping: async () => true,
           getSyncMappingByConversation: async () => ({
             conversation: { id: 1, title: 'Hello', url: 'https://x', source: 'chatgpt' },
             mapping: null,
@@ -1648,7 +1662,7 @@ describe('background-router notion sync', () => {
           },
           createPageInDatabase: async () => ({ id: 'p_new' }),
           updatePageProperties: async () => ({ ok: true }),
-          appendChildren: async () => ({ ok: true }),
+          appendChildren: async (_t: string, _blockId: string, blocks: any[]) => notionAppendResult(blocks),
           messagesToBlocks: () => [
             {
               object: 'block',
@@ -1687,6 +1701,7 @@ describe('background-router notion sync', () => {
         tokenStore: { getToken: async () => ({ accessToken: 't' }) },
         dbManager: { ensureDatabase: async () => ({ databaseId: 'db1' }) },
         storage: {
+          patchSyncMapping: async () => true,
           getSyncMappingByConversation: async () => ({
             conversation: { id: 1, title: 'Hello', url: 'https://x', source: 'chatgpt' },
             mapping: null,
@@ -1756,6 +1771,7 @@ describe('background-router notion sync', () => {
           },
         },
         storage: {
+          patchSyncMapping: async () => true,
           getSyncMappingByConversation: async () => ({
             conversation: { id: 1, title: 'Hello', url: 'https://x', source: 'chatgpt' },
             mapping: null,
@@ -1770,13 +1786,15 @@ describe('background-router notion sync', () => {
           createPageInDatabase: async (_t: string, payload: any) => {
             createCalls.push(payload.databaseId);
             if (payload.databaseId === 'db_stale') {
-              throw new Error(
-                'notion api failed: POST /v1/pages HTTP 404 {"code":"object_not_found","message":"Could not find database with ID: db_stale"}',
-              );
+              const error: any = new Error('database missing');
+              error.status = 404;
+              error.code = 'object_not_found';
+              error.notionMessage = 'Could not find database with ID: db_stale';
+              throw error;
             }
             return { id: 'p_new' };
           },
-          appendChildren: async () => ({ ok: true }),
+          appendChildren: async (_t: string, _blockId: string, blocks: any[]) => notionAppendResult(blocks),
           messagesToBlocks: () => [{ kind: 'blocks', count: 1 }],
           isPageUsableForDatabase: () => false,
         },
@@ -1813,6 +1831,7 @@ describe('background-router notion sync', () => {
           clearCachedDatabaseId: async () => true,
         },
         storage: {
+          patchSyncMapping: async () => true,
           getSyncMappingByConversation: async (conversationId: number) => ({
             conversation: {
               id: conversationId,
@@ -1832,13 +1851,15 @@ describe('background-router notion sync', () => {
           createPageInDatabase: async (_t: string, payload: any) => {
             createCalls.push(payload.databaseId);
             if (payload.databaseId === 'db_stale') {
-              throw new Error(
-                'notion api failed: POST /v1/pages HTTP 404 {"code":"object_not_found","message":"Could not find database with ID: db_stale"}',
-              );
+              const error: any = new Error('database missing');
+              error.status = 404;
+              error.code = 'object_not_found';
+              error.notionMessage = 'Could not find database with ID: db_stale';
+              throw error;
             }
             return { id: `p_${createCalls.length}` };
           },
-          appendChildren: async () => ({ ok: true }),
+          appendChildren: async (_t: string, _blockId: string, blocks: any[]) => notionAppendResult(blocks),
           messagesToBlocks: () => [{ kind: 'blocks', count: 1 }],
           isPageUsableForDatabase: () => false,
         },
@@ -1863,12 +1884,13 @@ describe('background-router notion sync', () => {
         tokenStore: { getToken: async () => ({ accessToken: 't' }) },
         dbManager: { ensureDatabase: async () => ({ databaseId: 'db1' }) },
         storage: {
+          patchSyncMapping: async () => true,
           getSyncMappingByConversation: async () => await blockedLookup.promise,
           getMessagesByConversationId: async () => [],
         },
         syncService: {
           createPageInDatabase: async () => ({ id: 'p1' }),
-          appendChildren: async () => ({ ok: true }),
+          appendChildren: async (_t: string, _blockId: string, blocks: any[]) => notionAppendResult(blocks),
           messagesToBlocks: () => [],
         },
         jobStore,
@@ -1948,6 +1970,7 @@ describe('background-router notion sync', () => {
         tokenStore: { getToken: async () => ({ accessToken: 't' }) },
         dbManager: { ensureDatabase: async () => ({ databaseId: 'db1' }) },
         storage: {
+          patchSyncMapping: async () => true,
           getSyncMappingByConversation: async () => ({
             conversation: { id: 1, title: 'Hello', url: 'https://x', source: 'chatgpt' },
             mapping: null,
@@ -1995,6 +2018,7 @@ describe('background-router notion sync', () => {
         tokenStore: { getToken: async () => ({ accessToken: 't' }) },
         dbManager: { ensureDatabase: async () => ({ databaseId: 'db1' }) },
         storage: {
+          patchSyncMapping: async () => true,
           getSyncMappingByConversation: async () => ({
             conversation: { id: 1, title: 'Hello', url: 'https://x', source: 'chatgpt' },
             mapping: null,
@@ -2039,6 +2063,7 @@ describe('background-router notion sync', () => {
         tokenStore: { getToken: async () => ({ accessToken: 't' }) },
         dbManager: { ensureDatabase: async () => ({ databaseId: 'db1' }) },
         storage: {
+          patchSyncMapping: async () => true,
           getSyncMappingByConversation: async () => ({
             conversation: { id: 1, title: 'Hello', url: 'https://x', source: 'chatgpt' },
             mapping: null,

--- a/tests/smoke/notion-db-manager.test.ts
+++ b/tests/smoke/notion-db-manager.test.ts
@@ -8,7 +8,6 @@ vi.mock('@services/sync/notion/notion-api.ts', () => {
     return notionFetchImpl(req);
   };
   return {
-    NOTION_VERSION: '2022-06-28',
     notionFetch,
   };
 });
@@ -87,15 +86,6 @@ describe('notion-db-manager', () => {
     expect(create.body.properties?.Date).toBeUndefined();
   });
 
-  it('requires an explicit database spec instead of falling back to the chat database', async () => {
-    // @ts-expect-error test global
-    globalThis.chrome = mockChromeStorage();
-
-    await expect(notionDbManager.ensureDatabase({ accessToken: 't', parentPageId: 'p' } as any)).rejects.toThrow(
-      'notion dbSpec required',
-    );
-  });
-
   it('creates SyncNos-Web Articles database when missing (dbSpec-driven + separate cache key)', async () => {
     const calls: any[] = [];
     notionFetchImpl = async (req: any) => {
@@ -122,6 +112,32 @@ describe('notion-db-manager', () => {
     expect(create.body.properties?.['Last Activity']?.date).toBeTruthy();
     expect(create.body.properties?.Date).toBeUndefined();
     expect(create.body.properties?.AI).toBeFalsy();
+  });
+
+  it('throws when cached database has AI property with wrong type', async () => {
+    const calls: any[] = [];
+    notionFetchImpl = async (req: any) => {
+      calls.push(req);
+      if (req.method === 'GET' && req.path === '/v1/databases/db1') {
+        return {
+          id: 'db1',
+          parent: { type: 'page_id', page_id: 'p' },
+          properties: {
+            Name: { type: 'title' },
+            'Last Activity': { type: 'date' },
+            URL: { type: 'url' },
+            AI: { type: 'select' },
+          },
+        };
+      }
+      throw new Error(`unexpected notionFetch: ${req.method} ${req.path}`);
+    };
+
+    // @ts-expect-error test global
+    globalThis.chrome = mockChromeStorage({ initial: { [CHAT_DB_STORAGE_KEY]: 'db1' } });
+
+    await expect(ensureChatDatabase()).rejects.toThrow('AI must be multi_select');
+    expect(calls.some((c) => c.method === 'PATCH')).toBe(false);
   });
 
   it('renames legacy Date before adding missing AI when reusing a cached database', async () => {
@@ -152,7 +168,7 @@ describe('notion-db-manager', () => {
     expect(patches[1]?.body?.properties?.AI?.multi_select).toBeTruthy();
   });
 
-  it('renames legacy Date idempotently and preserves an existing user Date when Last Activity already exists', async () => {
+  it('renames legacy Date only once', async () => {
     const calls: any[] = [];
     let properties: Record<string, any> = {
       Name: { type: 'title' },
@@ -184,40 +200,6 @@ describe('notion-db-manager', () => {
     await ensureChatDatabase();
     await ensureChatDatabase();
     expect(calls.filter((c) => c.method === 'PATCH')).toHaveLength(1);
-
-    properties = {
-      ...properties,
-      Date: { type: 'rich_text' },
-    };
-    calls.length = 0;
-    await ensureChatDatabase();
-    expect(calls.some((c) => c.method === 'PATCH')).toBe(false);
-  });
-
-  it('throws when cached database has AI property with wrong type', async () => {
-    const calls: any[] = [];
-    notionFetchImpl = async (req: any) => {
-      calls.push(req);
-      if (req.method === 'GET' && req.path === '/v1/databases/db1') {
-        return {
-          id: 'db1',
-          parent: { type: 'page_id', page_id: 'p' },
-          properties: {
-            Name: { type: 'title' },
-            'Last Activity': { type: 'date' },
-            URL: { type: 'url' },
-            AI: { type: 'select' },
-          },
-        };
-      }
-      throw new Error(`unexpected notionFetch: ${req.method} ${req.path}`);
-    };
-
-    // @ts-expect-error test global
-    globalThis.chrome = mockChromeStorage({ initial: { [CHAT_DB_STORAGE_KEY]: 'db1' } });
-
-    await expect(ensureChatDatabase()).rejects.toThrow('AI must be multi_select');
-    expect(calls.some((c) => c.method === 'PATCH')).toBe(false);
   });
 
   it.each([
@@ -278,7 +260,10 @@ describe('notion-db-manager', () => {
     notionFetchImpl = async (req: any) => {
       calls.push(req);
       if (req.method === 'GET' && req.path === '/v1/databases/db_old') {
-        throw new Error('notion api failed: GET /v1/databases/db_old HTTP 404 {"code":"object_not_found"}');
+        const error: any = new Error('database missing');
+        error.status = 404;
+        error.code = 'object_not_found';
+        throw error;
       }
       if (req.method === 'POST' && req.path === '/v1/search') return { results: [] };
       if (req.method === 'POST' && req.path === '/v1/databases') return { id: 'db_new' };

--- a/tests/smoke/notion-files-api.test.ts
+++ b/tests/smoke/notion-files-api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { NOTION_VERSION, notionFetch, searchPages } from '@services/sync/notion/notion-api.ts';
+import { notionFetch } from '@services/sync/notion/notion-api.ts';
 import {
   createExternalURLUpload,
   createFileUpload,
@@ -38,70 +38,8 @@ describe('notion-api', () => {
     await notionFetch({ accessToken: 't', method: 'GET', path: '/v1/users/me' });
     await notionFetch({ accessToken: 't', method: 'GET', path: '/v1/users/me', notionVersion: '2099-01-01' });
 
-    expect(calls[0].headers['Notion-Version']).toBe(NOTION_VERSION);
+    expect(calls[0].headers['Notion-Version']).toBe('2022-06-28');
     expect(calls[1].headers['Notion-Version']).toBe('2099-01-01');
-  });
-
-  it('searchPages paginates and returns usable parent pages only', async () => {
-    const bodies: any[] = [];
-    // @ts-expect-error test global
-    globalThis.fetch = async (_url: string, init: any) => {
-      const body = JSON.parse(String(init?.body ?? '{}'));
-      bodies.push(body);
-      if (bodies.length === 1) {
-        return {
-          ok: true,
-          status: 200,
-          headers: createHeaders({ 'content-type': 'application/json' }),
-          text: async () =>
-            JSON.stringify({
-              results: [{ object: 'page', id: 'entry1', parent: { type: 'database_id', database_id: 'db1' } }],
-              has_more: true,
-              next_cursor: 'cursor_2',
-            }),
-        };
-      }
-      return {
-        ok: true,
-        status: 200,
-        headers: createHeaders({ 'content-type': 'application/json' }),
-        text: async () =>
-          JSON.stringify({
-            results: [
-              { object: 'page', id: 'entry2', parent: { type: 'database_id', database_id: 'db2' } },
-              { object: 'page', id: 'p2', parent: { type: 'page_id', page_id: 'root1' }, properties: {} },
-            ],
-            has_more: false,
-          }),
-      };
-    };
-
-    const res = await searchPages({ accessToken: 't', query: '', pageSize: 50 });
-
-    expect(Array.isArray(res.results)).toBe(true);
-    expect(res.results.length).toBe(1);
-    expect(res.results[0].id).toBe('p2');
-    expect(Object.prototype.hasOwnProperty.call(bodies[0], 'query')).toBe(false);
-    expect(bodies[0].filter?.value).toBe('page');
-    expect(bodies[1].start_cursor).toBe('cursor_2');
-  });
-
-  it('searchPages keeps non-empty query', async () => {
-    const bodies: any[] = [];
-    // @ts-expect-error test global
-    globalThis.fetch = async (_url: string, init: any) => {
-      bodies.push(JSON.parse(String(init?.body ?? '{}')));
-      return {
-        ok: true,
-        status: 200,
-        headers: createHeaders({ 'content-type': 'application/json' }),
-        text: async () => JSON.stringify({ results: [{ object: 'page', id: 'p1', properties: {} }], has_more: false }),
-      };
-    };
-
-    await searchPages({ accessToken: 't', query: 'syncnos', pageSize: 10 });
-    expect(bodies[0].query).toBe('syncnos');
-    expect(bodies[0].page_size).toBe(10);
   });
 });
 
@@ -180,7 +118,6 @@ describe('notion-files-api', () => {
       accessToken: 't',
       filename: 'a.png',
       contentType: 'image/png',
-      contentLength: 3,
     });
     expect(created.id).toBe('u2');
 

--- a/tests/smoke/notion-sync-orchestrator-kind-routing.test.ts
+++ b/tests/smoke/notion-sync-orchestrator-kind-routing.test.ts
@@ -137,6 +137,7 @@ describe('notion-sync-orchestrator kind routing', () => {
       },
       setConversationNotionPageId: async () => true,
       setSyncCursor: async () => true,
+      patchSyncMapping: async () => true,
     };
 
     const syncService = {
@@ -469,6 +470,7 @@ describe('notion-sync-orchestrator kind routing', () => {
         ],
         setConversationNotionPageId: async () => true,
         setSyncCursor: async () => true,
+        patchSyncMapping: async () => true,
       },
       conversationKinds,
       dbManager: { ensureDatabase: async () => ({ databaseId: 'db_articles' }) },
@@ -681,7 +683,10 @@ describe('notion-sync-orchestrator kind routing', () => {
         },
         mapping: {
           notionPageId: 'p1',
-          notionSections: { article: { headingBlockId: 'h_article' } },
+          notionSections: {
+            article: { headingBlockId: 'h_article' },
+            comments: { headingBlockId: 'h_comments' },
+          },
           notionSectionDigests: { article: { digest: 'old' } },
         },
       }),
@@ -696,6 +701,7 @@ describe('notion-sync-orchestrator kind routing', () => {
       ],
       setConversationNotionPageId: async () => true,
       setSyncCursor: async () => true,
+      patchSyncMapping: async () => true,
     };
 
     notionFetchImpl = async (req: any) => {

--- a/tests/smoke/notion-sync-service-image-upload.test.ts
+++ b/tests/smoke/notion-sync-service-image-upload.test.ts
@@ -8,13 +8,10 @@ vi.mock('@services/sync/notion/notion-files-api.ts', () => {
     return filesApi;
   };
   return {
-    FILE_UPLOAD_VERSION: '2025-09-03',
-    sanitizeFilename: (name: any) => String(name || '').trim() || 'image.jpg',
     guessFilenameFromUrl: (_url: any) => 'image.jpg',
     createExternalURLUpload: (input: any) => getApi().createExternalURLUpload(input),
     createFileUpload: (input: any) => getApi().createFileUpload(input),
     sendFileUpload: (input: any) => getApi().sendFileUpload(input),
-    retrieveUpload: (input: any) => getApi().retrieveUpload(input),
     waitUntilUploaded: (input: any) => getApi().waitUntilUploaded(input),
   };
 });
@@ -47,9 +44,6 @@ describe('notion-sync-service image uploads', () => {
         throw new Error('should not be called');
       },
       sendFileUpload: async () => {
-        throw new Error('should not be called');
-      },
-      retrieveUpload: async () => {
         throw new Error('should not be called');
       },
     };
@@ -85,8 +79,8 @@ describe('notion-sync-service image uploads', () => {
         calls.push({ op: 'createExternalURLUpload' });
         throw new Error('validation_error');
       },
-      createFileUpload: async ({ filename, contentType, contentLength }: any) => {
-        calls.push({ op: 'createFileUpload', filename, contentType, contentLength });
+      createFileUpload: async ({ filename, contentType }: any) => {
+        calls.push({ op: 'createFileUpload', filename, contentType });
         return { id: 'u2' };
       },
       sendFileUpload: async ({ id, bytes, filename, contentType }: any) => {
@@ -97,7 +91,6 @@ describe('notion-sync-service image uploads', () => {
         calls.push({ op: 'waitUntilUploaded', id });
         return { id, status: 'uploaded' };
       },
-      retrieveUpload: async () => ({ id: 'u2', status: 'uploaded' }),
     };
 
     const blocks = [
@@ -146,7 +139,6 @@ describe('notion-sync-service image uploads', () => {
         calls.push({ op: 'waitUntilUploaded' });
         throw new Error('nope');
       },
-      retrieveUpload: async () => ({ id: 'u1', status: 'failed' }),
     };
 
     const blocks = [
@@ -184,7 +176,6 @@ describe('notion-sync-service image uploads', () => {
         calls.push({ op: 'waitUntilUploaded', id });
         return { id, status: 'uploaded' };
       },
-      retrieveUpload: async () => ({ id: 'u_data_1', status: 'uploaded' }),
     };
 
     const blocks = [
@@ -219,7 +210,6 @@ describe('notion-sync-service image uploads', () => {
         calls.push({ op: 'waitUntilUploaded' });
         throw new Error('nope');
       },
-      retrieveUpload: async () => ({ id: 'u_data_2', status: 'failed' }),
     };
 
     const blocks = [

--- a/tests/smoke/notion-sync-service-rate-limit.test.ts
+++ b/tests/smoke/notion-sync-service-rate-limit.test.ts
@@ -83,43 +83,6 @@ describe('notion-sync-service rate limit', () => {
     expect(timeoutSpy.mock.calls.some((call) => Number(call[1]) >= 150)).toBe(true);
   });
 
-  it('still appends children when the source array has a broken slice implementation', async () => {
-    const notionSyncService = await loadNotionSyncService();
-    const appendBodies: any[] = [];
-    const fetchMock = vi.fn(async (_url: string, init?: { method?: string; body?: string }) => {
-      if (String(init?.method || '').toUpperCase() === 'PATCH') {
-        appendBodies.push(JSON.parse(String(init?.body || '{}')));
-      }
-      return notionResponse({ ok: true, status: 200, body: { results: [] } });
-    });
-    (globalThis as any).fetch = fetchMock;
-
-    class BadSliceArray<T> extends Array<T> {
-      override slice(start?: number, end?: number) {
-        if (start === undefined && end === undefined) {
-          return {
-            length: 1,
-            slice() {
-              return undefined;
-            },
-          } as any;
-        }
-        return super.slice(start, end);
-      }
-    }
-
-    const blocks = new BadSliceArray(paragraphBlock(0), paragraphBlock(1));
-
-    await expect(notionSyncService.appendChildren('token', 'page_5', blocks as any)).resolves.toEqual({
-      results: [],
-      count: 0,
-    });
-
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(Array.isArray(appendBodies[0]?.children)).toBe(true);
-    expect(appendBodies[0]?.children).toHaveLength(2);
-  });
-
   it('sends consecutive successful append batches without fixed delay', async () => {
     const notionSyncService = await loadNotionSyncService();
     const fetchMock = vi.fn().mockResolvedValue(notionResponse({ ok: true, status: 200, body: { results: [] } }));

--- a/tests/smoke/notion-sync-service.test.ts
+++ b/tests/smoke/notion-sync-service.test.ts
@@ -8,7 +8,6 @@ vi.mock('@services/sync/notion/notion-api.ts', () => {
     return notionFetchImpl(req);
   };
   return {
-    NOTION_VERSION: '2022-06-28',
     notionFetch,
   };
 });

--- a/tests/sync/notion-article-comments.test.ts
+++ b/tests/sync/notion-article-comments.test.ts
@@ -22,46 +22,6 @@ describe('notion article comments blocks', () => {
     expect(block?.heading_2?.rich_text?.[0]?.text?.content).toBe('Article');
   });
 
-  it('ignores archived toggle heading blocks when locating section headings', async () => {
-    const notionSections = await loadNotionSectionBlocks();
-    const archived = {
-      object: 'block',
-      id: 'b1',
-      archived: true,
-      type: 'heading_2',
-      heading_2: {
-        is_toggleable: true,
-        rich_text: [{ type: 'text', text: { content: 'Comments' }, plain_text: 'Comments' }],
-      },
-    };
-    const active = {
-      object: 'block',
-      id: 'b2',
-      type: 'heading_2',
-      heading_2: {
-        is_toggleable: true,
-        rich_text: [{ type: 'text', text: { content: 'Comments' }, plain_text: 'Comments' }],
-      },
-    };
-    const picked = notionSections.findToggleHeadingBlock([archived, active], 'Comments');
-    expect(picked?.id).toBe('b2');
-  });
-
-  it('locates toggle headings even when is_toggleable is missing', async () => {
-    const notionSections = await loadNotionSectionBlocks();
-    const legacyToggleHeading = {
-      object: 'block',
-      id: 'b_legacy',
-      type: 'heading_2',
-      has_children: true,
-      heading_2: {
-        rich_text: [{ type: 'text', text: { content: 'Conversations' }, plain_text: 'Conversations' }],
-      },
-    };
-    const picked = notionSections.findToggleHeadingBlock([legacyToggleHeading], 'Conversations');
-    expect(picked?.id).toBe('b_legacy');
-  });
-
   it('renders comments into quote + bullet blocks', async () => {
     const renderer = await loadNotionCommentsRenderer();
     const res = renderer.buildNotionCommentsBlocks([

--- a/tests/unit/notion-managed-sections-toggle-heading.test.ts
+++ b/tests/unit/notion-managed-sections-toggle-heading.test.ts
@@ -75,4 +75,52 @@ describe('notion managed sections', () => {
       notionSections: { conversations: { headingBlockId: 'b1' } },
     });
   });
+
+  it('does not create a duplicate heading when candidate retrieval fails', async () => {
+    const sections = await loadFresh('@services/sync/notion/notion-managed-sections.ts');
+
+    const fetchMock = vi.fn(async (url: string, init?: { method?: string }) => {
+      const method = String(init?.method || 'GET').toUpperCase();
+      const href = String(url);
+      if (method === 'GET' && href.includes('/v1/blocks/p1/children')) {
+        return notionHttpResponse({
+          results: [
+            {
+              object: 'block',
+              id: 'b1',
+              type: 'heading_2',
+              heading_2: {
+                rich_text: [{ type: 'text', text: { content: 'Conversations' }, plain_text: 'Conversations' }],
+              },
+            },
+          ],
+          has_more: false,
+          next_cursor: null,
+        });
+      }
+      if (method === 'GET' && href.includes('/v1/blocks/b1')) {
+        return notionHttpResponse({ code: 'service_unavailable', message: 'retry later' }, 503);
+      }
+      throw new Error(`unexpected fetch: ${method} ${href}`);
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const appendChildren = vi.fn(async () => ({ results: [{ id: 'new_heading' }], count: 1 }));
+    const patchSyncMapping = vi.fn(async () => true);
+
+    await expect(
+      sections.ensureSectionHeadingBlockId({
+        accessToken: 't',
+        pageId: 'p1',
+        section: { id: 'conversations', title: 'Conversations', level: 2 },
+        mapping: null,
+        notionSyncService: { appendChildren },
+        storage: { patchSyncMapping },
+        conversationId: 1,
+      }),
+    ).rejects.toMatchObject({ status: 503, code: 'service_unavailable' });
+
+    expect(appendChildren).not.toHaveBeenCalled();
+    expect(patchSyncMapping).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/notion-parent-pages.test.ts
+++ b/tests/unit/notion-parent-pages.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { listNotionParentPages } from '../../src/services/sync/notion/notion-parent-pages';
 
@@ -18,56 +18,70 @@ function notionPage(id: string, title: string, parent: any) {
   };
 }
 
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => null },
+    text: async () => JSON.stringify(body),
+  } as any;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  // @ts-expect-error test global
+  delete globalThis.fetch;
+});
+
 describe('listNotionParentPages', () => {
   it('paginates until it finds usable parent pages', async () => {
     const calls: any[] = [];
-    const notionFetchImpl = vi.fn(async (input: any) => {
-      calls.push(input);
-      if (input.method === 'POST' && input.path === '/v1/search') {
-        if (!input.body?.start_cursor) {
-          return {
-            results: [
-              notionPage('d1', 'db child', { type: 'database_id', database_id: 'db1' }),
-              notionPage('d2', 'db child 2', { database_id: 'db1' }),
-            ],
-            has_more: true,
-            next_cursor: 'c1',
-          };
-        }
-        return {
-          results: [notionPage('p1', 'parent page', { type: 'workspace', workspace: true })],
-          has_more: false,
-          next_cursor: null,
-        };
+    // @ts-expect-error test global
+    globalThis.fetch = vi.fn(async (_url: string, init: any) => {
+      const body = JSON.parse(String(init.body || '{}'));
+      calls.push(body);
+      if (!body.start_cursor) {
+        return jsonResponse({
+          results: [
+            notionPage('d1', 'db child', { type: 'database_id', database_id: 'db1' }),
+            notionPage('d2', 'db child 2', { database_id: 'db1' }),
+          ],
+          has_more: true,
+          next_cursor: 'c1',
+        });
       }
-      throw new Error(`unexpected call: ${input.method} ${input.path}`);
+      return jsonResponse({
+        results: [notionPage('p1', 'parent page', { type: 'workspace', workspace: true })],
+        has_more: false,
+        next_cursor: null,
+      });
     });
 
-    const res = await listNotionParentPages('token', { notionFetchImpl });
-    expect(res.pages.map((p) => p.id)).toEqual(['p1']);
-    expect(calls.length).toBe(2);
-    expect(calls[0].body?.start_cursor).toBeUndefined();
-    expect(calls[1].body?.start_cursor).toBe('c1');
+    const res = await listNotionParentPages('token');
+    expect(res.pages.map((page) => page.id)).toEqual(['p1']);
+    expect(calls).toHaveLength(2);
+    expect(calls[0].start_cursor).toBeUndefined();
+    expect(calls[1].start_cursor).toBe('c1');
   });
 
   it('resolves savedPageId via GET /pages/:id when missing from search results', async () => {
-    const notionFetchImpl = vi.fn(async (input: any) => {
-      if (input.method === 'POST' && input.path === '/v1/search') {
-        return {
+    // @ts-expect-error test global
+    globalThis.fetch = vi.fn(async (url: string, init: any) => {
+      if (init.method === 'POST') {
+        return jsonResponse({
           results: [notionPage('p1', 'parent page', { type: 'workspace', workspace: true })],
           has_more: false,
           next_cursor: null,
-        };
+        });
       }
-      if (input.method === 'GET' && String(input.path).startsWith('/v1/pages/')) {
-        return notionPage('s1', 'saved page', { type: 'page_id', page_id: 'root' });
+      if (init.method === 'GET' && String(url).includes('/v1/pages/s1')) {
+        return jsonResponse(notionPage('s1', 'saved page', { type: 'page_id', page_id: 'root' }));
       }
-      throw new Error(`unexpected call: ${input.method} ${input.path}`);
+      throw new Error(`unexpected call: ${init.method} ${url}`);
     });
 
-    const res = await listNotionParentPages('token', { notionFetchImpl, savedPageId: 's1' });
+    const res = await listNotionParentPages('token', { savedPageId: 's1' });
     expect(res.resolvedSaved?.id).toBe('s1');
-    expect(res.pages[0]?.id).toBe('s1');
-    expect(res.pages.map((p) => p.id)).toEqual(['s1', 'p1']);
+    expect(res.pages.map((page) => page.id)).toEqual(['s1', 'p1']);
   });
 });


### PR DESCRIPTION
## Related issue

N/A — 维护性重构；不引入新的用户功能，并保留既有 Notion `Date` → `Last Activity` 迁移语义。

## Why

Notion 同步链路长期积累了多套旧兼容、重复恢复路径、测试专用生产 API、重复的错误解析和对内部已知契约的防御性分支。这些代码增加了维护成本和 background bundle 体积，也会掩盖真实的远端失败，例如 section retrieve 失败后被当作“未找到”继续创建重复 section。

本 PR 收敛这些实现到当前唯一生产路径，同时保留真正位于外部/数据边界上的校验、重试与迁移行为。

## Scope

### In scope

- 清理 Notion API、database manager、managed sections、parent-page discovery、files/image upload、orchestrator 和 sync service 中已失效或重复的兼容逻辑。
- 收紧内部 service/storage/conversation-kind 契约，删除恒真的 optional/shape guard。
- 统一 section heading 恢复路径，并让真实 Notion API 错误继续向上冒泡。
- 删除生产代码中的测试注入参数、test-only exports 和未使用 API。
- 保留旧数据库 `Date: date` → `Last Activity` 的幂等 schema 迁移。
- 更新测试，使 mock 明确满足当前生产契约，并覆盖迁移及失败路径。

### Non-goals

- 不改变用户可见的 Notion 页面布局或当前新建数据库 schema。
- 不改变 Notion OAuth、token 存储、权限或网络目标。
- 不修改其他同步 provider。
- 不包含长字幕 Markdown 栈溢出修复；该修复已由 PR #563 单独进入 `main`。

## What changed

- 删除无生产调用方的 `searchPages()` 及对应测试，并收回仅内部使用的 Notion API/File API exports。
- Notion 错误判断只使用 `status` / `code` / `notionMessage` / `retryAfterMs` 等结构化字段，不再从错误字符串二次正则解析。
- `patchSyncMapping`、database/spec、conversation-kind 等生产必需依赖改为显式必需契约，删除重复的 optional guard。
- section heading 查找/恢复收敛到 `ensureSectionHeadingBlockId()`；retrieve 失败不再被吞成 `null`，避免远端失败时误建重复 section。
- parent page 与 database 搜索按 Notion cursor 正常翻页，删除任意 `maxPages` / `SEARCH_MAX_PAGES` 截断和生产函数中的测试注入参数。
- 删除未文档化的 `__SYNCNOS_NOTION_TRACE__` 调试链、旧 toggle heuristic、坏 `Array.slice()` 兼容和测试 compatibility wrapper。
- 图片上传链删除 Chrome MV3 不需要的 Node `Buffer` fallback、无用 `contentLength` 和重复 indirection，同时保留图片大小、conversation ownership、上传状态和内部 asset URL 隔离。
- 保留并验证旧数据库 `Date` → `Last Activity` rename；迁移后再补齐缺失的其他 schema（例如 `AI`）。

## Architecture / invariants

- 依赖方向仍保持在 `src/services/** -> platform/domain/client/shared` 范围内，没有引入 UI/viewmodel 反向依赖。
- Notion 手动同步与自动同步仍收敛到同一 orchestrator / `SyncJob` 生命周期；本 PR 只删除其内部重复分支，没有新增第二套 progress/terminal 状态路径。
- 外部 Notion API、持久化 mapping 和远端写入仍作为信任/数据边界保留校验与错误传播。

## Data, migration & recovery

- 旧数据库在存在 `Date: date` 且缺少 `Last Activity` 时，会把 `Date` 重命名为 `Last Activity`；不会额外创建第二个时间字段。
- 迁移是幂等的：再次同步时检测到 `Last Activity` 后不会重复 rename。
- 若 `Date` 或 `Last Activity` 类型不符合预期，会报 schema incompatible，而不是静默改写。
- rename 与其他缺失 schema patch 是独立远端 PATCH；如果 rename 成功而后续 patch 失败，下一次重试会识别已完成的 rename，仅继续补齐剩余 schema。
- 没有新增或修改本地 IndexedDB schema、revision 协议、backup 格式或 cache key。

## Permissions & privacy

N/A — manifest/host permissions、OAuth scopes、secret handling 和网络目标均未改变；没有让新的本地数据离开设备。

## Compatibility

- 运行时继续以当前 Chrome MV3 为目标，因此删除 Node `Buffer` fallback。
- 删除面向旧 Notion response shape 的 `has_children` toggle heuristic，使用当前 list/retrieve 路径确认 heading。
- Notion parent/database 搜索改为跟随服务端 cursor 到结束，不再受本地任意页数上限影响。

## Demo

N/A — no visual behavior changed.

## Drawbacks / risks

- 内部契约更严格后，编程错误或不完整测试 mock 会直接失败，而不是被 optional guard 静默掩盖；这是有意行为。
- 删除旧运行时/旧 response-shape 兼容意味着代码只维护当前受支持的 Chrome MV3 与 Notion API 路径。
- 真实外部边界的 token、schema、parent ownership、rate-limit、upload status 和数据完整性校验均保留。

## Tests & validation

### Automated

- `npm test -- tests/smoke/notion-db-manager.test.ts` — 13/13 通过。
- `npm run compile` — 通过。
- `npm run gate:ci` — lint、Prettier、compile 全通过；294/294 test files、2294/2294 tests 通过。
- `npm run build` — Chrome MV3 production build 通过。
- `rtk node "${CODEX_HOME:-$HOME/.codex}/skills/dev/neat-freak/scripts/audit_docs.ts" --repo . --base origin/main` — 长期 Markdown 候选与本地链接核销通过，无断链。
- `npm run format:check` 与 `rtk git diff --check` — 文档格式与 whitespace 校验通过。

### Manual

N/A — 没有新增浏览器/UI 操作流；本次未对真实 Notion workspace 执行额外写入，远端写入、迁移、重试和恢复路径由现有 smoke/integration tests 覆盖。

## Documentation

- `AGENTS.md`：新增 Notion managed schema/section 不变量，明确旧 `Date` 必须迁移为 `Last Activity`，以及 section list/retrieve 失败不得伪装成“未找到”。
- `docs/troubleshooting.md`：补充 Notion schema incompatible 与 section 远端读取失败的可复用排障路径。
- `docs/GENERATION.md`：同步扩展 troubleshooting 的 edit trigger，纳入 provider 同步失败/恢复诊断。
- README、Privacy、storage、CONTRIBUTING 与 store listing 已核对；本 PR 不改变它们拥有的用户能力、隐私/数据流、本地恢复或贡献流程事实，因此不复制内部 Notion 实现细节。

